### PR TITLE
Fastercsc

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # LightGraphs
 
-[![Build Status](https://travis-ci.org/sbromberger/LightGraphs.jl.svg?branch=master)](https://travis-ci.org/sbromberger/LightGraphs.jl)
-[![Coverage Status](https://coveralls.io/repos/sbromberger/LightGraphs.jl/badge.svg?branch=master)](https://coveralls.io/r/sbromberger/LightGraphs.jl?branch=master)
+[![Build Status](https://travis-ci.org/JuliaWeb/LightGraphs.jl.svg?branch=master)](https://travis-ci.org/sbromberger/LightGraphs.jl)
+[![Coverage Status](https://coveralls.io/repos/JuliaWeb/LightGraphs.jl/badge.svg?branch=master)](https://coveralls.io/r/sbromberger/LightGraphs.jl?branch=master)
 [![LightGraphs](http://pkg.julialang.org/badges/LightGraphs_release.svg)](http://pkg.julialang.org/?pkg=LightGraphs&ver=release)
 [![Documentation Status](https://readthedocs.org/projects/lightgraphsjl/badge/?version=latest)](https://readthedocs.org/projects/lightgraphsjl/?badge=latest)
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # LightGraphs
 
-[![Build Status](https://travis-ci.org/JuliaWeb/LightGraphs.jl.svg?branch=master)](https://travis-ci.org/sbromberger/LightGraphs.jl)
-[![Coverage Status](https://coveralls.io/repos/JuliaWeb/LightGraphs.jl/badge.svg?branch=master)](https://coveralls.io/r/sbromberger/LightGraphs.jl?branch=master)
+[![Build Status](https://travis-ci.org/JuliaGraphs/LightGraphs.jl.svg?branch=master)](https://travis-ci.org/JuliaGraphs/LightGraphs.jl)
+[![Coverage Status](https://coveralls.io/repos/JuliaGraphs/LightGraphs.jl/badge.svg?branch=master)](https://coveralls.io/r/JuliaGraphs/LightGraphs.jl?branch=master)
 [![LightGraphs](http://pkg.julialang.org/badges/LightGraphs_release.svg)](http://pkg.julialang.org/?pkg=LightGraphs&ver=release)
 [![Documentation Status](https://readthedocs.org/projects/lightgraphsjl/badge/?version=latest)](https://readthedocs.org/projects/lightgraphsjl/?badge=latest)
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
 site_name: LightGraphs.jl
 site_author: Seth Bromberger
-repo_url: https://github.com/sbromberger/LightGraphs.jl/
+repo_url: https://github.com/JuliaGraphs/LightGraphs.jl/
 theme: readthedocs
 pages:
 - ['index.md', 'Home']

--- a/src/core.jl
+++ b/src/core.jl
@@ -70,8 +70,26 @@ outdegree(g::AbstractGraph, v::Int) = length(g.finclist[v])
 indegree(g::AbstractGraph, v::AbstractArray{Int,1} = vertices(g)) = [indegree(g,x) for x in v]
 outdegree(g::AbstractGraph, v::AbstractArray{Int,1} = vertices(g)) = [outdegree(g,x) for x in v]
 degree(g::AbstractGraph, v::AbstractArray{Int,1} = vertices(g)) = [degree(g,x) for x in v]
-Δ(g::AbstractGraph) = maximum(degree(g))
-δ(g::AbstractGraph) = minimum(degree(g))
+#Δ(g::AbstractGraph) = maximum(degree(g))
+#δ(g::AbstractGraph) = minimum(degree(g))
+Δout(g) = noallocextreme(outdegree,(>), typemin(Int), g)
+δout(g) = noallocextreme(outdegree,(<), typemax(Int), g)
+δin(g)  = noallocextreme(indegree,(<), typemax(Int), g)
+Δin(g)  = noallocextreme(indegree,(>), typemin(Int), g)
+δ(g)    = noallocextreme(degree,(<), typemax(Int), g)
+Δ(g)    = noallocextreme(degree,(>), typemin(Int), g)
+
+#"computes the extreme value of [f(g,i) for i=i:nv(g)] without gathering them all"
+function noallocextreme(f, comparison, initial, g)
+    value = initial
+    for i in 1:nv(g)
+        funci = f(g, i)
+        if comparison(funci, value)
+            value = funci
+        end
+    end
+    return value
+end
 
 degree_histogram(g::AbstractGraph) = (hist(degree(g), 0:nv(g)-1)[2])
 

--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -5,8 +5,9 @@ function adjacency_matrix(g::AbstractGraph, T::DataType=Int)
     nz = ne(g) * (is_directed(g)? 1 : 2)
     colpt = ones(Int,n_v + 1)
     rowval = sizehint!(Int[],nz)
+    storage = Array(Int, Δout(g))
     for j in 1:n_v
-        dsts = out_neighbors(g, j)
+        dsts = outneighbors!(storage, g, j)
         colpt[j+1] = colpt[j] + length(dsts)
         append!(rowval,sort!(dsts))
     end
@@ -17,6 +18,15 @@ function laplacian_matrix(g::Graph)
     A = adjacency_matrix(g)
     D = spdiagm(sum(A,2)[:])
     return D - A
+end
+
+function outneighbors!(outneighborhood, g, j)
+    edgecollection = out_edges(g, j)
+    degj = outdegree(g, j)
+    for i =1:degj
+        outneighborhood[i] = edgecollection[i].dst
+    end
+    return sub(outneighborhood, 1:degj)
 end
 
 laplacian_spectrum(g::Graph) = eigvals(full(laplacian_matrix(g)))


### PR DESCRIPTION
This should reduce the gc time in `adjacency_matrix`. Uses `sub(A, 1:n)` which might not be 0.3 compatible without using a package. Also includes changes submitted in PR #25 which are used here to further reduce unnecessary allocation. I made two PRs because of the possible incompatibility with 0.3