### PR TITLE
Fasterdosrenyi

### DIFF
--- a/doc/generators.md
+++ b/doc/generators.md
@@ -6,6 +6,10 @@ Creates an [Erdős–Rényi](http://en.wikipedia.org/wiki/Erdős–Rényi_model)
 graph with *n* vertices. Edges are added between pairs of vertices with probability
 *p*. Undirected graphs are created by default; use `is_directed=true` to override.
 
+`sparse_erdos_renyi(n, p[, is_directed=false])`
+When *p* is small do only O(n) work to generate a uniform random sparse graph.
+See `erdos_renyi(n, p[, is_directed=false])` for more information.
+
 `watts_strogatz(n, k, β[, is_directed=false])`  
 Creates a [Watts-Strogatz](https://en.wikipedia.org/wiki/Watts_and_Strogatz_model) small
 model random graph with *n* vertices, each with degree *k*. Edges are randomized per

--- a/src/LightGraphs.jl
+++ b/src/LightGraphs.jl
@@ -72,7 +72,7 @@ module LightGraphs
     readgraph,
 
     # randgraphs
-    erdos_renyi, watts_strogatz
+    erdos_renyi, sparse_erdos_renyi, watts_strogatz
 
     include("core.jl")
         include("digraph.jl")

--- a/src/core.jl
+++ b/src/core.jl
@@ -70,12 +70,14 @@ outdegree(g::AbstractGraph, v::Int) = length(g.finclist[v])
 indegree(g::AbstractGraph, v::AbstractArray{Int,1} = vertices(g)) = [indegree(g,x) for x in v]
 outdegree(g::AbstractGraph, v::AbstractArray{Int,1} = vertices(g)) = [outdegree(g,x) for x in v]
 degree(g::AbstractGraph, v::AbstractArray{Int,1} = vertices(g)) = [degree(g,x) for x in v]
-Δout(g::AbstractGraph) = noallocextreme(outdegree,(>), typemin(Int), g)
-δout(g::AbstractGraph) = noallocextreme(outdegree,(<), typemax(Int), g)
-δin(g::AbstractGraph)  = noallocextreme(indegree,(<), typemax(Int), g)
-Δin(g::AbstractGraph)  = noallocextreme(indegree,(>), typemin(Int), g)
-δ(g::AbstractGraph)    = noallocextreme(degree,(<), typemax(Int), g)
-Δ(g::AbstractGraph)    = noallocextreme(degree,(>), typemin(Int), g)
+#Δ(g::AbstractGraph) = maximum(degree(g))
+#δ(g::AbstractGraph) = minimum(degree(g))
+Δout(g) = noallocextreme(outdegree,(>), typemin(Int), g)
+δout(g) = noallocextreme(outdegree,(<), typemax(Int), g)
+δin(g)  = noallocextreme(indegree,(<), typemax(Int), g)
+Δin(g)  = noallocextreme(indegree,(>), typemin(Int), g)
+δ(g)    = noallocextreme(degree,(<), typemax(Int), g)
+Δ(g)    = noallocextreme(degree,(>), typemin(Int), g)
 
 #"computes the extreme value of [f(g,i) for i=i:nv(g)] without gathering them all"
 function noallocextreme(f, comparison, initial, g)

--- a/src/randgraphs.jl
+++ b/src/randgraphs.jl
@@ -50,6 +50,31 @@ function erdos_renyi(n::Integer, p::Real; is_directed=false)
     return g
 end
 
+
+using Distributions
+#faster for sparse erdos renyi graphs if p≈1, then use the erdos_renyi function
+function sparse_erdos_renyi(n::Integer, p::Real; is_directed=false)
+    if is_directed
+        possibleedges = n*(n - 1)
+        g = DiGraph(n)
+    else
+        possibleedges = (n^2-n)/2
+        g = Graph(n)
+    end
+    numedges = rand(Binomial(Int(possibleedges), p))
+    vtxdist  = DiscreteUniform(1, n)
+    k = 0
+    while k < numedges
+        i, j = rand(vtxdist), rand(vtxdist)
+        if !has_edge(g, i, j)
+            add_edge!(g, i, j)
+            k += 1
+        end
+    end
+    @assert ne(g)==numedges "the number of edges is wrong"
+    return g
+end
+
 function watts_strogatz(n::Integer, k::Integer, β::Real; is_directed=false)
     @assert k < n/2
     if is_directed

--- a/test/randgraphs.jl
+++ b/test/randgraphs.jl
@@ -10,6 +10,13 @@ er = erdos_renyi(10, 0.5, is_directed=true)
 @test nv(er) == 10
 @test is_directed(er) == true
 
+er = sparse_erdos_renyi(10, 0.5)
+@test nv(er) == 10
+@test is_directed(er) == false
+er = sparse_erdos_renyi(10, 0.5, is_directed=true)
+@test nv(er) == 10
+@test is_directed(er) == true
+
 ws = watts_strogatz(10,4,0.2)
 @test nv(ws) == 10
 @test ne(ws) == 20


### PR DESCRIPTION
Here is a first draft it is already faster than the current n^2 implementation.
~~~~
julia> for n = [10^i for i =3:5]
       p = 200/(n*(n-1)); @time g = sparse_erdos_renyi(n,p); @show ne(g)
       end
elapsed time: 0.000176027 seconds (166136 bytes allocated)
ne(g) = 106
elapsed time: 0.000846324 seconds (1177832 bytes allocated)
ne(g) = 102
elapsed time: 0.008833541 seconds (11257336 bytes allocated)
ne(g) = 99

julia> for n = [10^i for i =3:5]
       p = 200/(n*(n-1)); @time g = erdos_renyi(n,p); @show ne(g)
       end
elapsed time: 0.002039418 seconds (153112 bytes allocated)
ne(g) = 86
elapsed time: 0.159099273 seconds (1172680 bytes allocated)
ne(g) = 108
elapsed time: 15.888211903 seconds (11252360 bytes allocated)
ne(g) = 106
~~~~
The following should be nearly constant time but isn't. I would guess because of garbage collection on growing the incidence lists.
~~~~julia
for n = [10^i for i =3:7]
      p = 2000/(n*(n-1));
      @time g = sparse_erdos_renyi(n,p)
      @show ne(g)
end
~~~~
Is that a problem with add_edge! 
