### PR TITLE
Speed up initialisation with adjmx

### DIFF
--- a/src/digraph.jl
+++ b/src/digraph.jl
@@ -39,16 +39,13 @@ function DiGraph{T<:Real}(adjmx::SparseMatrixCSC{T})
 end
 
 function DiGraph{T<:Real}(adjmx::AbstractMatrix{T})
-    dima, dimb = size(adjmx)
-    if dima != dimb
-        error("Adjacency / distance matrices must be square")
-    else
-        g = DiGraph(dima)
-        for i=1:dima, j=1:dima
-            if adjmx[i,j] != zero(T)
-                add_edge!(g,i,j)
-            end
-        end
+    dima,dimb = size(adjmx)
+    isequal(dima,dimb) || error("Adjacency / distance matrices must be square")
+
+    g = DiGraph(dima)
+    for i in find(adjmx)
+        ind = ind2sub((dima,dimb),i)
+        add_edge!(g,ind...)
     end
     return g
 end

--- a/src/graph.jl
+++ b/src/graph.jl
@@ -22,48 +22,18 @@ end
 
 Graph() = Graph(0)
 
-function Graph{T<:Real}(adjmx::SparseMatrixCSC{T})
-    dima, dimb = size(adjmx)
-    if dima != dimb
-        error("Adjacency / distance matrices must be square")
-    elseif !issym(adjmx)
-        error("Adjacency / distance matrices must be symmetric")
-    else
-        a = triu(adjmx)
-        g = Graph(dima)
-        maxc = length(a.colptr)
-        for c = 1:(maxc-1)
-            for rind = a.colptr[c]:a.colptr[c+1]-1
-                isnz = (a.nzval[rind] != zero(T))
-                if isnz
-                    r = a.rowval[rind]
-                    add_edge!(g,r,c)
-                end
-            end
-        end
-        return g
-    end
-end
-
-
-
 function Graph{T<:Real}(adjmx::AbstractMatrix{T})
-    dima, dimb = size(adjmx)
-    if dima != dimb
-        error("Adjacency / distance matrices must be square")
-    elseif !issym(adjmx)
-        error("Adjacency / distance matrices must be symmetric")
-    else
-        g = Graph(dima)
-        for i=1:dima, j=i:dima
-            if adjmx[i,j] != zero(T)
-                add_edge!(g,i,j)
-            end
-        end
+    dima,dimb = size(adjmx)
+    isequal(dima,dimb) || error("Adjacency / distance matrices must be square")
+    issym(adjmx) || error("Adjacency / distance matrices must be symmetric")
+
+    g = Graph(dima)
+    for i in find(triu(adjmx))
+        ind = ind2sub((dima,dimb),i)
+        add_edge!(g,ind...)
     end
     return g
 end
-
 
 function Graph(g::DiGraph)
     gnv = nv(g)


### PR DESCRIPTION
I've been able to substantially speed up initialisation of a `DiGraph` from an adjacency matrix,
```
elapsed time: 0.000879023 seconds (16328 bytes allocated)
elapsed time: 1.2425e-5 seconds (2496 bytes allocated)
```
where the top is the old method, and the bottom is my improved method. Currently the new method is called `DiGraph_new`, so if this commit is to be merged this should of course be renamed. The above results can be generated by running

```
using LightGraphs
mat = [
     0. 1. 0. 0. 0. 0.
     1. 0. 0. 0. 0. 0.
     0.5 0. 0. 0.5 0. 0.
     0. 0. 0. 0. 1. 0.
     0. 0. 0. 0. 0. 1.
     0. 0. 0. 1. 0. 0.
     ]

# precompile
LightGraphs.DiGraph(mat)
LightGraphs.DiGraph_new(mat)

@time g1 = LightGraphs.DiGraph(mat)
@time g2 = LightGraphs.DiGraph_new(mat)
```
as far as I can tell the new method is correct  as given by 
```
julia> adjacency_matrix(g1)
6x6 sparse matrix with 7 Int64 entries:
	[2, 1]  =  1
	[1, 2]  =  1
	[1, 3]  =  1
	[4, 3]  =  1
	[5, 4]  =  1
	[6, 5]  =  1
	[4, 6]  =  1

julia> adjacency_matrix(g2)
6x6 sparse matrix with 7 Int64 entries:
	[2, 1]  =  1
	[1, 2]  =  1
	[1, 3]  =  1
	[4, 3]  =  1
	[5, 4]  =  1
	[6, 5]  =  1
	[4, 6]  =  1
```
This method may also possibly be easily extended to operating on sparse adjacency matrices too, but the dispatch for them is a little bit awkward since as of `v0.4` there's no top level "matrix" type as far as I'm aware.