### PR TITLE
Fix regex for finding {{}}, still will catch some false positives...

### DIFF
--- a/doc/build.jl
+++ b/doc/build.jl
@@ -23,7 +23,7 @@ end
 buildwriter(ex::Expr) = :(print(file, $(esc(ex))))
 
 buildwriter(t::AbstractString) = Expr(:block,
-    [buildwriter(p, iseven(n)) for (n, p) in enumerate(split(t, r"{{|}}"))]...
+    [buildwriter(p, iseven(n)) for (n, p) in enumerate(split(t, r"^{{|\n{{|}}\s*(\n|$)"))]...
 )
 
 buildwriter(part, isdef) = isdef ?


### PR DESCRIPTION
Temporary fix for issue in building docs. cc #130 @sbromberger 

Really a parser needs to be written, otherwise it's never going to catch lines which end in }}
which isn't all that an unusual use case... Still edge cases, but better and will succeed in this instance.