### PR TITLE
Opt/connected components

### DIFF
--- a/bench/bfstree.jl
+++ b/bench/bfstree.jl
@@ -57,9 +57,6 @@ for matname in names
     # woah bfs_tree allocates a lot of memory
     @time tdg = LightGraphs.bfs_tree(g, seed)
     println(tdg)
-    println("bfs_tree_dict")
-    # using a dict is much faster but still a non constant amount of allocation.
-    @time tdict = LightGraphs.bfs_tree_dict(g, seed)
     # preallocating the output tree reduces the number of allocations.
     # much faster
     println("bfs_tree!(vector)")

--- a/bench/bfstree.jl
+++ b/bench/bfstree.jl
@@ -1,0 +1,46 @@
+using LightGraphs
+using MatrixDepot
+function symetrize(A)
+    println("Symmetrizing ")
+    tic()
+    if !issym(A) 
+        println(STDERR, "the matrix is not symmetric using A+A'")
+        A = A + A'
+    end
+    if isa(A, Base.LinAlg.Symmetric)
+        A.data.nzval = abs(A.data.nzval)
+    else
+        A.nzval = abs(A.nzval)
+    end
+    #= spA = abs(sparse(A)) =#
+    toc()
+    return A
+end
+
+function loadmat(matname)
+    println("Reading MTX for $matname")
+    tic()
+    A = matrixdepot(matname, :read)
+    A = symetrize(A)
+    g = Graph(A)
+    toc()
+    println(STDERR, "size(A) = $(size(A))")
+    return g
+end
+
+
+names = ["Newman/football" , "Newman/cond-mat-2003", "SNAP/amazon0302", "SNAP/roadNet-CA"]
+for matname in names
+    g = loadmat(matname)
+    seed = 1
+    println("bfs_tree")
+    # woah bfs_tree allocates a lot of memory
+    @time t = LightGraphs.bfs_tree(g, seed)
+    println(t)
+    # using a dict is much faster but still a non constant amount of allocation.
+    @time t = LightGraphs.bfs_tree_dict(g, seed)
+    # preallocating the output tree reduces the number of allocations.
+    # much faster
+    visitor = LightGraphs.TreeBFSVisitorVector(zeros(Int, nv(g)))
+    @time t = LightGraphs.bfs_tree!(visitor, g, seed)
+end

--- a/bench/connectivity.jl
+++ b/bench/connectivity.jl
@@ -1,0 +1,46 @@
+using LightGraphs
+using MatrixDepot
+using Base.Profile
+@doc "Find the largest connected component of graph and return it as a vector of indices." ->
+function symetrize(A)
+    println("Symmetrizing ")
+    tic()
+    if !issym(A) 
+        println(STDERR, "the matrix is not symmetric using A+A'")
+        A = A + A'
+    end
+    if isa(A, Base.LinAlg.Symmetric)
+        A.data.nzval = abs(A.data.nzval)
+    else
+        A.nzval = abs(A.nzval)
+    end
+    #= spA = abs(sparse(A)) =#
+    toc()
+    return A
+end
+
+function loadmat(matname)
+    println("Reading MTX of $matname")
+    tic()
+    A = matrixdepot(matname, :read)
+    A = symetrize(A)
+    tic()
+    g = Graph(A)
+    return g
+end
+
+names = ["Newman/football" , "Newman/cond-mat-2003", "SNAP/amazon0302"]#, "SNAP/roadNet-CA"]
+sucesses = []
+failures = []
+for matname in names
+    println("Working on $matname")
+    g = loadmat(matname)
+    println("Finding Components")
+    visitor = LightGraphs.TreeBFSVisitorVector(zeros(Int, nv(g)))
+    label = zeros(Int, nv(g))
+    @time label = LightGraphs.connected_components!(label, g)
+    @time components = LightGraphs.connected_components!(visitor, g)
+    @show length(components)
+    @time components_slow = LightGraphs.connected_components(g)
+    @assert length(components) == length(components_slow)
+end

--- a/src/traversals/bfs.jl
+++ b/src/traversals/bfs.jl
@@ -175,6 +175,7 @@ function bfs_tree(g::SimpleGraph, s::Int)
 end
 function bfs_tree_dict(g::SimpleGraph, s::Int)
     nvg = nv(g)
+    visitor[s] = s
     visitor = TreeBFSVisitorDict(Dict{Int, Int}())
     traverse_graph(g, BreadthFirst(), s, visitor)
     return visitor.tree

--- a/src/traversals/bfs.jl
+++ b/src/traversals/bfs.jl
@@ -132,6 +132,26 @@ type TreeBFSVisitor <:SimpleGraphVisitor
     tree::DiGraph
 end
 
+type TreeBFSVisitorDict <: SimpleGraphVisitor
+    tree::Dict{Int,Int}
+end
+type TreeBFSVisitorVector <: SimpleGraphVisitor
+    tree::Vector{Int}
+end
+function examine_neighbor!(visitor::TreeBFSVisitorDict, u::Int, v::Int, vcolor::Int, ecolor::Int)
+    # println("discovering $u -> $v, vcolor = $vcolor, ecolor = $ecolor")
+    if u != v && vcolor == 0
+        visitor.tree[v] = u
+    end
+    return true
+end
+function examine_neighbor!(visitor::TreeBFSVisitorVector, u::Int, v::Int, vcolor::Int, ecolor::Int)
+    # println("discovering $u -> $v, vcolor = $vcolor, ecolor = $ecolor")
+    if u != v && vcolor == 0
+        visitor.tree[v] = u
+    end
+    return true
+end
 # Return the DAG representing the traversal of a graph.
 
 TreeBFSVisitor(n::Int) = TreeBFSVisitor(DiGraph(n))
@@ -153,7 +173,21 @@ function bfs_tree(g::SimpleGraph, s::Int)
     traverse_graph(g, BreadthFirst(), s, visitor)
     return visitor.tree
 end
-
+function bfs_tree_dict(g::SimpleGraph, s::Int)
+    nvg = nv(g)
+    visitor = TreeBFSVisitorDict(Dict{Int, Int}())
+    traverse_graph(g, BreadthFirst(), s, visitor)
+    return visitor.tree
+end
+function bfs_tree(visitor::TreeBFSVisitorVector, g::SimpleGraph, s::Int)
+    nvg = nv(g)
+    visitor = TreeBFSVisitorVector(zeros(Int,nvg))
+    return bfs_tree!(visitor, g, s)
+end
+function bfs_tree!(visitor::TreeBFSVisitorVector, g::SimpleGraph, s::Int)
+    traverse_graph(g, BreadthFirst(), s, visitor)
+    return visitor.tree
+end
 
 # Test graph for bipartiteness
 

--- a/src/traversals/bfs.jl
+++ b/src/traversals/bfs.jl
@@ -132,19 +132,10 @@ type TreeBFSVisitor <:SimpleGraphVisitor
     tree::DiGraph
 end
 
-type TreeBFSVisitorDict <: SimpleGraphVisitor
-    tree::Dict{Int,Int}
-end
 type TreeBFSVisitorVector <: SimpleGraphVisitor
     tree::Vector{Int}
 end
-function examine_neighbor!(visitor::TreeBFSVisitorDict, u::Int, v::Int, vcolor::Int, ecolor::Int)
-    # println("discovering $u -> $v, vcolor = $vcolor, ecolor = $ecolor")
-    if u != v && vcolor == 0
-        visitor.tree[v] = u
-    end
-    return true
-end
+
 function examine_neighbor!(visitor::TreeBFSVisitorVector, u::Int, v::Int, vcolor::Int, ecolor::Int)
     # println("discovering $u -> $v, vcolor = $vcolor, ecolor = $ecolor")
     if u != v && vcolor == 0
@@ -173,19 +164,14 @@ function bfs_tree(g::SimpleGraph, s::Int)
     traverse_graph(g, BreadthFirst(), s, visitor)
     return visitor.tree
 end
-function bfs_tree_dict(g::SimpleGraph, s::Int)
-    nvg = nv(g)
-    visitor = TreeBFSVisitorDict(Dict{Int, Int}())
-    visitor.tree[s] = s
-    traverse_graph(g, BreadthFirst(), s, visitor)
-    return visitor.tree
-end
+
 function bfs_tree(visitor::TreeBFSVisitorVector, g::SimpleGraph, s::Int)
     nvg = nv(g)
     visitor = TreeBFSVisitorVector(zeros(Int,nvg))
     visitor.tree[s] = s
     return bfs_tree!(visitor, g, s)
 end
+
 function bfs_tree!(visitor::TreeBFSVisitorVector, g::SimpleGraph, s::Int)
     traverse_graph(g, BreadthFirst(), s, visitor)
     return visitor.tree

--- a/src/traversals/bfs.jl
+++ b/src/traversals/bfs.jl
@@ -175,14 +175,15 @@ function bfs_tree(g::SimpleGraph, s::Int)
 end
 function bfs_tree_dict(g::SimpleGraph, s::Int)
     nvg = nv(g)
-    visitor[s] = s
     visitor = TreeBFSVisitorDict(Dict{Int, Int}())
+    visitor.tree[s] = s
     traverse_graph(g, BreadthFirst(), s, visitor)
     return visitor.tree
 end
 function bfs_tree(visitor::TreeBFSVisitorVector, g::SimpleGraph, s::Int)
     nvg = nv(g)
     visitor = TreeBFSVisitorVector(zeros(Int,nvg))
+    visitor.tree[s] = s
     return bfs_tree!(visitor, g, s)
 end
 function bfs_tree!(visitor::TreeBFSVisitorVector, g::SimpleGraph, s::Int)


### PR DESCRIPTION
bfs_tree was wasting memory.

using bfs_tree!(visitor::TreeBFSVisitorVector, g::SimpleGraph, s::Int) should improve performance in many places. It doesn't produce a DiGraph output because you only need one Vector{Int} to store a tree. 

You can run see the improvement by running the benchmarks with `julia bench/bfstree.jl` and `julia bench/connectivity.jl`
They show the performance improvements from being more efficient with memory.

The TreeBFSVisitorDict is there to give context to the performance numbers, it is slower than the Vector version and would only be useful if you expect the BFS tree contain only a small fraction of the vertices.