### PR TITLE
v0.3.0-final tag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ os:
   - linux
   - osx
 julia:
+  - 0.3
   - release
   - nightly
 notifications:

--- a/doc/build.jl
+++ b/doc/build.jl
@@ -272,6 +272,15 @@ julia> save(SVG("wheel10.svg"), t)
 producing a graph like this:
 ![Wheel Graph](https://cloud.githubusercontent.com/assets/941359/8960499/17f703c0-35c5-11e5-935e-044be51bc531.png)
 
+###[GraphPlot.jl](https://github.com/afternone/GraphPlot.jl)
+Another graph visualization package that is very simple to use.
+[Compose.jl](https://github.com/dcjones/Compose.jl) is required for most rendering functionality:
+```julia
+julia> using GraphPlot, Compose
+julia> g = WheelGraph(10)
+julia> draw(PNG("/tmp/wheel10.png", 16cm, 16cm), gplot(g))
+```
+
 ###[Metis.jl](https://github.com/JuliaSparse/Metis.jl)
 The Metis graph partitioning package can interface with *LightGraphs.jl*:
 

--- a/doc/integration.md
+++ b/doc/integration.md
@@ -32,6 +32,15 @@ julia> save(SVG("wheel10.svg"), t)
 producing a graph like this:
 ![Wheel Graph](https://cloud.githubusercontent.com/assets/941359/8960499/17f703c0-35c5-11e5-935e-044be51bc531.png)
 
+###[GraphPlot.jl](https://github.com/afternone/GraphPlot.jl)
+Another graph visualization package that is very simple to use.
+[Compose.jl](https://github.com/dcjones/Compose.jl) is required for most rendering functionality:
+```julia
+julia> using GraphPlot, Compose
+julia> g = WheelGraph(10)
+julia> draw(PNG("/tmp/wheel10.png", 16cm, 16cm), gplot(g))
+```
+
 ###[Metis.jl](https://github.com/JuliaSparse/Metis.jl)
 The Metis graph partitioning package can interface with *LightGraphs.jl*:
 

--- a/doc/persistence.md
+++ b/doc/persistence.md
@@ -17,7 +17,14 @@ write(g::Union{LightGraphs.DiGraph,LightGraphs.Graph}, gname::AbstractString, fn
 write(stream, x)
 ```
 
-Write the canonical binary representation of a value to the given stream.
+Write the canonical binary representation of a value to the given stream. Returns the number of bytes written into the stream.
+
+You can write multiple values with the same :func:`write` call. i.e. the following are equivalent:
+
+```
+write(stream, x, y...)
+write(stream, x) + write(stream, y...)
+```
 
 Writes a dictionary of (name=>graph) to a file `fn`, with default `GZip` compression.
 


### PR DESCRIPTION
This is intended to be the final commit to master that is guaranteed to work on Julia v0.3.