### PR TITLE
some changes in rand graph generation

### DIFF
--- a/src/LightGraphs.jl
+++ b/src/LightGraphs.jl
@@ -171,5 +171,6 @@ include("core.jl")
             include("flow/push_relabel.jl")
         include("matching/linear-programming.jl")
         include("datasets/Datasets.jl")
+        include("utils.jl")
 
 end # module

--- a/src/randgraphs.jl
+++ b/src/randgraphs.jl
@@ -3,7 +3,7 @@ function Graph(nv::Integer, ne::Integer; seed::Int = -1)
     @assert(ne <= maxe, "Maximum number of edges for this graph is $maxe")
     ne > 2/3 * maxe && return complement(Graph(nv, maxe-ne))
 
-    rng = seed >= 0 ? MersenneTwister(seed) : MersenneTwister()
+    rng = seed >= 0 ? MersenneTwister(seed) : Base.Random.GLOBAL_RNG
     g = Graph(nv)
     while g.ne < ne
         source = rand(rng, 1:nv)
@@ -18,7 +18,7 @@ function DiGraph(nv::Integer, ne::Integer; seed::Int = -1)
     @assert(ne <= maxe, "Maximum number of edges for this graph is $maxe")
     ne > 2/3 * maxe && return complement(DiGraph(nv, maxe-ne))
 
-    rng = seed >= 0 ? MersenneTwister(seed) : MersenneTwister()
+    rng = seed >= 0 ? MersenneTwister(seed) : Base.Random.GLOBAL_RNG
     g = DiGraph(nv)
     while g.ne < ne
         source = rand(rng, 1:nv)
@@ -64,7 +64,7 @@ function watts_strogatz(n::Integer, k::Integer, β::Real; is_directed=false, see
     else
         g = Graph(n)
     end
-    rng = seed >= 0 ? MersenneTwister(seed) : MersenneTwister()
+    rng = seed >= 0 ? MersenneTwister(seed) : Base.Random.GLOBAL_RNG
     for s in 1:n
         for i in 1:(floor(Integer, k/2))
             target = ((s + i - 1) % n) + 1
@@ -162,7 +162,7 @@ function random_regular_graph(n::Int, k::Int; seed::Int=-1)
         return complement(random_regular_graph(n, n-k-1, seed=seed))
     end
 
-    rng = seed >= 0 ? MersenneTwister(seed) : MersenneTwister()
+    rng = seed >= 0 ? MersenneTwister(seed) : Base.Random.GLOBAL_RNG
 
     edges = _try_creation(n, k, rng)
     while isempty(edges)
@@ -191,7 +191,7 @@ function random_configuration_model(n::Int, k::Array{Int}; seed::Int=-1)
     @assert(iseven(m), "sum(k) must be even")
     @assert(all(0 .<= k .< n), "the 0 <= k[i] < n inequality must be satisfied")
 
-    rng = seed >= 0 ? MersenneTwister(seed) : MersenneTwister()
+    rng = seed >= 0 ? MersenneTwister(seed) : Base.Random.GLOBAL_RNG
 
     edges = _try_creation(n, k, rng)
     while m > 0 && isempty(edges)
@@ -225,8 +225,7 @@ function random_regular_digraph(n::Int, k::Int; dir::Symbol=:out, seed::Int=-1)
     if (k > n/2) && iseven(n * (n-k-1))
         return complement(random_regular_digraph(n, n-k-1, dir=dir, seed=seed))
     end
-    # rng = seed >= 0 ? MersenneTwister(seed) : MersenneTwister()
-
+    rng = seed >= 0 ? MersenneTwister(seed) : Base.Random.GLOBAL_RNG
     cs = collect(2:n)
     i = 1
     I = Array(Int, n*k)
@@ -235,10 +234,7 @@ function random_regular_digraph(n::Int, k::Int; dir::Symbol=:out, seed::Int=-1)
     for r in 1:n
         l = (r-1)*k+1 : r*k
         I[l] = r
-        J[l] = sample(cs, k; replace=false)
-        if r<n
-            cs[r] -= 1
-        end
+        J[l] = sample!(rng, cs, k, exclude = r)
     end
 
     if dir == :out

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -3,6 +3,12 @@ Base.done(it::Void, state::Void) = true
 Base.next(it::Void, state::Void) = (nothing, nothing)
 Base.length(v::Void) = 0
 
+"""
+Sample `k` element from array `a` without repetition and excluding elements in `exclude`.
+Pay attention, it changes the order of the elements in `a`.
+
+sample!(rng, a, k; exclude = nothing)
+"""
 function sample!(rng::AbstractRNG, a::AbstractArray, k::Integer; exclude = nothing)
     length(a) < k + length(exclude) && error("Array too short.")
     res = Vector{eltype(a)}()
@@ -19,3 +25,5 @@ function sample!(rng::AbstractRNG, a::AbstractArray, k::Integer; exclude = nothi
     end
     res
 end
+
+getRNG(seed::Integer) = seed >= 0 ? MersenneTwister(seed) : Base.Random.GLOBAL_RNG

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -8,6 +8,7 @@ Sample `k` element from array `a` without repetition and excluding elements in `
 Pay attention, it changes the order of the elements in `a`.
 
 sample!(rng, a, k; exclude = nothing)
+sample!(a, k; exclude = nothing)
 """
 function sample!(rng::AbstractRNG, a::AbstractArray, k::Integer; exclude = nothing)
     length(a) < k + length(exclude) && error("Array too short.")
@@ -26,4 +27,6 @@ function sample!(rng::AbstractRNG, a::AbstractArray, k::Integer; exclude = nothi
     res
 end
 
-getRNG(seed::Integer) = seed >= 0 ? MersenneTwister(seed) : Base.Random.GLOBAL_RNG
+sample!(a::AbstractArray, k::Integer; exclude = nothing) = sample!(getRNG(), a, k; exclude = exclude)
+
+getRNG(seed::Integer = -1) = seed >= 0 ? MersenneTwister(seed) : Base.Random.GLOBAL_RNG

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,0 +1,21 @@
+Base.start(it::Void) = nothing
+Base.done(it::Void, state::Void) = true
+Base.next(it::Void, state::Void) = (nothing, nothing)
+Base.length(v::Void) = 0
+
+function sample!(rng::AbstractRNG, a::AbstractArray, k::Integer; exclude = nothing)
+    length(a) < k + length(exclude) && error("Array too short.")
+    res = Vector{eltype(a)}()
+    sizehint!(res, k)
+    n = length(a)
+    i = 1
+    while length(res) < k
+        r = rand(rng, 1:n-i+1)
+        if !(a[r] in exclude)
+            push!(res, a[r])
+            a[r], a[n-i+1] = a[n-i+1], a[r]
+            i += 1
+        end
+    end
+    res
+end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,16 +1,11 @@
-Base.start(it::Void) = nothing
-Base.done(it::Void, state::Void) = true
-Base.next(it::Void, state::Void) = (nothing, nothing)
-Base.length(v::Void) = 0
-
 """
-Sample `k` element from array `a` without repetition and excluding elements in `exclude`.
+Sample `k` element from array `a` without repetition and eventually excluding elements in `exclude`.
 Pay attention, it changes the order of the elements in `a`.
 
 sample!(rng, a, k; exclude = nothing)
-sample!(a, k; exclude = nothing)
+sample!(a, k; exclude = ()))
 """
-function sample!(rng::AbstractRNG, a::AbstractArray, k::Integer; exclude = nothing)
+function sample!(rng::AbstractRNG, a::AbstractArray, k::Integer; exclude = ())
     length(a) < k + length(exclude) && error("Array too short.")
     res = Vector{eltype(a)}()
     sizehint!(res, k)
@@ -27,6 +22,6 @@ function sample!(rng::AbstractRNG, a::AbstractArray, k::Integer; exclude = nothi
     res
 end
 
-sample!(a::AbstractArray, k::Integer; exclude = nothing) = sample!(getRNG(), a, k; exclude = exclude)
+sample!(a::AbstractArray, k::Integer; exclude = ()) = sample!(getRNG(), a, k; exclude = exclude)
 
 getRNG(seed::Integer = -1) = seed >= 0 ? MersenneTwister(seed) : Base.Random.GLOBAL_RNG

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -79,7 +79,8 @@ tests = [
     "flow/push_relabel",
     "flow/maximum_flow",
     "matching/linear-programming",
-    "datasets/runtests"
+    "datasets/runtests",
+    "utils"
 ]
 
 

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -1,0 +1,16 @@
+s = LightGraphs.sample!([1:10;], 3)
+@test length(s) == 3
+for  e in s
+    @test 1 <= e <= 10
+end
+
+s = LightGraphs.sample!([1:10;], 6, exclude=[1,2])
+@test length(s) == 6
+for  e in s
+    @test 2 <= e <= 10
+end
+
+@test start(nothing) == nothing
+@test done(nothing, nothing) == true
+@test next(nothing, nothing) == (nothing, nothing)
+@test length(nothing) == 0

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -7,7 +7,7 @@ end
 s = LightGraphs.sample!([1:10;], 6, exclude=[1,2])
 @test length(s) == 6
 for  e in s
-    @test 2 <= e <= 10
+    @test 3 <= e <= 10
 end
 
 @test start(nothing) == nothing

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -9,8 +9,3 @@ s = LightGraphs.sample!([1:10;], 6, exclude=[1,2])
 for  e in s
     @test 3 <= e <= 10
 end
-
-@test start(nothing) == nothing
-@test done(nothing, nothing) == true
-@test next(nothing, nothing) == (nothing, nothing)
-@test length(nothing) == 0


### PR DESCRIPTION
- add `seed` to SBM @jpfairbanks 
- use the GLOBAL_RNG when seed <0 instead of MersenneTwister()
- avoid use of `sample` from StatsBase defining custom `sample!` (~10% faster and can use any RNG)