### PR TITLE
add Nonbacktracking type

### DIFF
--- a/bench/nonbacktracking.jl
+++ b/bench/nonbacktracking.jl
@@ -1,0 +1,48 @@
+using LightGraphs 
+
+sizesnbm1 = Int64[@allocated non_backtracking_matrix(CycleGraph(2^i))for i in 4:10]
+sizesnbm2 = Int64[@allocated Nonbacktracking(CycleGraph(2^i)) for i in 4:10]
+
+
+println("Relative Sizes:\n $(float(sizesnbm1./sizesnbm2))")
+
+macro storetime(name, expression)
+    ex = quote
+        val = $expression;
+        timeinfo[$name] = @elapsed $expression; 
+        val
+    end
+    return ex
+end
+
+function bench(g)
+    nbt = @storetime :Construction_Nonbacktracking  Nonbacktracking(g)
+    x  = ones(Float64, size(nbt)[1])
+    info("Cycle with $n vertices has nbt in R^$(size(nbt))")
+
+    B, nmap = @storetime :Construction_Dense        non_backtracking_matrix(g)
+    y  = @storetime :Multiplication_Nonbacktracking nbt*x
+    z  = @storetime :Multiplication_Dense           B*x;
+    S  = @storetime :Construction_DS                sparse(B)
+    z  = @storetime :Multiplication_Sparse          z = S*x;
+    Sp = @storetime :Construction_Sparse            sparse(nbt)
+    z  = @storetime :Multiplication_Sparse          Sp*x
+end
+
+function report(timeinfo)
+    info("Times")
+    println("Function\t Constructors\t Multiplication")
+    println("Dense   \t $(timeinfo[:Construction_Dense])\t $(timeinfo[:Multiplication_Dense])")
+    println("Sparse  \t $(timeinfo[:Construction_Sparse])\t $(timeinfo[:Multiplication_Sparse])")
+    println("Implicit\t $(timeinfo[:Construction_Nonbacktracking])\t $(timeinfo[:Multiplication_Nonbacktracking])")
+    info("Implicit Multiplication is $(timeinfo[:Multiplication_Dense]/timeinfo[:Multiplication_Nonbacktracking]) faster than dense.")
+    info("Sparse Multiplication is $(timeinfo[:Multiplication_Nonbacktracking]/timeinfo[:Multiplication_Sparse]) faster than implicit.")
+    info("Direct Sparse Construction took $(timeinfo[:Construction_Sparse])
+    Dense to Sparse took: $(timeinfo[:Construction_DS])")
+end
+
+n = 2^13
+C = CycleGraph(n)
+timeinfo = Dict{Symbol, Float64}()
+bench(C)
+report(timeinfo)

--- a/src/LightGraphs.jl
+++ b/src/LightGraphs.jl
@@ -82,6 +82,8 @@ indegree_centrality, outdegree_centrality, katz_centrality, pagerank,
 # spectral
 adjacency_matrix,laplacian_matrix, adjacency_spectrum, laplacian_spectrum,
 CombinatorialAdjacency, non_backtracking_matrix, incidence_matrix,
+nonbacktrack_embedding_dense, nonbacktrack_embedding, Nonbacktracking,
+contract,
 
 # astar
 a_star,

--- a/src/LightGraphs.jl
+++ b/src/LightGraphs.jl
@@ -82,7 +82,7 @@ indegree_centrality, outdegree_centrality, katz_centrality, pagerank,
 # spectral
 adjacency_matrix,laplacian_matrix, adjacency_spectrum, laplacian_spectrum,
 CombinatorialAdjacency, non_backtracking_matrix, incidence_matrix,
-nonbacktrack_embedding_dense, nonbacktrack_embedding, Nonbacktracking,
+nonbacktrack_embedding, Nonbacktracking,
 contract,
 
 # astar

--- a/src/community/detection.jl
+++ b/src/community/detection.jl
@@ -9,13 +9,13 @@ return : array containing vertex assignments
 """
 function community_detection_nback(g::Graph, k::Int)
     #TODO insert check on connected_components
-    ϕ = nonbacktrack_embedding(g, k)
+    ϕ = real(nonbacktrack_embedding(g, k))
     if k==2
         c = community_detection_threshold(g, ϕ[1,:])
     else
         c = kmeans(ϕ, k).assignments
     end
-    c
+    return c
 end
 
 function community_detection_threshold(g::SimpleGraph, coords::AbstractArray)
@@ -39,10 +39,10 @@ end
 
 return : a matrix ϕ where ϕ[:,i] are the coordinates for vertex i.
 """
-function nonbacktrack_embedding(g::Graph, k::Int)
+function nonbacktrack_embedding_dense(g::Graph, k::Int)
     B, edgeid = non_backtracking_matrix(g)
-    λ,eigv,_ = eigs(B, nev=k+1)
-    ϕ = zeros(Float64, k-1, nv(g))
+    λ,eigv,conv = eigs(B, nev=k+1, v0=ones(Float64, size(B,1)))
+    ϕ = zeros(Complex64, k-1, nv(g))
     # TODO decide what to do with the stationary distribution ϕ[:,1]
     # this code just throws it away in favor of eigv[:,2:k+1].
     # we might also use the degree distribution to scale these vectors as is
@@ -57,4 +57,31 @@ function nonbacktrack_embedding(g::Graph, k::Int)
         end
     end
     return ϕ
+end
+
+""" Spectral embedding of the non-backtracking matrix of `g`
+(see [Krzakala et al.](http://www.pnas.org/content/110/52/20935.short)).
+
+`g`: imput Graph
+`k`: number of dimensions in which to embed
+
+return : a matrix ϕ where ϕ[:,i] are the coordinates for vertex i.
+
+Note does not explicitly construct the `non_backtracking_matrix`.
+See `Nonbacktracking` for details.
+
+"""
+function nonbacktrack_embedding(g::Graph, k::Int)
+    B = Nonbacktracking(g)
+    λ,eigv,conv = eigs(B, nev=k+1, v0=ones(Float64, B.m))
+    ϕ = zeros(Complex64, nv(g), k-1)
+    # TODO decide what to do with the stationary distribution ϕ[:,1]
+    # this code just throws it away in favor of eigv[:,2:k+1].
+    # we might also use the degree distribution to scale these vectors as is
+    # common with the laplacian/adjacency methods.
+    for n=1:k-1
+        v= eigv[:,n+1]
+        ϕ[:,n] = contract(B, v)
+    end
+    return ϕ'
 end

--- a/src/community/detection.jl
+++ b/src/community/detection.jl
@@ -30,35 +30,6 @@ function community_detection_threshold(g::SimpleGraph, coords::AbstractArray)
 end
 
 
-
-""" Spectral embedding of the non-backtracking matrix of `g`
-(see [Krzakala et al.](http://www.pnas.org/content/110/52/20935.short)).
-
-`g`: imput Graph
-`k`: number of dimensions in which to embed
-
-return : a matrix ϕ where ϕ[:,i] are the coordinates for vertex i.
-"""
-function nonbacktrack_embedding_dense(g::Graph, k::Int)
-    B, edgeid = non_backtracking_matrix(g)
-    λ,eigv,conv = eigs(B, nev=k+1, v0=ones(Float64, size(B,1)))
-    ϕ = zeros(Complex64, k-1, nv(g))
-    # TODO decide what to do with the stationary distribution ϕ[:,1]
-    # this code just throws it away in favor of eigv[:,2:k+1].
-    # we might also use the degree distribution to scale these vectors as is
-    # common with the laplacian/adjacency methods.
-    for n=1:k-1
-        v= eigv[:,n+1]
-        for i=1:nv(g)
-            for j in neighbors(g, i)
-                u = edgeid[Edge(j,i)]
-                ϕ[n,i] += v[u]
-            end
-        end
-    end
-    return ϕ
-end
-
 """ Spectral embedding of the non-backtracking matrix of `g`
 (see [Krzakala et al.](http://www.pnas.org/content/110/52/20935.short)).
 

--- a/test/community/detection.jl
+++ b/test/community/detection.jl
@@ -1,3 +1,24 @@
+n = 10; k = 5
+pg = PathGraph(n)
+ϕ1 = nonbacktrack_embedding(pg, k)'
+
+nbt = Nonbacktracking(pg)
+B, emap = non_backtracking_matrix(pg)
+
+# check that matvec works
+x = ones(Float64, nbt.m)
+y = nbt * x
+z = B * x
+@test norm(y-z) < 1e-8
+
+#check that matmat works and full(nbt) == B
+@test norm(nbt*eye(nbt.m) - B) < 1e-8
+
+#check that we can use the implicit matvec in nonbacktrack_embedding
+@test size(y) == size(x)
+ϕ2 = LightGraphs.nonbacktrack_embedding_dense(pg, k)'
+
+#check that this recovers communities in the path of cliques
 n=10
 g10 = CompleteGraph(n)
 z = copy(g10)
@@ -13,3 +34,4 @@ for k=2:5
         end
     end
 end
+


### PR DESCRIPTION
Changes the community detection with nonbacktring operator
to use an implicit representation of the NBT operator.
This should allow for improved scalability since non_backtracking_matrix is dense.

The representation is based on GraphMatrices.jl

Tests are included comparing to old implementation on a small graph.

closes #209 