### PR TITLE
docs for missing randgraphs and for smallgraphs

### DIFF
--- a/doc/build.jl
+++ b/doc/build.jl
@@ -1,6 +1,7 @@
 include("../src/LightGraphs.jl")
 pd = pwd()
 using LightGraphs
+using LightGraphs.Datasets
 # pd = joinpath(Pkg.dir(), string(module_name(LightGraphs)))
 
 # This file generated the Markdown documentation files.
@@ -47,14 +48,18 @@ buildwriter(part, isdef) = isdef ?
         quote
             for (f, docstring) in $(esc(parts))
                 if isa(f, Function)
-                    println(file, "### ", first(methods(f)).func.code.name)
+                    println(file, "### ", first(methods(f)).func.code.name) ### paragraph with function name
                     docs = getlgdoc(docstring)
                     printsignature = true
                     if isa(docs[1][1], Markdown.Code)
                         c = docs[1][1].code
                         s = split(string(f),".")
                         if ((length(s) == 1  &&  startswith(c, s[1]))
-                           || (length(s) > 1 && s[1] == "LightGraphs" && startswith(c, s[2])))
+                               || (length(s) > 1
+                                   && ((s[1] == "LightGraphs" && startswith(c, s[2]))
+                                   || (s[2] == "Datasets" && startswith(c, s[3])))
+                                  )
+                            )
                             printsignature = false  # the signature is in the docstring
                             docs[1][1].language = "julia"    # set language to julia
                         end
@@ -68,6 +73,10 @@ buildwriter(part, isdef) = isdef ?
                             writemime(file, "text/plain", d)
                         end
                     end
+                elseif isa(f, DataType)
+                    s=split(string(f),'.')[2]
+                    println(file, "### ", s[1:findfirst(s,'{')-1]) ### paragraph with type name
+                    writemime(file, "text/plain", docstring)
                 else
                     writemime(file, "text/plain", docstring)
                 end
@@ -77,7 +86,9 @@ buildwriter(part, isdef) = isdef ?
     end :
     :(print(file, $(esc(part))))
 
-getlgdoc(docstring) = docstring.content[find(c->c.meta[:module] == LightGraphs, docstring.content)]
+getlgdoc(docstring) = docstring.content[find(c->c.meta[:module] == LightGraphs
+                                                || c.meta[:module] == LightGraphs.Datasets
+                                            , docstring.content)]
 
 function md_methodtable(io, f)
     println(io, "```julia")
@@ -148,21 +159,25 @@ Centrality measures implemented in *LightGraphs.jl* include the following:
 # Generators
 
 ## Random Graphs
-*LightGraphs.jl* implements three common random graph generators:
+*LightGraphs.jl* implements some common random graph generators:
 
-{{erdos_renyi, watts_strogatz, random_regular_graph, random_regular_digraph}}
-
-In addition, [stochastic block model](https://en.wikipedia.org/wiki/Stochastic_block_model)
-graphs are available using the following constructs:
-
-{{StochasticBlockModel, make_edgestream}}
-
-`StochasticBlockModel` instances may be used to create Graph objects.
+{{erdos_renyi, watts_strogatz, random_regular_graph, random_regular_digraph,
+    random_configuration_model, stochastic_block_model,
+    StochasticBlockModel, make_edgestream}}
 
 ## Static Graphs
 *LightGraphs.jl* also implements a collection of classic graph generators:
 
-{{CompleteGraph, CompleteDiGraph, StarGraph, StarDiGraph,PathGraph, PathDiGraph, WheelGraph, WheelDiGraph}}
+{{CompleteGraph, CompleteBipartiteGraph, CompleteDiGraph, StarGraph, StarDiGraph,PathGraph, PathDiGraph,
+ WheelGraph, WheelDiGraph, BinaryTree, DoubleBinaryTree, RoachGraph}}
+
+## Smallgraphs
+Many notorious graphs are available in the Datasets submodule:
+```julia
+using LightGraphs.Datasets
+```
+
+{{smallgraph}}
 
 """
 

--- a/src/datasets/smallgraphs.jl
+++ b/src/datasets/smallgraphs.jl
@@ -18,33 +18,39 @@ function _make_simple_directed_graph{T<:Integer}(n::T, edgelist::Vector{Tuple{T,
     return g
 end
 
-doc"""Creates a small graph of the following types:
+doc"""
+    smallgraph(s::Symbol)
+    smallgraph(s::AbstractString)
 
+Creates a small graph of type `s`. Admissible values for `s` are:
 
-    :bull            A [bull graph](https://en.wikipedia.org/wiki/Bull_graph).
-    :chvatal         A [Chvátal graph](https://en.wikipedia.org/wiki/Chvátal_graph).
-    :cubical         A [Platonic cubical graph](https://en.wikipedia.org/wiki/Platonic_graph).
-    :desargues       A [Desargues graph](https://en.wikipedia.org/wiki/Desargues_graph).
-    :diamond         A [diamond graph](http://en.wikipedia.org/wiki/Diamond_graph).
-    :dodecahedral    A [Platonic dodecahedral graph](https://en.wikipedia.org/wiki/Platonic_graph).
-    :frucht          A [Frucht graph](https://en.wikipedia.org/wiki/Frucht_graph).
-    :heawood         A [Heawood graph](https://en.wikipedia.org/wiki/Heawood_graph).
-    :house           A graph mimicing the classic outline of a house.
-    :housex          A house graph, with two edges crossing the bottom square.
-    :icosahedral     A [Platonic icosahedral  graph](https://en.wikipedia.org/wiki/Platonic_graph).
-    :krackhardtkite  A [Krackhardt-Kite social network graph](http://mathworld.wolfram.com/KrackhardtKite.html).
-    :moebiuskantor   A [Möbius-Kantor graph](http://en.wikipedia.org/wiki/Möbius–Kantor_graph).
-    :octahedral      A [Platonic octahedral  graph](https://en.wikipedia.org/wiki/Platonic_graph).
-    :pappus          A [Pappus graph](http://en.wikipedia.org/wiki/Pappus_graph).
-    :petersen        A [Petersen graph](http://en.wikipedia.org/wiki/Petersen_graph).
-    :sedgewickmaze   A simple maze graph used in Sedgewick's *Algorithms in C++Graph Algorithms (3rd ed.)*
-    :tetrahedral     A [Platonic tetrahedral graph](https://en.wikipedia.org/wiki/Platonic_graph).
-    :truncatedcube   A skeleton of the [truncated cube graph](https://en.wikipedia.org/wiki/Truncated_cube).
-    :truncatedtetrahedron        A skeleton of the [truncated tetrahedron graph](https://en.wikipedia.org/wiki/Truncated_tetrahedron).
-    :truncatedtetrahedron_dir    A skeleton of the [truncated tetrahedron digraph](https://en.wikipedia.org/wiki/Truncated_tetrahedron).
-    :tutte           A [Tutte graph](https://en.wikipedia.org/wiki/Tutte_graph).
+| `s`                       | graph type                       |
+|:------------------------|:---------------------------------|
+| :bull                       | A [bull graph](https://en.wikipedia.org/wiki/Bull_graph).  |
+| :chvatal                    | A [Chvátal graph](https://en.wikipedia.org/wiki/Chvátal_graph). |
+| :cubical                    | A [Platonic cubical graph](https://en.wikipedia.org/wiki/Platonic_graph). |
+| :desargues                |   A [Desarguesgraph](https://en.wikipedia.org/wiki/Desargues_graph).|
+| :diamond                  |   A [diamond graph](http://en.wikipedia.org/wiki/Diamond_graph). |
+| :dodecahedral             |   A [Platonic dodecahedral  graph](https://en.wikipedia.org/wiki/Platonic_graph). |
+| :frucht                   |   A [Frucht graph](https://en.wikipedia.org/wiki/Frucht_graph). |
+| :heawood                  |   A [Heawood graph](https://en.wikipedia.org/wiki/Heawood_graph). |
+| :house                    |   A graph mimicing the classic outline of a house. |
+| :housex                   |   A house graph, with two edges crossing the bottom square. |
+| :icosahedral              |   A [Platonic icosahedral   graph](https://en.wikipedia.org/wiki/Platonic_graph). |
+| :krackhardtkite           |   A [Krackhardt-Kite social network  graph](http://mathworld.wolfram.com/KrackhardtKite.html). |
+| :moebiuskantor            |   A [Möbius-Kantor | graph](http://en.wikipedia.org/wiki/Möbius–Kantor_graph). |
+| :octahedral               |   A [Platonic octahedral  | graph](https://en.wikipedia.org/wiki/Platonic_graph).
+| :pappus                   |   A [Pappus graph](http://en.wikipedia.org/wiki/Pappus_graph). |
+| :petersen                 |   A [Petersen graph](http://en.wikipedia.org/wiki/Petersen_graph). |
+| :sedgewickmaze            |   A simple maze graph used in Sedgewick's *Algorithms in C++: Graph  Algorithms (3rd ed.)* |
+| :tetrahedral              |   A [Platonic tetrahedral  graph](https://en.wikipedia.org/wiki/Platonic_graph). |
+| :truncatedcube            |   A skeleton of the [truncated cube graph](https://en.wikipedia.org/wiki/Truncated_cube). |
+| :truncatedtetrahedron     |   A skeleton of the [truncated tetrahedron  graph](https://en.wikipedia.org/wiki/Truncated_tetrahedron). |
+| :truncatedtetrahedron_dir |   A skeleton of the [truncated tetrahedron digraph](https://en.wikipedia.org/wiki/Truncated_tetrahedron). |
+| :tutte                    |   A [Tutte graph](https://en.wikipedia.org/wiki/Tutte_graph). |
+
 """
-function smallgraph(s::Symbol=:help)
+function smallgraph(s::Symbol)
     graphmap = Dict(
     :bull            => BullGraph,
     :chvatal         => ChvatalGraph,

--- a/src/randgraphs.jl
+++ b/src/randgraphs.jl
@@ -265,12 +265,12 @@ Returns a Graph generated according to the Stochastic Block Model (SBM).
 
 `c[a,b]` : Mean number of neighbors of a vertex in block `a` belonging to block `b`.
            Only the upper triangular part is considered, since the lower traingular is
-           determined by c[b,a] = c[a,b] * n[a]/n[b].
+           determined by $c[b,a] = c[a,b] * n[a]/n[b]$.
 `n[a]` : Number of vertices in block `a`
 
 The second form samples from a SBM with `c[a,a]=cin`, and `c[a,b]=coff`.
 
-For a dynamic version of the SBM see the StochasticBlockModel type and
+For a dynamic version of the SBM see the `StochasticBlockModel` type and
 related functions.
 """
 function stochastic_block_model{T<:Real}(c::Matrix{T}, n::Vector{Int}; seed::Int = -1)
@@ -314,17 +314,23 @@ function stochastic_block_model{T<:Real}(cint::T, cext::T, n::Vector{Int}; seed:
     stochastic_block_model(c, n, seed=seed)
 end
 
-""""StochasticBlockModel(n,nodemap,affinities)
+"""
+    type StochasticBlockModel{T<:Integer,P<:Real}
+        n::T
+        nodemap::Array{T}
+        affinities::Matrix{P}
+        rng::MersenneTwister
+    end
 
 A type capturing the parameters of the SBM.
-Each vertex is assigned to a block and the probability of edge (i,j)
-depends only on the block labels of vertex i and vertex j.
+Each vertex is assigned to a block and the probability of edge `(i,j)`
+depends only on the block labels of vertex `i` and vertex `j`.
 
-The assignement is stored in nodemap and the block affinities a k by k
+The assignement is stored in nodemap and the block affinities a `k` by `k`
 matrix is stored in affinities.
 
-affinities[k,l] is the probability of an edge between any vertex in
-block k and any vertex in block l.
+`affinities[k,l]` is the probability of an edge between any vertex in
+block k and any vertex in block `l`.
 
 We are generating the graphs by taking random `i,j in vertices(g)` and
 flipping a coin with probability `affinities[nodemap[i],nodemap[j]]`.
@@ -419,7 +425,10 @@ function random_pair(rng::AbstractRNG, n::Int)
 end
 
 
-"""Take an infinite sample from the sbm.
+"""
+    make_edgestream(sbm::StochasticBlockModel)
+
+Take an infinite sample from the sbm.
 Pass to `Graph(nvg, neg, edgestream)` to get a Graph object.
 """
 function make_edgestream(sbm::StochasticBlockModel)


### PR DESCRIPTION
just some missing docs and some improvements to docstrings. 

For the time being the `smallgraph` function is in the `Graph Generators` section. When the Datasets submodule will contain more functions ( `largegraphs`?) we will want to create a dedicated page in the docs