### PR TITLE
Adding NetworkViz integration to README and docs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ symmetric difference, blkdiag, induced subgraphs, products (cartesian/scalar)
 
 - **persistence formats:** proprietary compressed, [GraphML](http://en.wikipedia.org/wiki/GraphML), [GML](https://en.wikipedia.org/wiki/Graph_Modelling_Language), [Gexf](http://gexf.net/format), [DOT](https://en.wikipedia.org/wiki/DOT_(graph_description_language)), [Pajek NET](http://gephi.org/users/supported-graph-formats/pajek-net-format/)
 
-- **visualization:** integration with [GraphLayout](https://github.com/IainNZ/GraphLayout.jl), [TikzGraphs](https://github.com/sisl/TikzGraphs.jl), [GraphPlot](https://github.com/afternone/GraphPlot.jl)
+- **visualization:** integration with [GraphLayout](https://github.com/IainNZ/GraphLayout.jl), [TikzGraphs](https://github.com/sisl/TikzGraphs.jl), [GraphPlot](https://github.com/afternone/GraphPlot.jl), [NetworkViz](https://github.com/abhijithanilkumar/NetworkViz.jl/)
 
 
 ## Documentation

--- a/doc/build.jl
+++ b/doc/build.jl
@@ -233,6 +233,28 @@ julia> a = CombinatorialAdjacency(g)
 GraphMatrices.CombinatorialAdjacency{Float64,LightGraphs.Graph,Array{Float64,1}}({10, 9} undirected graph,[1.0,2.0,2.0,2.0,2.0,2.0,2.0,2.0,2.0,1.0])
 ```
 
+##[NetworkViz.jl](https://github.com/abhijithanilkumar/NetworkViz.jl)
+NetworkViz.jl is tightly coupled with *LightGraphs.jl*. Graphs can be visualized in 2D as well as 3D using [ThreeJS.jl](https://github.com/rohitvarkey/ThreeJS.jl) and [Escher.jl](https://github.com/shashi/Escher.jl).
+
+```julia
+#Run this code in Escher
+
+using NetworkViz
+using LightGraphs
+
+main(window) = begin
+  push!(window.assets, "widgets")
+  push!(window.assets,("ThreeJS","threejs"))
+  g = CompleteGraph(10)
+  drawGraph(g)
+end
+```
+
+The above code produces the following output :
+
+![alt tag](https://raw.githubusercontent.com/abhijithanilkumar/NetworkViz.jl/master/examples/networkviz.gif)
+
+
 """
 
 @file "linalg.md" """

--- a/doc/index.md
+++ b/doc/index.md
@@ -145,7 +145,7 @@ symmetric difference, blkdiag, induced subgraphs, products (cartesian/scalar)
 
 - **persistence formats:** proprietary compressed, [GraphML](http://en.wikipedia.org/wiki/GraphML), [GML](https://en.wikipedia.org/wiki/Graph_Modelling_Language), [Gexf](http://gexf.net/format), [DOT](https://en.wikipedia.org/wiki/DOT_(graph_description_language)), [Pajek NET](http://gephi.org/users/supported-graph-formats/pajek-net-format/)
 
-- **visualization:** integration with [GraphLayout](https://github.com/IainNZ/GraphLayout.jl), [TikzGraphs](https://github.com/sisl/TikzGraphs.jl), [GraphPlot](https://github.com/afternone/GraphPlot.jl)
+- **visualization:** integration with [GraphLayout](https://github.com/IainNZ/GraphLayout.jl), [TikzGraphs](https://github.com/sisl/TikzGraphs.jl), [GraphPlot](https://github.com/afternone/GraphPlot.jl), [NetworkViz](https://github.com/abhijithanilkumar/NetworkViz.jl/)
 
 
 ## Documentation

--- a/doc/integration.md
+++ b/doc/integration.md
@@ -65,3 +65,24 @@ julia> a = CombinatorialAdjacency(g)
 GraphMatrices.CombinatorialAdjacency{Float64,LightGraphs.Graph,Array{Float64,1}}({10, 9} undirected graph,[1.0,2.0,2.0,2.0,2.0,2.0,2.0,2.0,2.0,1.0])
 ```
 
+##[NetworkViz.jl](https://github.com/abhijithanilkumar/NetworkViz.jl)
+NetworkViz.jl is tightly coupled with *LightGraphs.jl*. Graphs can be visualized in 2D as well as 3D using [ThreeJS.jl](https://github.com/rohitvarkey/ThreeJS.jl) and [Escher.jl](https://github.com/shashi/Escher.jl).
+
+```julia
+#Run this code in Escher
+
+using NetworkViz
+using LightGraphs
+
+main(window) = begin
+  push!(window.assets, "widgets")
+  push!(window.assets,("ThreeJS","threejs"))
+  g = CompleteGraph(10)
+  drawGraph(g)
+end
+```
+
+The above code produces the following output :
+
+![alt tag](https://raw.githubusercontent.com/abhijithanilkumar/NetworkViz.jl/master/examples/networkviz.gif)
+

--- a/doc/integration.md
+++ b/doc/integration.md
@@ -86,3 +86,4 @@ The above code produces the following output :
 
 ![alt tag](https://raw.githubusercontent.com/abhijithanilkumar/NetworkViz.jl/master/examples/networkviz.gif)
 
+


### PR DESCRIPTION
NetworkViz support has been added to the README and the integration section in the docs. An example with a gif showing the working is also included. @sbromberger Do you need any further details to be added ?