### PR TITLE
Fix to nonbacktracking_embedding

### DIFF
--- a/src/community/detection.jl
+++ b/src/community/detection.jl
@@ -44,7 +44,8 @@ See `Nonbacktracking` for details.
 """
 function nonbacktrack_embedding(g::Graph, k::Int)
     B = Nonbacktracking(g)
-    λ,eigv,conv = eigs(B, nev=k+1, v0=ones(Float64, B.m))
+    2 <= k+1 <= size(B)[2] || throw(BoundsError("cannot get $(k+1) eigenvectors"))
+    λ,eigv,conv = eigs(B, nev=k+1)
     ϕ = zeros(Complex64, nv(g), k-1)
     # TODO decide what to do with the stationary distribution ϕ[:,1]
     # this code just throws it away in favor of eigv[:,2:k+1].

--- a/test/community/detection.jl
+++ b/test/community/detection.jl
@@ -8,7 +8,7 @@ return : a matrix ϕ where ϕ[:,i] are the coordinates for vertex i.
 """
 function nonbacktrack_embedding_dense(g::Graph, k::Int)
     B, edgeid = non_backtracking_matrix(g)
-    λ,eigv,conv = eigs(B, nev=k+1, v0=ones(Float64, size(B,1)))
+    λ,eigv,conv = eigs(B, nev=k+1)
     ϕ = zeros(Complex64, k-1, nv(g))
     # TODO decide what to do with the stationary distribution ϕ[:,1]
     # this code just throws it away in favor of eigv[:,2:k+1].

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -51,7 +51,6 @@ tests = [
     "graphdigraph",
     "persistence",
     "distance",
-    "spectral",
     "cliques",
     "subgraphs",
     "connectivity",
@@ -66,8 +65,9 @@ tests = [
     "traversals/maxadjvisit",
     "traversals/graphvisit",
     "traversals/randomwalks",
-    "community/core-periphery",
+    "spectral",
     "community/detection",
+    "community/core-periphery",
     "community/modularity",
     "community/clustering",
     "centrality/betweenness",
@@ -82,7 +82,7 @@ tests = [
     "flow/maximum_flow",
     "matching/linear-programming",
     "datasets/runtests",
-    "utils"
+    "utils",
 ]
 
 

--- a/test/spectral.jl
+++ b/test/spectral.jl
@@ -1,3 +1,5 @@
+import Base.full
+
 @test adjacency_matrix(g3)[3,2] == 1
 @test adjacency_matrix(g3)[2,4] == 0
 @test laplacian_matrix(g3)[3,2] == -1
@@ -21,6 +23,15 @@ for i=1:10
     @test sum(B[:,i]) == 8
     @test sum(B[i,:]) == 8
 end
+B₁ = Nonbacktracking(g10)
+
+# just so that we can assert equality of matrices
+full(nbt::Nonbacktracking) = full(sparse(nbt))
+
+@test full(B₁) == full(B)
+@test  B₁ * ones(size(B₁)[2]) == B*ones(size(B)[2])
+@test size(B₁) == size(B)
+@test_approx_eq_eps norm(eigs(B₁)[1] - eigs(B)[1]) 0.0 1e-8
 
 @test_approx_eq_eps(adjacency_spectrum(g5)[3],0.311, 0.001)
 


### PR DESCRIPTION
Giving eigs a seed vector can produce unexpected behavior errors.

- The seed vector passed to eigs is removed.
- Improves test coverage of Nonbacktracking operator.