### PR TITLE
[RFC] remove Requires, GraphMatrices. Add JuMP, MatrixDepot

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,9 @@ notifications:
 # uncomment the following lines to override the default test script
 script:
   - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
-  - julia --check-bounds=yes -e 'Pkg.add("GraphMatrices"); Pkg.add("JuMP"); Pkg.add("MatrixDepot"); Pkg.add("Clp")'
+  - julia --check-bounds=yes -e 'Pkg.add("MatrixDepot"); Pkg.add("JuMP"); Pkg.add("Clp")'
   - julia --check-bounds=yes -e 'Pkg.clone(pwd()); Pkg.build("LightGraphs"); Pkg.test("LightGraphs"; coverage=true)'
-  
+
 cache:
   directories:
     - $HOME/.julia/v0.4/JuMP/

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,8 +1,9 @@
 julia 0.4 0.5-
-Requires
 GZip 0.2.18
 StatsBase 0.7.4
 LightXML 0.2.1
 ParserCombinator 1.7.3
 JLD
 Clustering 0.4
+JuMP
+MatrixDepot

--- a/doc/build.jl
+++ b/doc/build.jl
@@ -245,6 +245,7 @@ package:
 julia> g = PathGraph(10)
 {10, 9} undirected graph
 
+julia> using GraphMatrices
 julia> a = CombinatorialAdjacency(g)
 GraphMatrices.CombinatorialAdjacency{Float64,LightGraphs.Graph,Array{Float64,1}}({10, 9} undirected graph,[1.0,2.0,2.0,2.0,2.0,2.0,2.0,2.0,2.0,1.0])
 ```

--- a/doc/index.md
+++ b/doc/index.md
@@ -172,6 +172,10 @@ Please include version numbers of all relevant libraries and Julia itself.
 - PRs should contain one logical enhancement to the codebase.
 - Squash commits in a PR.
 - Open an issue to discuss a feature before you start coding (this maximizes the likelihood of patch acceptance).
+- Minimize dependencies on external packages, and avoid introducing new dependencies. In general,
+    - PRs introducing dependencies on core Julia packages are ok.
+    - PRs introducing dependencies on non-core "leaf" packages (no subdependencies except for core Julia packages) are less ok.
+    - PRs introducing dependencies on non-core non-leaf packages require strict scrutiny and will likely not be accepted without some compelling reason (urgent bugfix or much-needed functionality).
 - Put type assertions on all function arguments (use abstract types, Union, or Any if necessary).
 - If the algorithm was presented in a paper, include a reference to the paper (i.e. a proper academic citation along with an eprint link).
 - Take steps to ensure that code works on graphs with multiple connected components efficiently.

--- a/doc/integration.md
+++ b/doc/integration.md
@@ -61,6 +61,7 @@ package:
 julia> g = PathGraph(10)
 {10, 9} undirected graph
 
+julia> using GraphMatrices
 julia> a = CombinatorialAdjacency(g)
 GraphMatrices.CombinatorialAdjacency{Float64,LightGraphs.Graph,Array{Float64,1}}({10, 9} undirected graph,[1.0,2.0,2.0,2.0,2.0,2.0,2.0,2.0,2.0,1.0])
 ```

--- a/doc/matching.md
+++ b/doc/matching.md
@@ -21,8 +21,6 @@ The algorithm relies on a linear relaxation on of the matching problem, which is
 
 Eventually a `cutoff` argument can be given, to reduce computational times excluding edges with weights lower than the cutoff.
 
-The package JuMP.jl and one of its supported solvers is required.
-
 The returned object is of type
 
 ```
@@ -35,9 +33,11 @@ end
 
 where
 
+```
 weight: total weight of the matching
 
 inmatch: `inmatch[e]=true` if edge `e` belongs to the matching.
 
-m:       `m[i]=j` if vertex `i` is matched to vertex `j`.          `m[i]=-1` for unmatched vertices.
-
+m:      `m[i]=j` if vertex `i` is matched to vertex `j`.
+        `m[i]=-1` for unmatched vertices.
+```

--- a/src/LightGraphs.jl
+++ b/src/LightGraphs.jl
@@ -1,24 +1,13 @@
 __precompile__(true)
 module LightGraphs
 
-using Requires
 using GZip
 using StatsBase: rand_binom, sample
 using Base.Collections
 using LightXML
 using ParserCombinator: Parsers.DOT, Parsers.GML
 using Clustering: kmeans
-try
-    import GraphMatrices: CombinatorialAdjacency
-    nothing
-catch
-end
-
-try
-    using JuMP
-    nothing
-catch
-end
+using JuMP
 
 import Base: write, ==, <, *, isless, issubset, complement, union, intersect,
             reverse, reverse!, blkdiag, getindex, setindex!, show, print, copy, in,
@@ -79,7 +68,7 @@ indegree_centrality, outdegree_centrality, katz_centrality, pagerank,
 
 # spectral
 adjacency_matrix,laplacian_matrix, adjacency_spectrum, laplacian_spectrum,
-CombinatorialAdjacency, non_backtracking_matrix, incidence_matrix,
+non_backtracking_matrix, incidence_matrix,
 nonbacktrack_embedding, Nonbacktracking,
 contract,
 

--- a/src/datasets/Datasets.jl
+++ b/src/datasets/Datasets.jl
@@ -1,12 +1,7 @@
 module Datasets
 
 using ...LightGraphs
-using Requires
-try
-    using MatrixDepot
-    nothing
-catch
-end
+using MatrixDepot
 
 # smallgraphs
 export smallgraph,

--- a/src/datasets/matrixdepot.jl
+++ b/src/datasets/matrixdepot.jl
@@ -1,4 +1,3 @@
-@require MatrixDepot begin
 function MDGraph(a::AbstractString, x...)
     a in matrixdepot("symmetric") || error("Valid matrix not found in collection")
     external = a in matrixdepot("data")
@@ -16,5 +15,3 @@ function MDDiGraph(a::AbstractString, x...)
 
     return DiGraph(m)
 end
-
-end     # @require MatrixDepot

--- a/src/matching/linear-programming.jl
+++ b/src/matching/linear-programming.jl
@@ -1,3 +1,9 @@
+type MatchingResult
+    weight::Float64
+    inmatch::Dict{Edge,Bool}
+    m::Vector{Int}
+end
+
 """
     maximum_weight_maximal_matching{T<:Number}(g, w::Dict{Edge,T})
     maximum_weight_maximal_matching{T<:Number}(g, w::Dict{Edge,T}, cutoff)
@@ -14,8 +20,6 @@ guaranteed to have integer solution on bipartite graps.
 Eventually a `cutoff` argument can be given, to reduce computational times
 excluding edges with weights lower than the cutoff.
 
-The package JuMP.jl and one of its supported solvers is required.
-
 The returned object is of type
 
     type MatchingResult
@@ -26,25 +30,13 @@ The returned object is of type
 
 where
 
-weight: total weight of the matching
+    weight: total weight of the matching
 
-inmatch: `inmatch[e]=true` if edge `e` belongs to the matching.
+    inmatch: `inmatch[e]=true` if edge `e` belongs to the matching.
 
-m:       `m[i]=j` if vertex `i` is matched to vertex `j`.
-         `m[i]=-1` for unmatched vertices.
+    m:      `m[i]=j` if vertex `i` is matched to vertex `j`.
+            `m[i]=-1` for unmatched vertices.
 """
-maximum_weight_maximal_matching(args...; kws...) = isdefined(:JuMP) ?  error("wrong arguments") : error("JuMP is required")
-
-@require JuMP begin
-
-type MatchingResult
-    weight::Float64
-    inmatch::Dict{Edge,Bool}
-    m::Vector{Int}
-end
-
-
-
 function maximum_weight_maximal_matching{T<:Number}(g::Graph, w::Dict{Edge,T}, cutoff)
     wnew = Dict{Edge,T}()
     for (e,x) in w
@@ -130,4 +122,3 @@ function maximum_weight_maximal_matching{T<:Number}(g::Graph, w::Dict{Edge,T})
 
     return MatchingResult(cost, inmatch, m)
 end
-end # @require

--- a/src/spectral.jl
+++ b/src/spectral.jl
@@ -84,19 +84,6 @@ eigenvalues/eigenvectors. Default values for `dir` and `T` are the same as
 adjacency_spectrum(g::Graph, dir::Symbol=:out, T::DataType=Int) = eigvals(full(adjacency_matrix(g, dir, T)))
 adjacency_spectrum(g::DiGraph, dir::Symbol=:both, T::DataType=Int) = eigvals(full(adjacency_matrix(g, dir, T)))
 
-
-
-# GraphMatrices integration
-# CombinatorialAdjacency(g) returns a type that supports iterative linear solvers and eigenvector solvers.
-@require GraphMatrices begin
-
-function CombinatorialAdjacency(g::Graph)
-    d = float(indegree(g))
-    return CombinatorialAdjacency{Float64, typeof(g), typeof(d)}(g,d)
-end
-end # @require
-
-
 """Returns a sparse node-arc incidence matrix for a graph, indexed by
 `[v, i]`, where `i` is in `1:ne(g)`, indexing an edge `e`. For
 directed graphs, a value of `-1` indicates that `src(e) == v`, while a
@@ -108,7 +95,7 @@ function incidence_matrix(g::SimpleGraph, T::DataType=Int)
     n_v = nv(g)
     n_e = ne(g)
     nz = 2 * n_e
-    
+
     # every col has the same 2 entries
     colpt = collect(1:2:(nz + 1))
     nzval = repmat([isdir ? -one(T) : one(T), one(T)], n_e)
@@ -276,4 +263,3 @@ function contract(nbt::Nonbacktracking, edgespace::Vector)
     contract!(y,nbt,edgespace)
     return y
 end
-

--- a/test/datasets/matrixdepot.jl
+++ b/test/datasets/matrixdepot.jl
@@ -1,12 +1,10 @@
-@require MatrixDepot begin
-    println("*** Running MatrixDepot tests")
-    randstr = "LightGraphs/$(rand(1:10000))"
-    g = MDGraph("hilb", 4)
-    @test nv(g) == 4 && ne(g) == 10
+println("*** Running MatrixDepot tests")
+randstr = "LightGraphs/$(rand(1:10000))"
+g = MDGraph("hilb", 4)
+@test nv(g) == 4 && ne(g) == 10
 
-    g = MDDiGraph("baart", 4)
-    @test nv(g) == 4 && ne(g) == 16
+g = MDDiGraph("baart", 4)
+@test nv(g) == 4 && ne(g) == 16
 
-    @test_throws ErrorException MDGraph("baart", 4)
-    println("*** Finished MatrixDepot tests")
-end
+@test_throws ErrorException MDGraph("baart", 4)
+println("*** Finished MatrixDepot tests")

--- a/test/matching/linear-programming.jl
+++ b/test/matching/linear-programming.jl
@@ -1,4 +1,3 @@
-@require JuMP begin
 g =CompleteBipartiteGraph(2,2)
 w =Dict{Edge,Float64}()
 w[Edge(1,3)] = 10.
@@ -83,4 +82,3 @@ match = maximum_weight_maximal_matching(g,w,0)
 @test match.m[4] == -1
 @test match.m[5] == 2
 @test match.m[6] == 1
-end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,6 @@
-# include("../src/LightGraphs.jl")
+include("../src/LightGraphs.jl")
 using LightGraphs
 using LightGraphs.Datasets
-using Requires
 using Base.Test
 
 g1 = smallgraph("PetersenGraph")

--- a/test/spectral.jl
+++ b/test/spectral.jl
@@ -52,22 +52,6 @@ for dir in [:in, :out, :both]
     @test_approx_eq_eps minimum(evals) 0 1e-13
 end
 
-# GraphMatrices integration tests
-@require GraphMatrices begin
-    println("*** Running GraphMatrices tests")
-    mat = PathGraph(10)
-    onevec = ones(Float64, 10)
-    adjmat = CombinatorialAdjacency(mat)
-    @test eltype(mat) == Float64
-    @test zero(eltype(mat)) == 0.0
-    @test eltype(adjmat) == Float64
-    @test zero(eltype(adjmat)) == 0.0
-    @test sum(abs(adjmat*onevec)) != 0
-    lapl = GraphMatrices.CombinatorialLaplacian(adjmat)
-    @test_approx_eq_eps(eigs(lapl, which=:LR)[1][1], 3.902, 0.001)
-    println("*** Finished GraphMatrices tests")
-end
-
 # testing incidence_matrix, first directed graph
 @test size(incidence_matrix(g4)) == (5,4)
 @test incidence_matrix(g4)[1,1] == -1


### PR DESCRIPTION
The package Requires has some well known problems with precompilation, and its use its being discouraged. I myself get some warning and errors every now and then. 

Therefore I'd like to remove Requires from the required packages. We are relying on Requires for JuMP, MatrixDepot and GraphMatrices. Since GraphMatrices is used in just one function wich could be easily integrated back in GraphMatrices itself (@jpfairbanks) and just mentioned in LG docs, I removed it from LG.  The other two packages add to be added to REQUIRE
