### PR TITLE
Remove show(io::IO,edge::Pair{Int,Int})

### DIFF
--- a/src/core.jl
+++ b/src/core.jl
@@ -17,10 +17,6 @@ dst(e::Edge) = e.second
 
 ==(e1::Edge, e2::Edge) = (e1.first == e2.first && e1.second == e2.second)
 
-function show(io::IO, e::Edge)
-    print(io, "edge $(e.first) - $(e.second)")
-end
-
 """A type representing an undirected graph."""
 type Graph
     vertices::UnitRange{Int}

--- a/test/core.jl
+++ b/test/core.jl
@@ -1,7 +1,6 @@
 @test e1.first == src(e1) == 1
 @test e1.second == dst(e1) == 2
 @test reverse(e1) == re1
-@test sprint(show, e1) == "edge 1 - 2"
 
 g = Graph(5)
 add_edge!(g, 1, 2)


### PR DESCRIPTION
Remove overloading show method [for a type defined in base Julia](http://docs.julialang.org/en/latest/manual/style-guide/#don-t-overload-methods-of-base-container-types). Tracked some weird printing going on in a session where LightGraphs had been imported where I was collecting an Accumulator from DataStructures and saw a bunch of edges.