### PR TITLE
more efficient modularity

### DIFF
--- a/src/community/modularity.jl
+++ b/src/community/modularity.jl
@@ -5,8 +5,10 @@ Computes Newman's modularity `Q`
 for graph `g` given the partitioning `c`.
 """
 function modularity(g::Graph, c)
+    m = ne(g)
+    m == 0 && (return 0.0)
     labels = unique(c)
-    length(labels) == 1 && return 0.0
+    length(labels) == 1 && (return 0.0)
     e = Dict{Int,Int}()
     a = Dict{Int,Int}()
     for edge in edges(g)
@@ -18,14 +20,11 @@ function modularity(g::Graph, c)
         a[c1] = get(a,c1,0) + 1
         a[c2] = get(a,c2,0) + 1
     end
-    m = ne(g)
     Q = 0.0
-    if m > 0
-        for label in labels
-            tmp = get(a,label,0)/2/m
-            Q += get(e,label,0)/2/m
-            Q -= tmp*tmp
-        end
+    for label in labels
+        tmp = get(a,label,0)/2/m
+        Q += get(e,label,0)/2/m
+        Q -= tmp*tmp
     end
     return Q
 end

--- a/src/community/modularity.jl
+++ b/src/community/modularity.jl
@@ -5,18 +5,27 @@ Computes Newman's modularity `Q`
 for graph `g` given the partitioning `c`.
 """
 function modularity(g::Graph, c)
-    Q = 0.
-    m = 2 * ne(g)
-    m == 0 && return 0.
-    s1 = 0
-    s2 = 0
-    for u in vertices(g)
-        for v in vertices(g)
-            c[u] != c[v] && continue
-            s1 += has_edge(g, u, v) ? 1 : 0
-            s2 += degree(g, u)*degree(g, v)
+    labels = unique(c)
+    length(labels) == 1 && return 0.0
+    e = Dict{Int,Int}()
+    a = Dict{Int,Int}()
+    for edge in edges(g)
+        c1 = c[src(edge)]
+        c2 = c[dst(edge)]
+        if c1 == c2
+            e[c1] = get(e,c1,0) + 2
+        end
+        a[c1] = get(a,c1,0) + 1
+        a[c2] = get(a,c2,0) + 1
+    end
+    m = ne(g)
+    Q = 0.0
+    if m > 0
+        for label in labels
+            tmp = get(a,label,0)/2/m
+            Q += get(e,label,0)/2/m
+            Q -= tmp*tmp
         end
     end
-    Q = s1/m - s2/m^2
     return Q
 end

--- a/src/community/modularity.jl
+++ b/src/community/modularity.jl
@@ -5,26 +5,28 @@ Computes Newman's modularity `Q`
 for graph `g` given the partitioning `c`.
 """
 function modularity(g::Graph, c)
-    m = ne(g)
-    m == 0 && (return 0.0)
-    labels = unique(c)
-    length(labels) == 1 && (return 0.0)
-    e = Dict{Int,Int}()
-    a = Dict{Int,Int}()
-    for edge in edges(g)
-        c1 = c[src(edge)]
-        c2 = c[dst(edge)]
-        if c1 == c2
-            e[c1] = get(e,c1,0) + 2
+    n = nv(g)
+    m = 2*ne(g)
+    m == 0 && return 0.0
+    e = zeros(Int,n)
+    a = zeros(Int,n)
+    for u in vertices(g)
+        for v in neighbors(g,u)
+            if u <= v
+                c1 = c[u]
+                c2 = c[v]
+                if c1 == c2
+                    e[c1] += 2
+                end
+                a[c1] += 1
+                a[c2] += 1
+            end
         end
-        a[c1] = get(a,c1,0) + 1
-        a[c2] = get(a,c2,0) + 1
     end
-    Q = 0.0
-    for label in labels
-        tmp = get(a,label,0)/2/m
-        Q += get(e,label,0)/2/m
-        Q -= tmp*tmp
+
+    Q = 0
+    @inbounds for i=1:n
+        Q += e[i]*m - a[i]*a[i]
     end
-    return Q
+    return Q/m/m
 end


### PR DESCRIPTION
The `modularity` function in `src/community/modularity.jl` is very time-consuming for large networks. Because it has `N^2` loops. I update the function to make it fast for large networks. Below is the benchmark.
```
julia> g = barabasi_albert(100000,3)
{100000, 299991} undirected graph

julia> c = label_propagation(g)[1]
100000-element Array{Int64,1}:
    1
    2
    3
    ⋮
 2771
 3260
 3505

julia> @time LightGraphs.modularity(g,c)
 16.693947 seconds (22.58 M allocations: 517.595 MB, 0.45% gc time)
0.32058762903587995

julia> # the new function
julia> @time LightGraphs.modularity1(g,c)
  0.050851 seconds (300.15 k allocations: 10.182 MB)
0.3205876290359057
```