### PR TITLE
add flexible barabasi_albert model

### DIFF
--- a/src/LightGraphs.jl
+++ b/src/LightGraphs.jl
@@ -4,6 +4,7 @@ module LightGraphs
 using Requires
 using GZip
 using StatsBase: rand_binom, sample
+import StatsBase: sample!
 using Base.Collections
 using LightXML
 using ParserCombinator: Parsers.DOT, Parsers.GML
@@ -98,7 +99,7 @@ maximum_weight_maximal_matching, MatchingResult,
 # randgraphs
 erdos_renyi, watts_strogatz, random_regular_graph, random_regular_digraph, random_configuration_model,
 StochasticBlockModel, make_edgestream, nearbipartiteSBM, blockcounts, blockfractions,
-stochastic_block_model, barabasi_albert, static_fitness_model, static_scale_free,
+stochastic_block_model, barabasi_albert, barabasi_albert!, static_fitness_model, static_scale_free,
 
 #community
 modularity, community_detection_nback, core_periphery_deg,

--- a/src/randgraphs.jl
+++ b/src/randgraphs.jl
@@ -150,9 +150,12 @@ end
 """
     barabasi_albert(n::Integer, k::Integer; is_directed::Bool = false, complete::Bool = false, seed::Int = -1)
 
-Creates a [Barabási–Albert model](https://en.wikipedia.org/wiki/Barab%C3%A1si%E2%80%93Albert_model) random graph with `n` vertices.
-It is grown by adding new vertices to an initial graph with `k` vertices. Each new vertex is attached with `k` edges to `k` different vertices already present in the system by preferential attachment.
-Initial graphs are undirected and consist of isolated vertices by default; use `is_directed=true` and `complete=true` for directed and complete initial graphs.
+Creates a [Barabási–Albert model](https://en.wikipedia.org/wiki/Barab%C3%A1si%E2%80%93Albert_model)
+random graph with `n` vertices. It is grown by adding new vertices to an initial
+graph with `k` vertices. Each new vertex is attached with `k` edges to `k`
+different vertices already present in the system by preferential attachment.
+Initial graphs are undirected and consist of isolated vertices by default; 
+use `is_directed=true` and `complete=true` for directed and complete initial graphs.
 """
 barabasi_albert(n::Integer, k::Integer; keyargs...) =
     barabasi_albert(n, k, k; keyargs...)
@@ -160,9 +163,12 @@ barabasi_albert(n::Integer, k::Integer; keyargs...) =
 """
     barabasi_albert(n::Integer, n0::Integer, k::Integer; is_directed::Bool = false, complete::Bool = false, seed::Int = -1)
 
-Creates a [Barabási–Albert model](https://en.wikipedia.org/wiki/Barab%C3%A1si%E2%80%93Albert_model) random graph with `n` vertices.
-It is grown by adding new vertices to an initial graph with `n0` vertices. Each new vertex is attached with `k` edges to `k` different vertices already present in the system by preferential attachment.
-Initial graphs are undirected and consist of isolated vertices by default; use `is_directed=true` and `complete=true` for directed and complete initial graphs.
+Creates a [Barabási–Albert model](https://en.wikipedia.org/wiki/Barab%C3%A1si%E2%80%93Albert_model)
+random graph with `n` vertices. It is grown by adding new vertices to an initial
+graph with `n0` vertices. Each new vertex is attached with `k` edges to `k`
+different vertices already present in the system by preferential attachment.
+Initial graphs are undirected and consist of isolated vertices by default;
+use `is_directed=true` and `complete=true` for directed and complete initial graphs.
 """
 function barabasi_albert(n::Integer, n0::Integer, k::Integer; is_directed::Bool = false, complete::Bool = false, seed::Int = -1)
     if complete
@@ -178,12 +184,16 @@ end
 """
     barabasi_albert!(g::SimpleGraph, n::Integer, k::Integer; seed::Int = -1)
 
-Creates a [Barabási–Albert model](https://en.wikipedia.org/wiki/Barab%C3%A1si%E2%80%93Albert_model) random graph with `n` vertices.
-It is grown by adding new vertices to an initial graph `g`. Each new vertex is attached with `k` edges to `k` different vertices already present in the system by preferential attachment.
+Creates a [Barabási–Albert model](https://en.wikipedia.org/wiki/Barab%C3%A1si%E2%80%93Albert_model)
+random graph with `n` vertices. It is grown by adding new vertices to an initial
+graph `g`. Each new vertex is attached with `k` edges to `k` different vertices
+already present in the system by preferential attachment.
 """
 function barabasi_albert!(g::SimpleGraph, n::Integer, k::Integer; seed::Int=-1)
     n0 = nv(g)
-    1 <= k <= n0 <= n || throw(ArgumentError("Barabási-Albert model requires 1 <= k <= n0 <= n where n0 is the number of nodes in graph g"))
+    1 <= k <= n0 <= n ||
+        throw(ArgumentError("Barabási-Albert model requires 1 <= k <= n0 <= n" *
+			    "where n0 is the number of nodes in graph g"))
     n0 == n && return g
     
     # seed random number generator
@@ -193,7 +203,8 @@ function barabasi_albert!(g::SimpleGraph, n::Integer, k::Integer; seed::Int=-1)
     sizehint!(g.fadjlist, n)
     add_vertices!(g, n - n0)
 
-    # if initial graph doesn't contain any edges expand it by one vertex and add k edges from this additional node
+    # if initial graph doesn't contain any edges
+    # expand it by one vertex and add k edges from this additional node
     if ne(g) == 0
         # expand initial graph
         n0 += 1

--- a/test/randgraphs.jl
+++ b/test/randgraphs.jl
@@ -31,14 +31,64 @@ ws = watts_strogatz(10, 4, 0.2, is_directed=true)
 @test ne(ws) == 20
 @test is_directed(ws) == true
 
-ba = barabasi_albert(10,2)
+ba = barabasi_albert(10, 2)
 @test nv(ba) == 10
 @test ne(ba) == 16
+@test is_directed(ba) == false
+
+ba = barabasi_albert(10, 2, 2)
+@test nv(ba) == 10
+@test ne(ba) == 16
+@test is_directed(ba) == false
+
+ba = barabasi_albert(10, 4, 2)
+@test nv(ba) == 10
+@test ne(ba) == 12
+@test is_directed(ba) == false
+
+ba = barabasi_albert(10, 2, complete=true)
+@test nv(ba) == 10
+@test ne(ba) == 17
+@test is_directed(ba) == false
+
+ba = barabasi_albert(10, 2, 2, complete=true)
+@test nv(ba) == 10
+@test ne(ba) == 17
+@test is_directed(ba) == false
+
+ba = barabasi_albert(10, 4, 2, complete=true)
+@test nv(ba) == 10
+@test ne(ba) == 18
 @test is_directed(ba) == false
 
 ba = barabasi_albert(10, 2, is_directed=true)
 @test nv(ba) == 10
 @test ne(ba) == 16
+@test is_directed(ba) == true
+
+ba = barabasi_albert(10, 2, 2, is_directed=true)
+@test nv(ba) == 10
+@test ne(ba) == 16
+@test is_directed(ba) == true
+
+ba = barabasi_albert(10, 4, 2, is_directed=true)
+@test nv(ba) == 10
+@test ne(ba) == 12
+@test is_directed(ba) == true
+
+ba = barabasi_albert(10, 2, is_directed=true, complete=true)
+@test nv(ba) == 10
+@test ne(ba) == 18
+@test is_directed(ba) == true
+
+ba = barabasi_albert(10, 2, 2, is_directed=true, complete=true)
+@test nv(ba) == 10
+@test ne(ba) == 18
+@test is_directed(ba) == true
+
+ba = barabasi_albert_complete(10, 4, 2, is_directed=true, complete=true)
+@test nv(ba) == 10
+@test ne(ba) == 24
 @test is_directed(ba) == true
 
 fm = static_fitness_model(20, rand(10))


### PR DESCRIPTION
This is my first try of a PR regarding https://github.com/JuliaGraphs/LightGraphs.jl/issues/372

```julia

julia> @time g = barabasi_albert(100_000, 3) # old implementation
  0.305237 seconds (2.88 M allocations: 105.200 MB, 18.56% gc time)
  {100000, 299991} undirected graph

julia> @time g = barabasi_albert(100_000, 3) # new implementation
  0.259497 seconds (2.02 M allocations: 87.816 MB, 15.89% gc time)
  {100000, 299991} undirected graph
```