### PR TITLE
remove Requires, add JuMP, GraphMatrices,MatrixDepot

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,12 +11,12 @@ notifications:
 # uncomment the following lines to override the default test script
 script:
   - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
-  - julia --check-bounds=yes -e 'Pkg.add("GraphMatrices"); Pkg.add("JuMP"); Pkg.add("MatrixDepot"); Pkg.add("Clp")'
-  - julia --check-bounds=yes -e 'Pkg.clone(pwd()); Pkg.build("LightGraphs"); Pkg.test("LightGraphs"; coverage=true)'
-  
-cache:
-  directories:
-    - $HOME/.julia/v0.4/JuMP/
-    - $HOME/.julia/v0.5/JuMP/
+  - julia -e 'Pkg.add("Clp")'
+  - julia -e 'Pkg.clone(pwd()); Pkg.build("LightGraphs"); Pkg.test("LightGraphs"; coverage=true)'
+
+# cache:
+#   directories:
+#     - $HOME/.julia/v0.4/JuMP/
+#     - $HOME/.julia/v0.5/JuMP/
 after_success:
     - julia -e 'cd(Pkg.dir("LightGraphs")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(process_folder()); Codecov.submit(process_folder())'

--- a/REQUIRE
+++ b/REQUIRE
@@ -6,5 +6,5 @@ ParserCombinator 1.7.3
 JLD
 Clustering 0.4
 Distributions
-GraphMatrices  #only by CombinatorialAdjacency
+GraphMatrices
 MatrixDepot

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,8 +1,10 @@
 julia 0.4 0.5-
-Requires
+JuMP
 GZip 0.2.18
 LightXML 0.2.1
 ParserCombinator 1.7.3
 JLD
 Clustering 0.4
 Distributions
+GraphMatrices  #only by CombinatorialAdjacency
+MatrixDepot

--- a/src/LightGraphs.jl
+++ b/src/LightGraphs.jl
@@ -1,24 +1,14 @@
 __precompile__(true)
 module LightGraphs
 
-using Requires
 using GZip
 using Distributions: Binomial
 using Base.Collections
 using LightXML
 using ParserCombinator: Parsers.DOT, Parsers.GML
 using Clustering: kmeans
-try
-    import GraphMatrices: CombinatorialAdjacency
-    nothing
-catch
-end
-
-try
-    using JuMP
-    nothing
-catch
-end
+import GraphMatrices: CombinatorialAdjacency
+using JuMP
 
 import Base: write, ==, <, *, isless, issubset, complement, union, intersect,
             reverse, reverse!, blkdiag, getindex, setindex!, show, print, copy, in,

--- a/src/datasets/Datasets.jl
+++ b/src/datasets/Datasets.jl
@@ -1,13 +1,7 @@
 module Datasets
 
 using ...LightGraphs
-using Requires
-try
-    using MatrixDepot
-    nothing
-catch
-end
-
+using MatrixDepot
 # smallgraphs
 export smallgraph,
 

--- a/src/datasets/matrixdepot.jl
+++ b/src/datasets/matrixdepot.jl
@@ -1,4 +1,3 @@
-@require MatrixDepot begin
 function MDGraph(a::AbstractString, x...)
     a in matrixdepot("symmetric") || error("Valid matrix not found in collection")
     external = a in matrixdepot("data")
@@ -16,5 +15,3 @@ function MDDiGraph(a::AbstractString, x...)
 
     return DiGraph(m)
 end
-
-end     # @require MatrixDepot

--- a/src/matching/linear-programming.jl
+++ b/src/matching/linear-programming.jl
@@ -1,3 +1,10 @@
+type MatchingResult
+    weight::Float64
+    inmatch::Dict{Edge,Bool}
+    m::Vector{Int}
+end
+
+
 """
     maximum_weight_maximal_matching{T<:Number}(g, w::Dict{Edge,T})
     maximum_weight_maximal_matching{T<:Number}(g, w::Dict{Edge,T}, cutoff)
@@ -33,18 +40,6 @@ inmatch: `inmatch[e]=true` if edge `e` belongs to the matching.
 m:       `m[i]=j` if vertex `i` is matched to vertex `j`.
          `m[i]=-1` for unmatched vertices.
 """
-maximum_weight_maximal_matching(args...; kws...) = isdefined(:JuMP) ?  error("wrong arguments") : error("JuMP is required")
-
-@require JuMP begin
-
-type MatchingResult
-    weight::Float64
-    inmatch::Dict{Edge,Bool}
-    m::Vector{Int}
-end
-
-
-
 function maximum_weight_maximal_matching{T<:Number}(g::Graph, w::Dict{Edge,T}, cutoff)
     wnew = Dict{Edge,T}()
     for (e,x) in w
@@ -108,11 +103,11 @@ function maximum_weight_maximal_matching{T<:Number}(g::Graph, w::Dict{Edge,T})
 
     status = solve(model)
     status != :Optimal && error("JuMP solver failed to find optimal solution.")
-    sol = getValue(x)
+    sol = getvalue(x)
 
     all(Bool[s == 1 || s == 0 for s in sol]) || error("Found non-integer solution.")
 
-    cost = getObjectiveValue(model)
+    cost = getobjectivevalue(model)
 
     inmatch = Dict{Edge,Bool}()
     m = fill(-1, nv(g))
@@ -130,4 +125,3 @@ function maximum_weight_maximal_matching{T<:Number}(g::Graph, w::Dict{Edge,T})
 
     return MatchingResult(cost, inmatch, m)
 end
-end # @require

--- a/src/spectral.jl
+++ b/src/spectral.jl
@@ -88,13 +88,10 @@ adjacency_spectrum(g::DiGraph, dir::Symbol=:both, T::DataType=Int) = eigvals(ful
 
 # GraphMatrices integration
 # CombinatorialAdjacency(g) returns a type that supports iterative linear solvers and eigenvector solvers.
-@require GraphMatrices begin
-
 function CombinatorialAdjacency(g::Graph)
     d = float(indegree(g))
     return CombinatorialAdjacency{Float64, typeof(g), typeof(d)}(g,d)
 end
-end # @require
 
 
 """Returns a sparse node-arc incidence matrix for a graph, indexed by
@@ -108,7 +105,7 @@ function incidence_matrix(g::SimpleGraph, T::DataType=Int)
     n_v = nv(g)
     n_e = ne(g)
     nz = 2 * n_e
-    
+
     # every col has the same 2 entries
     colpt = collect(1:2:(nz + 1))
     nzval = repmat([isdir ? -one(T) : one(T), one(T)], n_e)
@@ -276,4 +273,3 @@ function contract(nbt::Nonbacktracking, edgespace::Vector)
     contract!(y,nbt,edgespace)
     return y
 end
-

--- a/test/datasets/matrixdepot.jl
+++ b/test/datasets/matrixdepot.jl
@@ -1,12 +1,10 @@
-@require MatrixDepot begin
-    println("*** Running MatrixDepot tests")
-    randstr = "LightGraphs/$(rand(1:10000))"
-    g = MDGraph("hilb", 4)
-    @test nv(g) == 4 && ne(g) == 10
+println("*** Running MatrixDepot tests")
+randstr = "LightGraphs/$(rand(1:10000))"
+g = MDGraph("hilb", 4)
+@test nv(g) == 4 && ne(g) == 10
 
-    g = MDDiGraph("baart", 4)
-    @test nv(g) == 4 && ne(g) == 16
+g = MDDiGraph("baart", 4)
+@test nv(g) == 4 && ne(g) == 16
 
-    @test_throws ErrorException MDGraph("baart", 4)
-    println("*** Finished MatrixDepot tests")
-end
+@test_throws ErrorException MDGraph("baart", 4)
+println("*** Finished MatrixDepot tests")

--- a/test/matching/linear-programming.jl
+++ b/test/matching/linear-programming.jl
@@ -1,4 +1,3 @@
-@require JuMP begin
 g =CompleteBipartiteGraph(2,2)
 w =Dict{Edge,Float64}()
 w[Edge(1,3)] = 10.
@@ -83,4 +82,3 @@ match = maximum_weight_maximal_matching(g,w,0)
 @test match.m[4] == -1
 @test match.m[5] == 2
 @test match.m[6] == 1
-end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,8 @@
 # include("../src/LightGraphs.jl")
 using LightGraphs
 using LightGraphs.Datasets
-using Requires
+using MatrixDepot
+using GraphMatrices
 using Base.Test
 
 g1 = smallgraph("PetersenGraph")

--- a/test/spectral.jl
+++ b/test/spectral.jl
@@ -52,21 +52,18 @@ for dir in [:in, :out, :both]
     @test_approx_eq_eps minimum(evals) 0 1e-13
 end
 
-# GraphMatrices integration tests
-@require GraphMatrices begin
-    println("*** Running GraphMatrices tests")
-    mat = PathGraph(10)
-    onevec = ones(Float64, 10)
-    adjmat = CombinatorialAdjacency(mat)
-    @test eltype(mat) == Float64
-    @test zero(eltype(mat)) == 0.0
-    @test eltype(adjmat) == Float64
-    @test zero(eltype(adjmat)) == 0.0
-    @test sum(abs(adjmat*onevec)) != 0
-    lapl = GraphMatrices.CombinatorialLaplacian(adjmat)
-    @test_approx_eq_eps(eigs(lapl, which=:LR)[1][1], 3.902, 0.001)
-    println("*** Finished GraphMatrices tests")
-end
+println("*** Running GraphMatrices tests")
+mat = PathGraph(10)
+onevec = ones(Float64, 10)
+adjmat = CombinatorialAdjacency(mat)
+@test eltype(mat) == Float64
+@test zero(eltype(mat)) == 0.0
+@test eltype(adjmat) == Float64
+@test zero(eltype(adjmat)) == 0.0
+@test sum(abs(adjmat*onevec)) != 0
+lapl = GraphMatrices.CombinatorialLaplacian(adjmat)
+@test_approx_eq_eps(eigs(lapl, which=:LR)[1][1], 3.902, 0.001)
+println("*** Finished GraphMatrices tests")
 
 # testing incidence_matrix, first directed graph
 @test size(incidence_matrix(g4)) == (5,4)


### PR DESCRIPTION
Julia 0.5 is coming and Requires removal cannot be postponed anymore (see also #377). 

In this PR I remove the dependence on Requires, and add  JuMP, GraphMatrices,MatrixDepot, a small variation from the attempt in #363, the difference being that we keep GraphMatrices as reasonably requested by @jpfairbanks  

Any of these packages it's used only in extremely localized parts of LightGraphs, still I think it is worth to keep all of them.

GraphMatrices and MatrixDepot are small leaf dependencies and they are graph oriented packages, so I think we should keep them.

JuMP is an heavy depence but it can be considered a core julia package, already present in many julia's installation. In the end either we have JuMP's dependence or we remove the matching algorithm, tertium non datur. I'm strongly in favor of merging this PR as soon as possible and procede with the transition too julia 0.5 (wich could not be smooth, I'm observing some weird errors with edge iterators btw)
