### PR TITLE
Create alias functions for triangles

### DIFF
--- a/src/LightGraphs.jl
+++ b/src/LightGraphs.jl
@@ -102,7 +102,7 @@ stochastic_block_model, barabasi_albert, barabasi_albert!, static_fitness_model,
 
 #community
 modularity, community_detection_nback, core_periphery_deg,
-local_clustering,local_clustering_coefficient, global_clustering_coefficient, triangles
+local_clustering,local_clustering_coefficient, global_clustering_coefficient, triangles,
 label_propagation,
 
 #generators

--- a/src/LightGraphs.jl
+++ b/src/LightGraphs.jl
@@ -102,7 +102,7 @@ stochastic_block_model, barabasi_albert, barabasi_albert!, static_fitness_model,
 
 #community
 modularity, community_detection_nback, core_periphery_deg,
-local_clustering,local_clustering_coefficient, global_clustering_coefficient,
+local_clustering,local_clustering_coefficient, global_clustering_coefficient, triangles
 label_propagation,
 
 #generators

--- a/src/community/clustering.jl
+++ b/src/community/clustering.jl
@@ -32,6 +32,13 @@ function local_clustering(g::SimpleGraph, v::Integer)
     return is_directed(g) ? (c , k*(k-1)) : (div(c,2) , div(k*(k-1),2))
 end
 
+"""
+    triangles(g, v)
+
+Returns the number of triangles in the neighborhood for node `v`.
+"""
+triangles(g::SimpleGraph, v::Integer) = local_clustering(g, v)[1]
+
 
 """
     local_clustering_coefficient(g, vlist = vertices(g))
@@ -56,6 +63,14 @@ function local_clustering(g::SimpleGraph, vlist = vertices(g))
     end
     return ntriang, nalltriang
 end
+
+"""
+    triangles(g, vlist = vertices(g))
+
+Returns a vector containing the number of traingles for vertices `vlist`.
+"""
+triangles(g::SimpleGraph, vlist = vertices(g)) = local_clustering(g, vlist)[1]
+
 
 """
     global_clustering_coefficient(g)

--- a/src/community/clustering.jl
+++ b/src/community/clustering.jl
@@ -67,7 +67,7 @@ end
 """
     triangles(g, vlist = vertices(g))
 
-Returns a vector containing the number of traingles for vertices `vlist`.
+Returns a vector containing the number of triangles for vertices `vlist`.
 """
 triangles(g::SimpleGraph, vlist = vertices(g)) = local_clustering(g, vlist)[1]
 

--- a/test/community/clustering.jl
+++ b/test/community/clustering.jl
@@ -3,3 +3,4 @@ g10 = CompleteGraph(10)
 @test global_clustering_coefficient(g10) == 1
 @test local_clustering(g10) == (fill(36, 10), fill(36, 10))
 @test triangles(g10) == fill(36, 10)
+@test triangles(g10, 1) == 36

--- a/test/community/clustering.jl
+++ b/test/community/clustering.jl
@@ -2,3 +2,4 @@ g10 = CompleteGraph(10)
 @test local_clustering_coefficient(g10) == ones(10)
 @test global_clustering_coefficient(g10) == 1
 @test local_clustering(g10) == (fill(36, 10), fill(36, 10))
+@test triangles(g10) == fill(36, 10)


### PR DESCRIPTION
I followed the code structure of `local_clustering` and `local_clustering_coefficient`. That's why there are two `triangles` functions: one taking an index (a node `v`) and another taking a list (vertices list `vlist`) as input.