### PR TITLE
updates for Julia 0.5 (rebased)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ os:
   - linux
 #  - osx
 julia:
-  - release
-#  - nightly
+ - 0.5
+ - nightly
 notifications:
   email: false
 # uncomment the following lines to override the default test script
@@ -13,9 +13,5 @@ script:
   - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
   - julia -e 'Pkg.clone(pwd()); Pkg.build("LightGraphs"); Pkg.test("LightGraphs"; coverage=true)'
 
-# cache:
-#   directories:
-#     - $HOME/.julia/v0.4/JuMP/
-#     - $HOME/.julia/v0.5/JuMP/
 after_success:
     - julia -e 'cd(Pkg.dir("LightGraphs")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(process_folder()); Codecov.submit(process_folder())'

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
-julia 0.4 0.5-
+julia 0.5
 GZip 0.2.18
 LightXML 0.2.1
 ParserCombinator 1.7.3

--- a/bench/bfstree.jl
+++ b/bench/bfstree.jl
@@ -3,7 +3,7 @@ using MatrixDepot
 function symmetrize(A)
     println("Symmetrizing ")
     tic()
-    if !issym(A) 
+    if !issymmetric(A) 
         println(STDERR, "the matrix is not symmetric using A+A'")
         A = A + A'
     end

--- a/bench/connectivity.jl
+++ b/bench/connectivity.jl
@@ -6,7 +6,7 @@ using Base.Profile
 function symmetrize(A)
     println("Symmetrizing ")
     tic()
-    if !issym(A)
+    if !issymmetric(A)
         println(STDERR, "the matrix is not symmetric using A+A'")
         A = A + A'
     end

--- a/doc/build.jl
+++ b/doc/build.jl
@@ -130,7 +130,7 @@ types:
 
 ## Neighbors and Degree
 
-{{degree, indegree, outdegree, Δ, δ, Δout, δout, δin, Δin, degree_histogram, density, neighbors,
+{{degree, indegree, outdegree, Δ, δ, Δout, δout, δin, Δin, density, neighbors,  degree_histogram,
     in_neighbors, all_neighbors, common_neighbors, neighborhood, egonet, isgraphical}}
 """
 

--- a/src/LightGraphs.jl
+++ b/src/LightGraphs.jl
@@ -6,10 +6,11 @@ using Distributions: Binomial
 using Base.Collections
 using LightXML
 using ParserCombinator: Parsers.DOT, Parsers.GML
+using StatsBase: fit, Histogram
 
-import Base: write, ==, <, *, isless, issubset, complement, union, intersect,
+import Base: write, ==, <, *, isless, issubset, union, intersect,
             reverse, reverse!, blkdiag, getindex, setindex!, show, print, copy, in,
-            sum, size, sparse, eltype, length, ndims, issym, transpose,
+            sum, size, sparse, eltype, length, ndims, issymmetric, transpose,
             ctranspose, join, start, next, done, eltype, get
 
 
@@ -17,9 +18,10 @@ import Base: write, ==, <, *, isless, issubset, complement, union, intersect,
 export SimpleGraph, Edge, Graph, DiGraph, vertices, edges, src, dst,
 fadj, badj, in_edges, out_edges, has_vertex, has_edge, is_directed,
 nv, ne, add_edge!, rem_edge!, add_vertex!, add_vertices!,
-indegree, outdegree, degree, degree_histogram, density, Δ, δ,
+indegree, outdegree, degree, density, Δ, δ,
 Δout, Δin, δout, δin, neighbors, in_neighbors, out_neighbors,
 common_neighbors, all_neighbors, has_self_loop, rem_vertex!,
+degree_histogram,
 
 # distance
 eccentricity, diameter, periphery, radius, center,

--- a/src/centrality/pagerank.jl
+++ b/src/centrality/pagerank.jl
@@ -7,11 +7,12 @@ iterations (`n`), and convergence threshold (`ϵ`). If convergence is not
 reached within `n` iterations, an error will be returned.
 """
 function pagerank(g::DiGraph, α=0.85, n=100, ϵ = 1.0e-6)
-    M = adjacency_matrix(g,:out,Float64)
-    S = vec(sum(M,1))
+    A = adjacency_matrix(g,:out,Float64)
+    S = vec(sum(A,1))
     S = 1./S
     S[find(S .== Inf)]=0.0
-    M = scale(S, M')
+    M = A' # need a separate line due to a bug in julia
+    M = Diagonal(S) * M
     N = nv(g)
     x = repmat([1.0/N], N)
     p = repmat([1.0/N], N)

--- a/src/centrality/pagerank.jl
+++ b/src/centrality/pagerank.jl
@@ -11,8 +11,8 @@ function pagerank(g::DiGraph, α=0.85, n=100, ϵ = 1.0e-6)
     S = vec(sum(A,1))
     S = 1./S
     S[find(S .== Inf)]=0.0
-    M = A' # need a separate line due to a bug in julia
-    M = Diagonal(S) * M
+    M = A' # need a separate line due to bug #17456 in julia
+    M = (Diagonal(S) * M)'
     N = nv(g)
     x = repmat([1.0/N], N)
     p = repmat([1.0/N], N)
@@ -21,7 +21,7 @@ function pagerank(g::DiGraph, α=0.85, n=100, ϵ = 1.0e-6)
 
     for _ in 1:n
         xlast = x
-        x = α * (M.' * x + sum(x[is_dangling]) * dangling_weights) + (1 - α) * p
+        x = α * (M * x + sum(x[is_dangling]) * dangling_weights) + (1 - α) * p
         err = sum(abs(x - xlast))
         if (err < N * ϵ)
             return x

--- a/src/core.jl
+++ b/src/core.jl
@@ -221,15 +221,12 @@ function noallocextreme(f, comparison, initial, g)
     return value
 end
 
-"""Produces a histogram of degree values across all vertices for the graph `g`.
-The number of histogram buckets is based on the number of vertices in `g`.
-Degree 0 vertices are excluded.
-
-`degree_histogram(g)[i]` is the number of vertices in g with degree `i`.
-
 """
-degree_histogram(g::SimpleGraph) = (hist(degree(g), 0:nv(g)-1)[2])
+    degree_histogram(g)
 
+Returns a `StatsBase.Histogram` of the degrees of vertices in `g`.
+"""
+degree_histogram(g::SimpleGraph) = fit(Histogram, degree(g))
 
 """Returns a list of all neighbors connected to vertex `v` by an incoming edge.
 

--- a/src/flow/maximum_flow.jl
+++ b/src/flow/maximum_flow.jl
@@ -140,11 +140,7 @@ Generic maximum_flow function. Requires arguments:
 The function defaults to the Push-relabel algorithm. Alternatively, the algorithm
 to be used can also be specified through a keyword argument. A default capacity of 1
 is assumed for each link if no capacity matrix is provided.
-<<<<<<< HEAD
 If the restriction is bigger than 0, it is applied to capacity_matrix.
-=======
-If the restriction is bigger than 0, it is apply to capacity_matrix.
->>>>>>> e6632ac... Compressed the restricted max-flow into classical max-flow
 
 All algorithms return a tuple with 1) the maximum flow and 2) the flow matrix.
 For the Boykov-Kolmogorov algorithm, the associated mincut is returned as a third output.

--- a/src/graph.jl
+++ b/src/graph.jl
@@ -22,7 +22,7 @@ Graph() = Graph(0)
 function Graph{T<:Real}(adjmx::AbstractMatrix{T})
     dima,dimb = size(adjmx)
     isequal(dima,dimb) || error("Adjacency / distance matrices must be square")
-    issym(adjmx) || error("Adjacency / distance matrices must be symmetric")
+    issymmetric(adjmx) || error("Adjacency / distance matrices must be symmetric")
 
     g = Graph(dima)
     for i in find(triu(adjmx))

--- a/src/operators.jl
+++ b/src/operators.jl
@@ -265,11 +265,11 @@ sum(g::SimpleGraph) = ne(g)
 """sparse(g) is the adjacency_matrix of g"""
 sparse(g::SimpleGraph) = adjacency_matrix(g)
 
-#arrayfunctions = (:eltype, :length, :ndims, :size, :strides, :issym)
+#arrayfunctions = (:eltype, :length, :ndims, :size, :strides, :issymmetric)
 eltype(g::SimpleGraph) = Float64
 length(g::SimpleGraph) = nv(g)*nv(g)
 ndims(g::SimpleGraph) = 2
-issym(g::SimpleGraph) = !is_directed(g)
+issymmetric(g::SimpleGraph) = !is_directed(g)
 
 """
     cartesian_product(g, h)

--- a/src/spectral.jl
+++ b/src/spectral.jl
@@ -200,7 +200,7 @@ end
 
 size(nbt::Nonbacktracking) = (nbt.m,nbt.m)
 eltype(nbt::Nonbacktracking) = Float64
-issym(nbt::Nonbacktracking) = false
+issymmetric(nbt::Nonbacktracking) = false
 
 function *{G, T<:Number}(nbt::Nonbacktracking{G}, x::Vector{T})
     length(x) == nbt.m || error("dimension mismatch")

--- a/test/core.jl
+++ b/test/core.jl
@@ -66,7 +66,9 @@ end
 @test CompleteDiGraph(4) != PathDiGraph(4)
 @test CompleteDiGraph(4) == CompleteDiGraph(4)
 
-@test degree_histogram(g)[1:4] == [1, 3, 1, 0]
+@test degree_histogram(CompleteDiGraph(10)).weights == [10]
+@test degree_histogram(CompleteGraph(10)).weights == [10]
+
 @test neighbors(g, 1) == [2, 3, 4]
 @test common_neighbors(g, 2, 3) == [1, 5]
 @test common_neighbors(h, 2, 3) == [5]

--- a/test/operators.jl
+++ b/test/operators.jl
@@ -88,8 +88,8 @@ x = p*ones(10)
 @test eltype(p) == Float64
 @test length(p) == 100
 @test ndims(p) == 2
-@test issym(p)
-@test !issym(g5)
+@test issymmetric(p)
+@test !issymmetric(g5)
 
 g22 = CompleteGraph(2)
 h = cartesian_product(g22, g22)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,4 @@
-include("../src/LightGraphs.jl")
+# include("../src/LightGraphs.jl")
 using LightGraphs
 using Base.Test
 

--- a/test/spectral.jl
+++ b/test/spectral.jl
@@ -21,6 +21,8 @@ for i=1:10
     @test sum(B[:,i]) == 8
     @test sum(B[i,:]) == 8
 end
+@test !issymmetric(B)
+@test !issymmetric(Nonbacktracking(g10))
 
 @test_approx_eq_eps(adjacency_spectrum(g5)[3],0.311, 0.001)
 


### PR DESCRIPTION
rebase of #388. No warnings

This PR is not compatible with julia 0.4, because of issymmetric. If we want to keep compatibility with 0.4 we should use Compat. I'm ok with having new versions of LG supporting only julia 0.5

@sbromberger I had to remove degree_histogram because of 
```julia
WARNING: hist(...) and hist!(...) are deprecated. Use fit(Histogram,...) in StatsBase.jl instead.
```