### PR TITLE
Multiroute flow (Kishimoto and Extended Multiroute Flow (EMRF) versions)

### DIFF
--- a/doc/basicmeasures.md
+++ b/doc/basicmeasures.md
@@ -26,23 +26,25 @@ Returns `true` if `g` is a `DiGraph`.
 
 ### nv
 ```julia
-nv(g::Union{LightGraphs.DiGraph,LightGraphs.Graph})
+nv(g)
 ```
+
 The number of vertices in `g`.
 
 ### ne
 ```julia
-ne(g::Union{LightGraphs.DiGraph,LightGraphs.Graph})
+ne(g)
 ```
+
 The number of edges in `g`.
 
 ### has_edge
 ```julia
-has_edge(g::Union{LightGraphs.DiGraph,LightGraphs.Graph}, src::Int64, dst::Int64)
+has_edge(g::Union{LightGraphs.DiGraph,LightGraphs.Graph}, u::Int64, v::Int64)
 has_edge(g::LightGraphs.DiGraph, e::Pair{Int64,Int64})
 has_edge(g::LightGraphs.Graph, e::Pair{Int64,Int64})
 ```
-Return true if the graph `g` has an edge from `src` to `dst`.
+Return true if the graph `g` has an edge from `u` to `v`.
 
 ### has_vertex
 ```julia
@@ -52,15 +54,17 @@ Return true if `v` is a vertex of `g`.
 
 ### in_edges
 ```julia
-in_edges(g::Union{LightGraphs.DiGraph,LightGraphs.Graph}, v::Int64)
+in_edges(g, v)
 ```
-Return an Array of the edges in `g` that arrive at vertex `v`.
+
+Returns an Array of the edges in `g` that arrive at vertex `v`. `v=dst(e)` for each returned edge `e`.
 
 ### out_edges
 ```julia
-out_edges(g::Union{LightGraphs.DiGraph,LightGraphs.Graph}, v::Int64)
+out_edges(g, v)
 ```
-Return an Array of the edges in `g` that emanate from vertex `v`.
+
+Returns an Array of the edges in `g` that depart from vertex `v`. `v = src(e)` for each returned edge `e`.
 
 ### src
 ```julia

--- a/doc/build.jl
+++ b/doc/build.jl
@@ -289,6 +289,19 @@ computation:
 Stoer's simple minimum cut gets the minimum cut of an undirected graph.
 
 {{mincut}}
+
+## Multiroute Flow
+A multiroute flow of k routes (k-route flow) is a non-negative linear combination of k edge-disjoint paths. Intuitively, for a set of k edge-disjoint elementary paths with the same value v, after any attack/failure of k-1 edges, there still is a flow of value at least v.
+
+Formally, the multiroute context can be extented to a parametric non-integer number number of routes. The multiroute flow is then piecewise linear and can be characterized as a set of breaking points.
+
+LightGraphs.jl provides two algorithms for multiroute flow computation:
+
+* [Kishimoto algorithm](http://dx.doi.org/10.1109/ICCS.1992.255031) (k must be a fixed integer)
+* [Extended Multiroute Flow (EMRF) algorithm](http://dx.doi.org/10.1016/j.disopt.2016.05.002) (k can be a real number and/or a variable)
+
+{{multiroute_flow}}
+
 """
 
 @file "operators.md" """

--- a/doc/flowcut.md
+++ b/doc/flowcut.md
@@ -87,15 +87,17 @@ LightGraphs.jl provides two algorithms for multiroute flow computation:
 ### multiroute_flow
 ```julia
 multiroute_flow(flow_graph::LightGraphs.DiGraph, source::Int64, target::Int64)
-multiroute_flow{T<:Number}(flow_graph::LightGraphs.DiGraph, source::Int64, target::Int64, capacity_matrix::AbstractArray{T<:Number,2}, flow_algorithm::LightGraphs.AbstractFlowAlgorithm, mrf_algorithm::LightGraphs.KishimotoAlgorithm, routes::Int64)
-multiroute_flow{T<:Number,R<:Real}(flow_graph::LightGraphs.DiGraph, source::Int64, target::Int64, capacity_matrix::AbstractArray{T<:Number,2}, flow_algorithm::LightGraphs.AbstractFlowAlgorithm, mrf_algorithm::LightGraphs.ExtendedMultirouteFlowAlgorithm, routes::R<:Real)
-multiroute_flow{T<:Number,R<:Real}(breakingpoints::Array{Tuple{T<:Number,T<:Number,Int64},1}, routes::R<:Real)
-multiroute_flow{T<:Number,R<:Real}(breakingpoints::Array{Tuple{T<:Number,T<:Number,Int64},1}, routes::R<:Real, flow_algorithm::LightGraphs.AbstractFlowAlgorithm)
-multiroute_flow{T<:Number}(flow_graph::LightGraphs.DiGraph, source::Int64, target::Int64, capacity_matrix::AbstractArray{T<:Number,2})
+multiroute_flow{T<:Real}(flow_graph::LightGraphs.DiGraph, source::Int64, target::Int64, capacity_matrix::AbstractArray{T<:Real,2}, flow_algorithm::LightGraphs.AbstractFlowAlgorithm, mrf_algorithm::LightGraphs.KishimotoAlgorithm, routes::Int64)
+multiroute_flow{T<:Real,R<:Real}(flow_graph::LightGraphs.DiGraph, source::Int64, target::Int64, capacity_matrix::AbstractArray{T<:Real,2}, flow_algorithm::LightGraphs.AbstractFlowAlgorithm, mrf_algorithm::LightGraphs.ExtendedMultirouteFlowAlgorithm, routes::R<:Real)
+multiroute_flow{T<:Real,R<:Real}(breakingpoints::Array{Tuple{T<:Real,T<:Real,Int64},1}, routes::R<:Real)
+multiroute_flow{T1<:Real,R<:Real}(breakingpoints::Array{Tuple{T1<:Real,T1<:Real,Int64},1}, routes::R<:Real, flow_graph::LightGraphs.DiGraph, source::Int64, target::Int64)
+multiroute_flow{T1<:Real,T2<:Real,R<:Real}(breakingpoints::Array{Tuple{T1<:Real,T1<:Real,Int64},1}, routes::R<:Real, flow_graph::LightGraphs.DiGraph, source::Int64, target::Int64, capacity_matrix::AbstractArray{T2<:Real,2})
+multiroute_flow{T<:Real}(flow_graph::LightGraphs.DiGraph, source::Int64, target::Int64, capacity_matrix::AbstractArray{T<:Real,2})
 ```
-The generic multiroute_flow function will output two kinds of results:
+The generic multiroute_flow function will output three kinds of results:
 
   * When the number of routes is 0 or non-specified, the set of breaking points of the multiroute flow is returned.
+  * When the input is limited to a set of breaking points and a route value k, only the value of the k-route flow is returned
   * Otherwise, a tuple with 1) the maximum flow and 2) the flow matrix. When the max-flow subroutine is the Boykov-Kolmogorov algorithm, the associated mincut is returned as a third output.
 
 When the input is a network, it requires the following arguments:
@@ -103,16 +105,25 @@ When the input is a network, it requires the following arguments:
   * flow_graph::DiGraph                   # the input graph
   * source::Int                           # the source vertex
   * target::Int                           # the target vertex
-  * capacity_matrix::AbstractArray{T,2}   # edge flow capacities
+  * capacity_matrix::AbstractArray{T, 2}  # edge flow capacities with T<:Real
   * flow_algorithm::AbstractFlowAlgorithm # keyword argument for flow algorithm
   * mrf_algorithm::AbstractFlowAlgorithm  # keyword argument for multiroute flow algorithm
-  * routes::R<:Number                     # keyword argument for the number of routes
+  * routes::R<:Real                       # keyword argument for the number of routes
 
-When the input is the set of (breaking) points (the number of route is then a parameter), it requires the following arguments:
+When the input is only the set of (breaking) points and the number of route, it requires the following arguments:
 
-  * breakingpoints::Vector{Tuple{T,T,Int}},      # vector of breaking points
-  * routes::R<:Number,                           # keyword argument for routes
-  * flow_algorithm::AbstractFlowAlgorithm        # keyword argument for flow algorithm
+  * breakingpoints::Vector{Tuple{T, T, Int}},    # vector of breaking points
+  * routes::R<:Real,                             # number of routes
+
+When the input is the set of (breaking) points, the number of routes, and the network descriptors, it requires the following arguments:
+
+  * breakingpoints::Vector{Tuple{T1, T1, Int}} # vector of breaking points (T1<:Real)
+  * routes::R<:Real                            # number of routes
+  * flow_graph::DiGraph                        # the input graph
+  * source::Int                                # the source vertex
+  * target::Int                                # the target vertex
+  * capacity_matrix::AbstractArray{T2, 2}      # optional edge flow capacities (T2<:Real)
+  * flow_algorithm::AbstractFlowAlgorithm      # keyword argument for algorithm
 
 The function defaults to the Push-relabel (classical flow) and Kishimoto (multiroute) algorithms. Alternatively, the algorithms to be used can also be specified through  keyword arguments. A default capacity of 1 is assumed for each link if no capacity matrix is provided.
 
@@ -130,15 +141,15 @@ The mrf_algorithm keyword is inforced to Extended Multiroute Flow in the followi
 # Create a flow-graph and a capacity matrix
 flow_graph = DiGraph(8)
 flow_edges = [
-    (1,2,10),(1,3,5),(1,4,15),(2,3,4),(2,5,9),
-    (2,6,15),(3,4,4),(3,6,8),(4,7,16),(5,6,15),
-    (5,8,10),(6,7,15),(6,8,10),(7,3,6),(7,8,10)
+    (1, 2, 10), (1, 3, 5),  (1, 4, 15), (2, 3, 4),  (2, 5, 9),
+    (2, 6, 15), (3, 4, 4),  (3, 6, 8),  (4, 7, 16), (5, 6, 15),
+    (5, 8, 10), (6, 7, 15), (6, 8, 10), (7, 3, 6),  (7, 8, 10)
 ]
 capacity_matrix = zeros(Int, 8, 8)
 for e in flow_edges
     u, v, f = e
     add_edge!(flow_graph, u, v)
-    capacity_matrix[u,v] = f
+    capacity_matrix[u, v] = f
 end
 
 # Run default multiroute_flow with an integer number of routes = 2
@@ -150,10 +161,12 @@ f, F = multiroute_flow(flow_graph, 1, 8, capacity_matrix, routes = 1.5)
 # Run default multiroute_flow for all the breaking points values
 points = multiroute_flow(flow_graph, 1, 8, capacity_matrix)
 # Then run multiroute flow algorithm for any positive number of routes
-f, F = multiroute_flow(points, routes = 1.5)
+f, F = multiroute_flow(points, 1.5)
+f = multiroute_flow(points, 1.5, valueonly = true)
 
 # Run multiroute flow algorithm using Boykov-Kolmogorov algorithm as max_flow routine
-f, F, labels = multiroute_flow(flow_graph,1,8,capacity_matrix,algorithm=BoykovKolmogorovAlgorithm(),routes=2)
+f, F, labels = multiroute_flow(flow_graph, 1, 8, capacity_matrix,
+               algorithm = BoykovKolmogorovAlgorithm(), routes = 2)
 
 ```
 

--- a/doc/flowcut.md
+++ b/doc/flowcut.md
@@ -25,8 +25,9 @@ Generic maximum_flow function. Requires arguments:
   * target::Int                           # the target vertex
   * capacity_matrix::AbstractArray{T,2}   # edge flow capacities
   * algorithm::AbstractFlowAlgorithm      # keyword argument for algorithm
+  * restriction::T                        # keyword argument for a restriction
 
-The function defaults to the Push-relabel algorithm. Alternatively, the algorithm to be used can also be specified through a keyword argument. A default capacity of 1 is assumed for each link if no capacity matrix is provided.
+The function defaults to the Push-relabel algorithm. Alternatively, the algorithm to be used can also be specified through a keyword argument. A default capacity of 1 is assumed for each link if no capacity matrix is provided. If the restriction is bigger than 0, it is applied to capacity_matrix.
 
 All algorithms return a tuple with 1) the maximum flow and 2) the flow matrix. For the Boykov-Kolmogorov algorithm, the associated mincut is returned as a third output.
 
@@ -73,4 +74,86 @@ mincut(graph::Union{LightGraphs.DiGraph,LightGraphs.Graph})
 mincut{T}(graph::Union{LightGraphs.DiGraph,LightGraphs.Graph}, distmx::AbstractArray{T,2})
 ```
 Returns a tuple `(parity, bestcut)`, where `parity` is a vector of integer values that determines the partition in `g` (1 or 2) and `bestcut` is the weight of the cut that makes this partition. An optional `distmx` matrix may be specified; if omitted, edge distances are assumed to be 1.
+
+## Multiroute Flow
+A multiroute flow of k routes (k-route flow) is a non-negative linear combination of k edge-disjoint paths. Intuitively, for a set of k edge-disjoint elementary paths with the same value v, after any attack/failure of k-1 edges, there still is a flow of value at least v.
+
+Formally, the multiroute context can be extented to a parametric non-integer number number of routes. The multiroute flow is then piecewise linear and can be characterized as a set of breaking points.
+
+LightGraphs.jl provides two algorithms for multiroute flow computation:
+
+* [Kishimoto algorithm](http://dx.doi.org/10.1109/ICCS.1992.255031) (k must be a fixed integer)
+* [Extended Multiroute Flow (EMRF) algorithm](http://dx.doi.org/10.1016/j.disopt.2016.05.002) (k can be a real number and/or a variable)
+### multiroute_flow
+```julia
+multiroute_flow(flow_graph::LightGraphs.DiGraph, source::Int64, target::Int64)
+multiroute_flow{T<:Number}(flow_graph::LightGraphs.DiGraph, source::Int64, target::Int64, capacity_matrix::AbstractArray{T<:Number,2}, flow_algorithm::LightGraphs.AbstractFlowAlgorithm, mrf_algorithm::LightGraphs.KishimotoAlgorithm, routes::Int64)
+multiroute_flow{T<:Number,R<:Number}(flow_graph::LightGraphs.DiGraph, source::Int64, target::Int64, capacity_matrix::AbstractArray{T<:Number,2}, flow_algorithm::LightGraphs.AbstractFlowAlgorithm, mrf_algorithm::LightGraphs.ExtendedMultirouteFlowAlgorithm, routes::R<:Number)
+multiroute_flow{T<:Number,R<:Number}(breakingpoints::Array{Tuple{T<:Number,T<:Number,Int64},1}, routes::R<:Number)
+multiroute_flow{T<:Number,R<:Number}(breakingpoints::Array{Tuple{T<:Number,T<:Number,Int64},1}, routes::R<:Number, flow_algorithm::LightGraphs.AbstractFlowAlgorithm)
+multiroute_flow{T<:Number}(flow_graph::LightGraphs.DiGraph, source::Int64, target::Int64, capacity_matrix::AbstractArray{T<:Number,2})
+```
+The generic multiroute_flow function will output two kinds of results:
+
+  * When the number of routes is 0 or non-specified, the set of breaking points of the multiroute flow is returned.
+  * Otherwise, a tuple with 1) the maximum flow and 2) the flow matrix. When the max-flow subroutine is the Boykov-Kolmogorov algorithm, the associated mincut is returned as a third output.
+
+When the input is a network, it requires the following arguments:
+
+  * flow_graph::DiGraph                   # the input graph
+  * source::Int                           # the source vertex
+  * target::Int                           # the target vertex
+  * capacity_matrix::AbstractArray{T,2}   # edge flow capacities
+  * flow_algorithm::AbstractFlowAlgorithm # keyword argument for flow algorithm
+  * mrf_algorithm::AbstractFlowAlgorithm  # keyword argument for multiroute flow algorithm
+  * routes::R<:Number                     # keyword argument for the number of routes
+
+When the input is the set of (breaking) points (the number of route is then a parameter), it requires the following arguments:
+
+  * breakingpoints::Vector{Tuple{T,T,Int}},      # vector of breaking points
+  * routes::R<:Number,                           # keyword argument for routes
+  * flow_algorithm::AbstractFlowAlgorithm        # keyword argument for flow algorithm
+
+The function defaults to the Push-relabel (classical flow) and Kishimoto (multiroute) algorithms. Alternatively, the algorithms to be used can also be specified through  keyword arguments. A default capacity of 1 is assumed for each link if no capacity matrix is provided.
+
+The mrf_algorithm keyword is inforced to Extended Multiroute Flow in the following cases:
+
+  * The number of routes is non-integer
+  * The number of routes is 0 or non-specified
+
+### Usage Example :
+
+(please consult the  max_flow section for options about flow_algorithm and capacity_matrix)
+
+```julia
+
+# Create a flow-graph and a capacity matrix
+flow_graph = DiGraph(8)
+flow_edges = [
+    (1,2,10),(1,3,5),(1,4,15),(2,3,4),(2,5,9),
+    (2,6,15),(3,4,4),(3,6,8),(4,7,16),(5,6,15),
+    (5,8,10),(6,7,15),(6,8,10),(7,3,6),(7,8,10)
+]
+capacity_matrix = zeros(Int, 8, 8)
+for e in flow_edges
+    u, v, f = e
+    add_edge!(flow_graph, u, v)
+    capacity_matrix[u,v] = f
+end
+
+# Run default multiroute_flow with an integer number of routes = 2
+f, F = multiroute_flow(flow_graph, 1, 8, capacity_matrix, routes = 2)
+
+# Run default multiroute_flow with a noninteger number of routes = 1.5
+f, F = multiroute_flow(flow_graph, 1, 8, capacity_matrix, routes = 1.5)
+
+# Run default multiroute_flow for all the breaking points values
+points = multiroute_flow(flow_graph, 1, 8, capacity_matrix)
+# Then run multiroute flow algorithm for any positive number of routes
+f, F = multiroute_flow(points, routes = 1.5)
+
+# Run multiroute flow algorithm using Boykov-Kolmogorov algorithm as max_flow routine
+f, F, labels = multiroute_flow(flow_graph,1,8,capacity_matrix,algorithm=BoykovKolmogorovAlgorithm(),routes=2)
+
+```
 

--- a/doc/flowcut.md
+++ b/doc/flowcut.md
@@ -88,9 +88,9 @@ LightGraphs.jl provides two algorithms for multiroute flow computation:
 ```julia
 multiroute_flow(flow_graph::LightGraphs.DiGraph, source::Int64, target::Int64)
 multiroute_flow{T<:Number}(flow_graph::LightGraphs.DiGraph, source::Int64, target::Int64, capacity_matrix::AbstractArray{T<:Number,2}, flow_algorithm::LightGraphs.AbstractFlowAlgorithm, mrf_algorithm::LightGraphs.KishimotoAlgorithm, routes::Int64)
-multiroute_flow{T<:Number,R<:Number}(flow_graph::LightGraphs.DiGraph, source::Int64, target::Int64, capacity_matrix::AbstractArray{T<:Number,2}, flow_algorithm::LightGraphs.AbstractFlowAlgorithm, mrf_algorithm::LightGraphs.ExtendedMultirouteFlowAlgorithm, routes::R<:Number)
-multiroute_flow{T<:Number,R<:Number}(breakingpoints::Array{Tuple{T<:Number,T<:Number,Int64},1}, routes::R<:Number)
-multiroute_flow{T<:Number,R<:Number}(breakingpoints::Array{Tuple{T<:Number,T<:Number,Int64},1}, routes::R<:Number, flow_algorithm::LightGraphs.AbstractFlowAlgorithm)
+multiroute_flow{T<:Number,R<:Real}(flow_graph::LightGraphs.DiGraph, source::Int64, target::Int64, capacity_matrix::AbstractArray{T<:Number,2}, flow_algorithm::LightGraphs.AbstractFlowAlgorithm, mrf_algorithm::LightGraphs.ExtendedMultirouteFlowAlgorithm, routes::R<:Real)
+multiroute_flow{T<:Number,R<:Real}(breakingpoints::Array{Tuple{T<:Number,T<:Number,Int64},1}, routes::R<:Real)
+multiroute_flow{T<:Number,R<:Real}(breakingpoints::Array{Tuple{T<:Number,T<:Number,Int64},1}, routes::R<:Real, flow_algorithm::LightGraphs.AbstractFlowAlgorithm)
 multiroute_flow{T<:Number}(flow_graph::LightGraphs.DiGraph, source::Int64, target::Int64, capacity_matrix::AbstractArray{T<:Number,2})
 ```
 The generic multiroute_flow function will output two kinds of results:

--- a/doc/linalg.md
+++ b/doc/linalg.md
@@ -11,7 +11,7 @@ adjacency_matrix(g::Union{LightGraphs.DiGraph,LightGraphs.Graph})
 adjacency_matrix(g::Union{LightGraphs.DiGraph,LightGraphs.Graph}, dir::Symbol)
 adjacency_matrix(g::Union{LightGraphs.DiGraph,LightGraphs.Graph}, dir::Symbol, T::DataType)
 ```
-Returns a sparse boolean adjacency matrix for a graph, indexed by `[src, dst]` vertices. `true` values indicate an edge between `src` and `dst`. Users may specify a direction (`:in`, `:out`, or `:both` are currently supported; `:out` is default for both directed and undirected graphs) and a data type for the matrix (defaults to `Int`).
+Returns a sparse boolean adjacency matrix for a graph, indexed by `[u, v]` vertices. `true` values indicate an edge between `u` and `v`. Users may specify a direction (`:in`, `:out`, or `:both` are currently supported; `:out` is default for both directed and undirected graphs) and a data type for the matrix (defaults to `Int`).
 
 Note: This function is optimized for speed.
 
@@ -36,7 +36,7 @@ laplacian_matrix(g::LightGraphs.DiGraph)
 laplacian_matrix(g::LightGraphs.DiGraph, dir::Symbol)
 laplacian_matrix(g::LightGraphs.DiGraph, dir::Symbol, T::DataType)
 ```
-Returns a sparse [Laplacian matrix](https://en.wikipedia.org/wiki/Laplacian_matrix) for a graph `g`, indexed by `[src, dst]` vertices. For undirected graphs, `dir` defaults to `:out`; for directed graphs, `dir` defaults to `:both`. `T` defaults to `Int` for both graph types.
+Returns a sparse [Laplacian matrix](https://en.wikipedia.org/wiki/Laplacian_matrix) for a graph `g`, indexed by `[u, v]` vertices. For undirected graphs, `dir` defaults to `:out`; for directed graphs, `dir` defaults to `:both`. `T` defaults to `Int` for both graph types.
 
 ### laplacian_spectrum
 ```julia

--- a/src/LightGraphs.jl
+++ b/src/LightGraphs.jl
@@ -7,7 +7,7 @@ using Base.Collections
 using LightXML
 using ParserCombinator: Parsers.DOT, Parsers.GML
 
-import Base: write, ==, <, *, isless, issubset, complement, union, intersect,
+import Base: write, ==, <, *, ≈, isless, issubset, complement, union, intersect,
             reverse, reverse!, blkdiag, getindex, setindex!, show, print, copy, in,
             sum, size, sparse, eltype, length, ndims, issym, transpose,
             ctranspose, join, start, next, done, eltype, get
@@ -76,9 +76,10 @@ a_star,
 # persistence
 # readgraph, readgraphml, readgml, writegraphml, writegexf, readdot,
 load, save,
+
 # flow
 maximum_flow, EdmondsKarpAlgorithm, DinicAlgorithm, BoykovKolmogorovAlgorithm, PushRelabelAlgorithm,
-multiroute_flow, KishimotoAlgorithm,
+multiroute_flow, KishimotoAlgorithm, ExtendedMultirouteFlowAlgorithm,
 
 # randgraphs
 erdos_renyi, watts_strogatz, random_regular_graph, random_regular_digraph, random_configuration_model,
@@ -156,6 +157,8 @@ include("core.jl")
             include("flow/boykov_kolmogorov.jl")
             include("flow/push_relabel.jl")
             include("flow/multiroute_flow.jl")
+                include("flow/kishimoto.jl")
+                include("flow/ext_multiroute_flow.jl")
         include("utils.jl")
 
 end # module

--- a/src/LightGraphs.jl
+++ b/src/LightGraphs.jl
@@ -78,6 +78,7 @@ a_star,
 load, save,
 # flow
 maximum_flow, EdmondsKarpAlgorithm, DinicAlgorithm, BoykovKolmogorovAlgorithm, PushRelabelAlgorithm,
+multiroute_flow, KishimotoAlgorithm,
 
 # randgraphs
 erdos_renyi, watts_strogatz, random_regular_graph, random_regular_digraph, random_configuration_model,
@@ -154,6 +155,7 @@ include("core.jl")
             include("flow/dinic.jl")
             include("flow/boykov_kolmogorov.jl")
             include("flow/push_relabel.jl")
+            include("flow/multiroute_flow.jl")
         include("utils.jl")
 
 end # module

--- a/src/flow/ext_multiroute_flow.jl
+++ b/src/flow/ext_multiroute_flow.jl
@@ -1,0 +1,230 @@
+"""
+Computes the maximum multiroute flow (for any real number of routes)
+between the source and target vertexes in a flow graph using the
+[Extended Multiroute Flow algorithm](http://dx.doi.org/10.1016/j.disopt.2016.05.002).
+If a number of routes is given, returns the value of the multiroute flow as
+well as the final flow matrix, along with a multiroute cut if
+Boykov-Kolmogorov max-flow algorithm is used as a subroutine.
+Otherwise, it returns the vector of breaking points of the parametric
+multiroute flow function.
+Use a default capacity of 1 when the capacity matrix isn\'t specified.
+Requires arguments:
+- flow_graph::DiGraph                    # the input graph
+- source::Int                            # the source vertex
+- target::Int                            # the target vertex
+- capacity_matrix::AbstractArray{T,2}    # edge flow capacities
+- flow_algorithm::AbstractFlowAlgorithm, # keyword argument for algorithm
+- routes::Int                            # keyword argument for routes
+"""
+
+# EMRF (Extended Multiroute Flow) algorithms
+function emrf{T<:AbstractFloat,R<:Number}(
+  flow_graph::DiGraph,                   # the input graph
+  source::Int,                           # the source vertex
+  target::Int,                           # the target vertex
+  capacity_matrix::AbstractArray{T,2},   # edge flow capacities
+  flow_algorithm::AbstractFlowAlgorithm, # keyword argument for algorithm
+  routes::R = 0
+  )
+  breakingpoints = breakingPoints(flow_graph,source,target,capacity_matrix)
+  if routes > zero(R)
+    x,f = intersection(breakingpoints,routes)
+    return maximum_flow(flow_graph,source,target,capacity_matrix,
+      algorithm=flow_algorithm,restriction=x)
+  end
+  return breakingpoints
+end
+
+"""
+Output a set of (point,slope) that compose the restricted max-flow function.
+One point by possible slope is enough (hence O(λ*max_flow) complexity).
+Requires arguments:
+- flow_graph::DiGraph                    # the input graph
+- source::Int                            # the source vertex
+- target::Int                            # the target vertex
+- capacity_matrix::AbstractArray{T,2}    # edge flow capacities
+"""
+
+function auxiliaryPoints{T<:AbstractFloat}(
+  flow_graph::DiGraph,                   # the input graph
+  source::Int,                           # the source vertex
+  target::Int,                           # the target vertex
+  capacity_matrix::AbstractArray{T,2}    # edge flow capacities
+  )
+  # Problem descriptors
+  λ = maximum_flow(flow_graph,source,target)[1] # Connectivity
+  n = nv(flow_graph) # number of nodes
+  r1, r2 = minmaxCapacity(capacity_matrix) # restriction left (1) and right (2)
+  auxpoints = fill((0.,0.),λ+1)
+
+  # Initialisation of left side (1)
+  f1, F1, cut1 = maximum_flow(flow_graph,source,target,capacity_matrix,
+                        algorithm=BoykovKolmogorovAlgorithm(),restriction=r1)
+  s1 = slope(flow_graph,capacity_matrix,cut1,r1) # left slope
+  auxpoints[λ + 1 - s1] = (r1,f1) # Add left initial auxiliary point
+
+  # Initialisation of right side (2)
+  f2, F2, cut2 = maximum_flow(flow_graph,source,target,capacity_matrix,
+                        algorithm=BoykovKolmogorovAlgorithm(),restriction=r2)
+  s2 = slope(flow_graph,capacity_matrix,cut2,r2) # right slope
+  auxpoints[λ + 1 - s2] = (r2,f2) # Add right initial auxiliary point
+
+  # Loop if the slopes are distinct by at least 2
+  if s1 > s2 + 1
+    queue = [((f1,s1,r1),(f2,s2,r2))]
+
+    while !isempty(queue)
+      # Computes an intersection (middle) with a new associated slope
+      (f1,s1,r1),(f2,s2,r2) = pop!(queue)
+      r, expectedflow = intersection(r1,f1,s1,r2,f2,s2)
+      f, F, cut = maximum_flow(flow_graph,source,target,capacity_matrix,
+                        algorithm=BoykovKolmogorovAlgorithm(),restriction=r)
+      s = slope(flow_graph,capacity_matrix,max(cut,1),r) # current slope
+      auxpoints[λ + 1 - s] = (r,f)
+      # If the flow at the intersection (middle) is as expected
+      if expectedflow ≈ f
+        for k in (s1 - 1):(s2 + 1)
+          auxpoints[λ + 1 - k] = (r, f) # add all points between left and right
+        end
+      else
+        # if the slope difference between (middle) and left is at least 2
+        # push (left),(middle)
+        if s1 > s + 1 && (r2,f2) ≉ (r,f) # if the slope between intersection
+          q = (f1,s1,r1),(f,s,r)
+          push!(queue,q)
+        end
+        # if the slope difference between (middle) and right is at least 2
+        # push (middle),(right)
+        if s > s2 + 1 && (r1,f1) ≉ (r,f)
+          q = (f,s,r),(f2,s2,r2)
+          push!(queue,q)
+        end
+      end
+    end
+  end
+  return auxpoints
+end
+
+"""
+Calculates the breaking of the restricted max-flow from a set of auxiliary points.
+Requires arguments:
+- flow_graph::DiGraph                    # the input graph
+- source::Int                            # the source vertex
+- target::Int                            # the target vertex
+- capacity_matrix::AbstractArray{T,2}    # edge flow capacities
+"""
+
+function breakingPoints{T<:AbstractFloat}(
+  flow_graph::DiGraph,                   # the input graph
+  source::Int,                           # the source vertex
+  target::Int,                           # the target vertex
+  capacity_matrix::AbstractArray{T,2}    # edge flow capacities
+  )
+  auxpoints = auxiliaryPoints(flow_graph,source,target,capacity_matrix)
+  λ = length(auxpoints) - 1
+  left_index = 1
+  breakingpoints = Vector{Tuple{T,T,Int}}()
+
+  for (id,point) in enumerate(auxpoints)
+    if id == 1
+      push!(breakingpoints,(0.,0.,λ))
+    else
+      pleft = breakingpoints[left_index]
+      if point[1] != 0
+        x, y = intersection(pleft[1],pleft[2],pleft[3],point[1],point[2], λ + 1 - id)
+        push!(breakingpoints,(x, y, λ + 1 - id))
+        left_index += 1
+      else
+        push!(breakingpoints,(-1.,-1.,λ + 1 - id))
+      end
+    end
+  end
+  return breakingpoints
+end
+
+"""
+Function to get the nonzero min and max function of a Matrix
+Requires argument:
+- capacity_matrix::AbstractArray{T,2}    # edge flow capacities
+"""
+
+# Function to get the nonzero min and max function of a Matrix
+function minmaxCapacity{T<:AbstractFloat}(capacity_matrix::AbstractArray{T,2})
+  cmin, cmax = typemax(T), typemin(T)
+  for c in capacity_matrix
+    if c > zero(T)
+      cmin = min(cmin,c)
+    end
+    cmax = max(cmax,c)
+  end
+  return cmin, cmax
+end
+
+"""
+Function to get the slope of the restricted flow. The slope is initialized at 0
+and is incremented for each non saturated edge in the restricted min-cut.
+Requires argument:
+- capacity_matrix::AbstractArray{T,2}    # edge flow capacities
+"""
+# Function to get the slope of the restricted flow
+function slope{T<:AbstractFloat}(
+  flow_graph::DiGraph,                   # the input graph
+  capacity_matrix::AbstractArray{T,2},   # edge flow capacities
+  cut::Vector{Int},                      # cut information for vertices
+  restriction::T                         # value of the restriction
+  )
+  slope = 0
+  for e in edges(flow_graph)
+    if cut[dst(e)] - cut[src(e)] > 0 &&
+      capacity_matrix[src(e),dst(e)] > restriction
+        slope += 1
+    end
+  end
+  return slope
+end
+
+"""
+Computes the intersection bewtween:
+1) Two lines
+2) A set of segment and a linear function of slope k passing by the origin.
+Requires argument:
+1) - x1,y1,a1,x2,y2,a2::T<:AbstractFloat # Coordinates/slopes
+2) - points::Vector{Tuple{T,T,Int}}      # vector of points with T<:AbstractFloat
+   - k::R<:Number                        # number of route (slope of the line)
+"""
+
+# Compute the (expected) intersection of two lines
+function intersection(x1,y1,a1,x2,y2,a2)
+  b1 = y1 - a1 * x1
+  b2 = y2 - a2 * x2
+  x = (b2 - b1)/(a1 - a2)
+  y = a1 * x + b1
+  return (x,y)
+end
+# Compute the intection between a set of segment and a line of slope k passing by the origin
+function intersection{T<:AbstractFloat,R<:Number}(
+  points::Vector{Tuple{T,T,Int}},
+  k::R
+  )
+  λ = length(points) - 1
+  if k == λ
+    return points[2]
+  end
+  for (id,p) in enumerate(points[2:end-1])
+    x,y = intersection(p[1],p[2],p[3],0,0,k)
+    if p[1] ≤ x ≤ points[id][1]
+      return x,y
+    end
+  end
+  p = points[end]
+  return intersection(p[1],p[2],p[3],0,0,k)
+end
+
+"""
+Redefinition of ≈ (isapprox) for a pair of Number
+Requires argument:
+- capacity_matrix::AbstractArray{T,2}    # edge flow capacities
+"""
+function ≈{T<:Number}(a::Tuple{T,T},b::Tuple{T,T})
+  return a[1] ≈ b[1] && a[2] ≈ b[2]
+end

--- a/src/flow/kishimoto.jl
+++ b/src/flow/kishimoto.jl
@@ -13,15 +13,15 @@ function kishimoto{T<:AbstractFloat}(
          capacity_matrix, algorithm = flow_algorithm)
   restriction = flow / routes
   flow, F, labels = maximum_flow(flow_graph, source, target, capacity_matrix,
-         algorithm = flow_algorithm, restriction = restriction)
+                       algorithm = flow_algorithm, restriction = restriction)
 
-  # Loop
+  # Loop condition : approximatively not equal is enforced by floating precision
   i = 1
-  while flow ≉ routes * restriction && flow < routes * restriction
+  while flow < routes * restriction && flow ≉ routes * restriction
     restriction = (flow - i * restriction) / (routes - i)
-    i = i + 1
+    i += 1
     flow, F, labels = maximum_flow(flow_graph, source, target, capacity_matrix,
-              algorithm = flow_algorithm, restriction = restriction)
+                         algorithm = flow_algorithm, restriction = restriction)
   end
 
   # End
@@ -61,9 +61,9 @@ function kishimoto{T<:AbstractFloat}(
   flow, F = maximum_flow(flow_graph, source, target, capacity_matrix,
           algorithm = flow_algorithm, restriction = restriction)
 
-  # Loop
+  # Loop condition : approximatively not equal is enforced by floating precision
   i = 1
-  while flow ≉ routes * restriction && flow < routes * restriction
+  while flow < routes * restriction && flow ≉ routes * restriction
     restriction = (flow - i * restriction) / (routes - i)
     i = i + 1
     flow, F = maximum_flow(flow_graph, source, target, capacity_matrix,

--- a/src/flow/kishimoto.jl
+++ b/src/flow/kishimoto.jl
@@ -1,3 +1,34 @@
+# Method when using Boykov-Kolmogorov as a subroutine
+# Kishimoto algorithm
+function kishimoto{T<:AbstractFloat}(
+  flow_graph::DiGraph,                       # the input graph
+  source::Int,                               # the source vertex
+  target::Int,                               # the target vertex
+  capacity_matrix::AbstractArray{T,2},       # edge flow capacities
+  flow_algorithm::BoykovKolmogorovAlgorithm, # keyword argument for algorithm
+  routes::Int                                # keyword argument for routes
+  )
+  # Initialisation
+  flow, F, labels = maximum_flow(flow_graph, source, target,
+         capacity_matrix, algorithm = flow_algorithm)
+  restriction = flow / routes
+  flow, F, labels = maximum_flow(flow_graph, source, target, capacity_matrix,
+         algorithm = flow_algorithm, restriction = restriction)
+
+  # Loop
+  i = 1
+  while flow ≉ routes * restriction && flow < routes * restriction
+    restriction = (flow - i * restriction) / (routes - i)
+    i = i + 1
+    flow, F, labels = maximum_flow(flow_graph, source, target, capacity_matrix,
+              algorithm = flow_algorithm, restriction = restriction)
+  end
+
+  # End
+  return flow, F, labels
+end
+
+
 """
 Computes the maximum multiroute flow (for an integer number of routes)
 between the source and target vertexes in a flow graph using the
@@ -14,7 +45,6 @@ Requires arguments:
 - routes::Int                            # keyword argument for routes
 """
 
-# Kishimoto algorithm
 function kishimoto{T<:AbstractFloat}(
   flow_graph::DiGraph,                   # the input graph
   source::Int,                           # the source vertex
@@ -23,45 +53,23 @@ function kishimoto{T<:AbstractFloat}(
   flow_algorithm::AbstractFlowAlgorithm, # keyword argument for algorithm
   routes::Int                            # keyword argument for routes
   )
-  if flow_algorithm ≠ BoykovKolmogorovAlgorithm()
-    # Initialisation 1
-    flow, F = maximum_flow(flow_graph, source, target,
-           capacity_matrix, algorithm = flow_algorithm)
-    restriction = flow / routes
+  # Initialisation
+  flow, F = maximum_flow(flow_graph, source, target,
+         capacity_matrix, algorithm = flow_algorithm)
+  restriction = flow / routes
 
+  flow, F = maximum_flow(flow_graph, source, target, capacity_matrix,
+          algorithm = flow_algorithm, restriction = restriction)
+
+  # Loop
+  i = 1
+  while flow ≉ routes * restriction && flow < routes * restriction
+    restriction = (flow - i * restriction) / (routes - i)
+    i = i + 1
     flow, F = maximum_flow(flow_graph, source, target, capacity_matrix,
-            algorithm = flow_algorithm, restriction = restriction)
-
-    # Loop 1
-    i = 1
-    while flow ≉ routes * restriction && flow < routes * restriction
-      restriction = (flow - i * restriction) / (routes - i)
-      i = i + 1
-      flow, F = maximum_flow(flow_graph, source, target, capacity_matrix,
-                algorithm = flow_algorithm, restriction = restriction)
-    end
-
-    # End 1
-    return flow, F
-  else
-    # Initialisation 2
-    flow, F, labels = maximum_flow(flow_graph, source, target,
-           capacity_matrix, algorithm = flow_algorithm)
-    restriction = flow / routes
-
-    flow, F, labels = maximum_flow(flow_graph, source, target, capacity_matrix,
-            algorithm = flow_algorithm, restriction = restriction)
-
-    # Loop 2
-    i = 1
-    while flow ≉ routes * restriction && flow < routes * restriction
-      restriction = (flow - i * restriction) / (routes - i)
-      i = i + 1
-      flow, F, labels = maximum_flow(flow_graph, source, target, capacity_matrix,
-                algorithm = flow_algorithm, restriction = restriction)
-    end
-
-    # End 2
-    return flow, F, labels
+              algorithm = flow_algorithm, restriction = restriction)
   end
+
+  # End
+  return flow, F
 end

--- a/src/flow/kishimoto.jl
+++ b/src/flow/kishimoto.jl
@@ -4,7 +4,7 @@ function kishimoto{T<:AbstractFloat}(
   flow_graph::DiGraph,                       # the input graph
   source::Int,                               # the source vertex
   target::Int,                               # the target vertex
-  capacity_matrix::AbstractArray{T,2},       # edge flow capacities
+  capacity_matrix::AbstractArray{T, 2},      # edge flow capacities
   flow_algorithm::BoykovKolmogorovAlgorithm, # keyword argument for algorithm
   routes::Int                                # keyword argument for routes
   )
@@ -40,7 +40,7 @@ Requires arguments:
 - flow_graph::DiGraph                    # the input graph
 - source::Int                            # the source vertex
 - target::Int                            # the target vertex
-- capacity_matrix::AbstractArray{T,2}    # edge flow capacities
+- capacity_matrix::AbstractArray{T, 2}   # edge flow capacities
 - flow_algorithm::AbstractFlowAlgorithm, # keyword argument for algorithm
 - routes::Int                            # keyword argument for routes
 """
@@ -49,7 +49,7 @@ function kishimoto{T<:AbstractFloat}(
   flow_graph::DiGraph,                   # the input graph
   source::Int,                           # the source vertex
   target::Int,                           # the target vertex
-  capacity_matrix::AbstractArray{T,2},   # edge flow capacities
+  capacity_matrix::AbstractArray{T, 2},  # edge flow capacities
   flow_algorithm::AbstractFlowAlgorithm, # keyword argument for algorithm
   routes::Int                            # keyword argument for routes
   )
@@ -65,7 +65,7 @@ function kishimoto{T<:AbstractFloat}(
   i = 1
   while flow < routes * restriction && flow ≉ routes * restriction
     restriction = (flow - i * restriction) / (routes - i)
-    i = i + 1
+    i += 1
     flow, F = maximum_flow(flow_graph, source, target, capacity_matrix,
               algorithm = flow_algorithm, restriction = restriction)
   end

--- a/src/flow/kishimoto.jl
+++ b/src/flow/kishimoto.jl
@@ -1,0 +1,67 @@
+"""
+Computes the maximum multiroute flow (for an integer number of routes)
+between the source and target vertexes in a flow graph using the
+[Kishimoto algorithm](http://dx.doi.org/10.1109/ICCS.1992.255031).
+Returns the value of the multiroute flow as well as the final flow matrix,
+along with a multiroute cut if Boykov-Kolmogorov is used as a subroutine.
+Use a default capacity of 1 when the capacity matrix isn\'t specified.
+Requires arguments:
+- flow_graph::DiGraph                    # the input graph
+- source::Int                            # the source vertex
+- target::Int                            # the target vertex
+- capacity_matrix::AbstractArray{T,2}    # edge flow capacities
+- flow_algorithm::AbstractFlowAlgorithm, # keyword argument for algorithm
+- routes::Int                            # keyword argument for routes
+"""
+
+# Kishimoto algorithm
+function kishimoto{T<:AbstractFloat}(
+  flow_graph::DiGraph,                   # the input graph
+  source::Int,                           # the source vertex
+  target::Int,                           # the target vertex
+  capacity_matrix::AbstractArray{T,2},   # edge flow capacities
+  flow_algorithm::AbstractFlowAlgorithm, # keyword argument for algorithm
+  routes::Int                            # keyword argument for routes
+  )
+  if flow_algorithm ≠ BoykovKolmogorovAlgorithm()
+    # Initialisation 1
+    flow, F = maximum_flow(flow_graph, source, target,
+           capacity_matrix, algorithm = flow_algorithm)
+    restriction = flow / routes
+
+    flow, F = maximum_flow(flow_graph, source, target, capacity_matrix,
+            algorithm = flow_algorithm, restriction = restriction)
+
+    # Loop 1
+    i = 1
+    while flow ≉ routes * restriction && flow < routes * restriction
+      restriction = (flow - i * restriction) / (routes - i)
+      i = i + 1
+      flow, F = maximum_flow(flow_graph, source, target, capacity_matrix,
+                algorithm = flow_algorithm, restriction = restriction)
+    end
+
+    # End 1
+    return flow, F
+  else
+    # Initialisation 2
+    flow, F, labels = maximum_flow(flow_graph, source, target,
+           capacity_matrix, algorithm = flow_algorithm)
+    restriction = flow / routes
+
+    flow, F, labels = maximum_flow(flow_graph, source, target, capacity_matrix,
+            algorithm = flow_algorithm, restriction = restriction)
+
+    # Loop 2
+    i = 1
+    while flow ≉ routes * restriction && flow < routes * restriction
+      restriction = (flow - i * restriction) / (routes - i)
+      i = i + 1
+      flow, F, labels = maximum_flow(flow_graph, source, target, capacity_matrix,
+                algorithm = flow_algorithm, restriction = restriction)
+    end
+
+    # End 2
+    return flow, F, labels
+  end
+end

--- a/src/flow/maximum_flow.jl
+++ b/src/flow/maximum_flow.jl
@@ -134,7 +134,7 @@ Generic maximum_flow function. Requires arguments:
 - source::Int                           # the source vertex
 - target::Int                           # the target vertex
 - capacity_matrix::AbstractArray{T,2}   # edge flow capacities
-- algorithm::AbstractFlowAlgorithm      # keyword argument for algorithm,
+- algorithm::AbstractFlowAlgorithm      # keyword argument for algorithm
 - restriction::T                        # keyword argument for a restriction
 
 The function defaults to the Push-relabel algorithm. Alternatively, the algorithm

--- a/src/flow/maximum_flow.jl
+++ b/src/flow/maximum_flow.jl
@@ -140,11 +140,7 @@ Generic maximum_flow function. Requires arguments:
 The function defaults to the Push-relabel algorithm. Alternatively, the algorithm
 to be used can also be specified through a keyword argument. A default capacity of 1
 is assumed for each link if no capacity matrix is provided.
-<<<<<<< HEAD
 If the restriction is bigger than 0, it is applied to capacity_matrix.
-=======
-If the restriction is bigger than 0, it is apply to capacity_matrix.
->>>>>>> e6632ac... Compressed the restricted max-flow into classical max-flow
 
 All algorithms return a tuple with 1) the maximum flow and 2) the flow matrix.
 For the Boykov-Kolmogorov algorithm, the associated mincut is returned as a third output.

--- a/src/flow/multiroute_flow.jl
+++ b/src/flow/multiroute_flow.jl
@@ -1,0 +1,87 @@
+"""
+Abstract type that allows users to pass in their preferred Algorithm
+"""
+abstract AbstractMultirouteFlowAlgorithm
+
+"""
+Forces the multiroute_flow function to use the Kishimoto algorithm.
+"""
+type KishimotoAlgorithm <: AbstractMultirouteFlowAlgorithm
+end
+
+"""
+Forces the multiroute_flow function to use the Extended Multiroute Flow algorithm.
+"""
+type ExtendedMultirouteFlowAlgorithm <: AbstractFlowAlgorithm
+end
+
+# Method for Kishimoto algorithm
+
+function multiroute_flow{T<:Number}(
+  flow_graph::DiGraph,                   # the input graph
+  source::Int,                           # the source vertex
+  target::Int,                           # the target vertex
+  capacity_matrix::AbstractArray{T,2},   # edge flow capacities
+  flow_algorithm::AbstractFlowAlgorithm, # keyword argument for algorithm
+  mrf_algorithm::KishimotoAlgorithm,     # keyword argument for algorithm
+  routes::Int                            # keyword argument for routes
+  )
+  return kishimoto(flow_graph, source, target, capacity_matrix, flow_algorithm, routes)
+end
+
+function multiroute_flow{T<:Number}(
+  flow_graph::DiGraph,                   # the input graph
+  source::Int,                           # the source vertex
+  target::Int,                           # the target vertex
+  capacity_matrix::AbstractArray{T,2} =  # edge flow capacities
+    DefaultCapacity(flow_graph);
+  flow_algorithm::AbstractFlowAlgorithm  =    # keyword argument for algorithm
+    PushRelabelAlgorithm(),
+  mrf_algorithm::AbstractMultirouteFlowAlgorithm  =    # keyword argument for algorithm
+    KishimotoAlgorithm(),
+  routes::Int = 1               # keyword argument for number of routes
+  )
+  if routes == 1 # a flow with a set of 1-disjoint path is a classical max-flow
+    return maximum_flow(flow_graph, source, target, capacity_matrix, flow_algorithm)
+  end
+  if routes > maximum_flow(flow_graph,source,target)[1]
+    n = nv(flow_graph)
+    return 0, zeros(T, n, n)
+  end
+  return multiroute_flow(flow_graph, source, target, capacity_matrix, flow_algorithm, mrf_algorithm, routes)
+end
+
+# Kishimoto algorithm
+function kishimoto{T<:Number}(
+  flow_graph::DiGraph,                   # the input graph
+  source::Int,                           # the source vertex
+  target::Int,                           # the target vertex
+  capacity_matrix::AbstractArray{T,2},   # edge flow capacities
+  flow_algorithm::AbstractFlowAlgorithm, # keyword argument for algorithm
+  routes::Int                            # keyword argument for routes
+  )
+  # Capacities need to be Floats
+  if !(T<:AbstractFloat)
+    capacity_matrix = convert(AbstractArray{Float64,2}, capacity_matrix)
+  end
+
+  # Initialisation
+  flow, F = maximum_flow(flow_graph, source, target,
+         capacity_matrix, algorithm = flow_algorithm)
+  restriction = flow / routes
+
+  flow, F = maximum_flow(flow_graph, source, target, capacity_matrix,
+            algorithm = flow_algorithm, restriction = restriction)
+
+  # Loop
+  i = 1
+  while flow ≉ routes * restriction && flow < routes * restriction
+    restriction = (flow - i * restriction) / (routes - i)
+    i = i + 1
+    flow, F = maximum_flow(flow_graph, source, target, capacity_matrix,
+              algorithm = flow_algorithm, restriction = restriction)
+  end
+
+  # End
+  return flow, F
+end

--- a/src/flow/multiroute_flow.jl
+++ b/src/flow/multiroute_flow.jl
@@ -15,6 +15,25 @@ Forces the multiroute_flow function to use the Extended Multiroute Flow algorith
 type ExtendedMultirouteFlowAlgorithm <: AbstractMultirouteFlowAlgorithm
 end
 
+# Methods when the number of routes is more than the connectivity
+# 1) When using Boykov-Kolmogorov as a flow subroutine
+# 2) Other flow algorithm
+function multiroute_flow{T<:Number}(
+  capacity_matrix::AbstractArray{T,2},      # edge flow capacities
+  flow_algorithm::BoykovKolmogorovAlgorithm # keyword argument for algorithm
+  )
+  n = size(capacity_matrix,1)
+  return zero(T), zeros(T,n,n), zeros(T,n)
+end
+# 2) Other flow algorithm
+function multiroute_flow{T<:Number}(
+  capacity_matrix::AbstractArray{T,2},      # edge flow capacities
+  flow_algorithm::AbstractFlowAlgorithm     # keyword argument for algorithm
+  )
+  n = size(capacity_matrix,1)
+  return zero(T), zeros(T,n,n)
+end
+
 # Method for Kishimoto algorithm
 function multiroute_flow{T<:Number}(
   flow_graph::DiGraph,                   # the input graph
@@ -129,11 +148,7 @@ function multiroute_flow{T<:Number,R<:Number}(
   end
   if routes > maximum_flow(flow_graph,source,target,        # routes > λ → f = 0
     DefaultCapacity(flow_graph),algorithm=flow_algorithm)[1]
-    n = nv(flow_graph)
-    if flow_algorithm ≠ BoykovKolmogorovAlgorithm()
-      return zero(T), zeros(T,n,n)
-    end
-    return zero(T), zeros(T,n,n), zeros(T,n)
+    return multiroute_flow(capacity_matrix,flow_algorithm)
   end
 
   if !(T<:AbstractFloat) # Capacities need to be Floats

--- a/src/flow/multiroute_flow.jl
+++ b/src/flow/multiroute_flow.jl
@@ -18,28 +18,28 @@ end
 # Methods when the number of routes is more than the connectivity
 # 1) When using Boykov-Kolmogorov as a flow subroutine
 # 2) Other flow algorithm
-function empty_flow{T<:Number}(
-  capacity_matrix::AbstractArray{T,2},      # edge flow capacities
+function empty_flow{T<:Real}(
+  capacity_matrix::AbstractArray{T, 2},     # edge flow capacities
   flow_algorithm::BoykovKolmogorovAlgorithm # keyword argument for algorithm
   )
-  n = size(capacity_matrix,1)
-  return zero(T), zeros(T,n,n), zeros(T,n)
+  n = size(capacity_matrix, 1)
+  return zero(T), zeros(T, n, n), zeros(T, n)
 end
 # 2) Other flow algorithm
-function empty_flow{T<:Number}(
-  capacity_matrix::AbstractArray{T,2},      # edge flow capacities
+function empty_flow{T<:Real}(
+  capacity_matrix::AbstractArray{T, 2},     # edge flow capacities
   flow_algorithm::AbstractFlowAlgorithm     # keyword argument for algorithm
   )
-  n = size(capacity_matrix,1)
-  return zero(T), zeros(T,n,n)
+  n = size(capacity_matrix, 1)
+  return zero(T), zeros(T, n, n)
 end
 
 # Method for Kishimoto algorithm
-function multiroute_flow{T<:Number}(
+function multiroute_flow{T<:Real}(
   flow_graph::DiGraph,                   # the input graph
   source::Int,                           # the source vertex
   target::Int,                           # the target vertex
-  capacity_matrix::AbstractArray{T,2},   # edge flow capacities
+  capacity_matrix::AbstractArray{T, 2},  # edge flow capacities
   flow_algorithm::AbstractFlowAlgorithm, # keyword argument for algorithm
   mrf_algorithm::KishimotoAlgorithm,     # keyword argument for algorithm
   routes::Int                            # keyword argument for routes
@@ -49,11 +49,11 @@ end
 
 ## Methods for Extended Multiroute Flow Algorithm
 #1 When the breaking points are not already known
-function multiroute_flow{T<:Number,R<:Real}(
+function multiroute_flow{T<:Real, R<:Real}(
   flow_graph::DiGraph,                            # the input graph
   source::Int,                                    # the source vertex
   target::Int,                                    # the target vertex
-  capacity_matrix::AbstractArray{T,2},            # edge flow capacities
+  capacity_matrix::AbstractArray{T, 2},           # edge flow capacities
   flow_algorithm::AbstractFlowAlgorithm,          # keyword argument for algorithm
   mrf_algorithm::ExtendedMultirouteFlowAlgorithm, # keyword argument for algorithm
   routes::R                                       # keyword argument for routes
@@ -61,20 +61,43 @@ function multiroute_flow{T<:Number,R<:Real}(
   return emrf(flow_graph, source, target, capacity_matrix, flow_algorithm, routes)
 end
 #2 When the breaking points are already known
-function multiroute_flow{T<:Number,R<:Real}(
-  breakingpoints::Vector{Tuple{T,T,Int}},         # vector of breaking points
-  routes::R,                                      # keyword argument for routes
-  flow_algorithm::AbstractFlowAlgorithm =         # keyword argument for algorithm
-      PushRelabelAlgorithm()
+#2-a Output: flow value (paired with the associated restriction)
+function multiroute_flow{T<:Real, R<:Real}(
+  breakingpoints::Vector{Tuple{T, T, Int}},       # vector of breaking points
+  routes::R                                       # keyword argument for routes
   )
-  return intersection(breakingpoints,routes,flow_algorithm)
+  return intersection(breakingpoints, routes)
+end
+#2-b Output: flow value, flows(, labels)
+function multiroute_flow{T1<:Real, T2<:Real, R<:Real}(
+  breakingpoints::Vector{Tuple{T1, T1, Int}}, # vector of breaking points
+  routes::R,                                # keyword argument for routes
+  flow_graph::DiGraph,                      # the input graph
+  source::Int,                              # the source vertex
+  target::Int,                              # the target vertex
+  capacity_matrix::AbstractArray{T2, 2} =    # edge flow capacities
+    DefaultCapacity(flow_graph);
+  flow_algorithm::AbstractFlowAlgorithm  =  # keyword argument for algorithm
+    PushRelabelAlgorithm()
+  )
+  x, f = intersection(breakingpoints, routes)
+
+  # For other cases, capacities need to be Floats
+  if !(T2<:AbstractFloat)
+    capacity_matrix = convert(AbstractArray{Float64, 2}, capacity_matrix)
+  end
+
+  return maximum_flow(flow_graph, source, target, capacity_matrix,
+                      algorithm = flow_algorithm, restriction = x)
 end
 
 """
-The generic multiroute_flow function will output two kinds of results:
+The generic multiroute_flow function will output three kinds of results:
 
 - When the number of routes is 0 or non-specified, the set of breaking points of
 the multiroute flow is returned.
+- When the input is limited to a set of breaking points and a route value k,
+only the value of the k-route flow is returned
 - Otherwise, a tuple with 1) the maximum flow and 2) the flow matrix. When the
 max-flow subroutine is the Boykov-Kolmogorov algorithm, the associated mincut is
 returned as a third output.
@@ -84,45 +107,57 @@ When the input is a network, it requires the following arguments:
 - flow_graph::DiGraph                   # the input graph
 - source::Int                           # the source vertex
 - target::Int                           # the target vertex
-- capacity_matrix::AbstractArray{T,2}   # edge flow capacities
+- capacity_matrix::AbstractArray{T, 2}  # edge flow capacities with T<:Real
 - flow_algorithm::AbstractFlowAlgorithm # keyword argument for flow algorithm
 - mrf_algorithm::AbstractFlowAlgorithm  # keyword argument for multiroute flow algorithm
-- routes::R<:Number                     # keyword argument for the number of routes
+- routes::R<:Real                       # keyword argument for the number of routes
 
-When the input is the set of (breaking) points (the number of route is then a parameter),
+When the input is only the set of (breaking) points and the number of route,
 it requires the following arguments:
 
-- breakingpoints::Vector{Tuple{T,T,Int}},      # vector of breaking points
-- routes::R<:Number,                           # keyword argument for routes
-- flow_algorithm::AbstractFlowAlgorithm        # keyword argument for flow algorithm
+- breakingpoints::Vector{Tuple{T, T, Int}},    # vector of breaking points
+- routes::R<:Real,                             # number of routes
+
+When the input is the set of (breaking) points, the number of routes,
+and the network descriptors, it requires the following arguments:
+
+- breakingpoints::Vector{Tuple{T1, T1, Int}} # vector of breaking points (T1<:Real)
+- routes::R<:Real                            # number of routes
+- flow_graph::DiGraph                        # the input graph
+- source::Int                                # the source vertex
+- target::Int                                # the target vertex
+- capacity_matrix::AbstractArray{T2, 2}      # optional edge flow capacities (T2<:Real)
+- flow_algorithm::AbstractFlowAlgorithm      # keyword argument for algorithm
 
 The function defaults to the Push-relabel (classical flow) and Kishimoto
 (multiroute) algorithms. Alternatively, the algorithms to be used can also
 be specified through  keyword arguments. A default capacity of 1 is assumed
 for each link if no capacity matrix is provided.
 
-The mrf_algorithm keyword is inforced to Extended Multiroute Flow in the following cases:
+The mrf_algorithm keyword is inforced to Extended Multiroute Flow
+in the following cases:
 
 - The number of routes is non-integer
 - The number of routes is 0 or non-specified
 
 ### Usage Example :
-(please consult the  max_flow section for options about flow_algorithm and capacity_matrix)
+(please consult the  max_flow section for options about flow_algorithm
+and capacity_matrix)
 
 ```julia
 
 # Create a flow-graph and a capacity matrix
 flow_graph = DiGraph(8)
 flow_edges = [
-    (1,2,10),(1,3,5),(1,4,15),(2,3,4),(2,5,9),
-    (2,6,15),(3,4,4),(3,6,8),(4,7,16),(5,6,15),
-    (5,8,10),(6,7,15),(6,8,10),(7,3,6),(7,8,10)
+    (1, 2, 10), (1, 3, 5),  (1, 4, 15), (2, 3, 4),  (2, 5, 9),
+    (2, 6, 15), (3, 4, 4),  (3, 6, 8),  (4, 7, 16), (5, 6, 15),
+    (5, 8, 10), (6, 7, 15), (6, 8, 10), (7, 3, 6),  (7, 8, 10)
 ]
 capacity_matrix = zeros(Int, 8, 8)
 for e in flow_edges
     u, v, f = e
     add_edge!(flow_graph, u, v)
-    capacity_matrix[u,v] = f
+    capacity_matrix[u, v] = f
 end
 
 # Run default multiroute_flow with an integer number of routes = 2
@@ -134,19 +169,21 @@ f, F = multiroute_flow(flow_graph, 1, 8, capacity_matrix, routes = 1.5)
 # Run default multiroute_flow for all the breaking points values
 points = multiroute_flow(flow_graph, 1, 8, capacity_matrix)
 # Then run multiroute flow algorithm for any positive number of routes
-f, F = multiroute_flow(points, routes = 1.5)
+f, F = multiroute_flow(points, 1.5)
+f = multiroute_flow(points, 1.5, valueonly = true)
 
 # Run multiroute flow algorithm using Boykov-Kolmogorov algorithm as max_flow routine
-f, F, labels = multiroute_flow(flow_graph,1,8,capacity_matrix,algorithm=BoykovKolmogorovAlgorithm(),routes=2)
+f, F, labels = multiroute_flow(flow_graph, 1, 8, capacity_matrix,
+               algorithm = BoykovKolmogorovAlgorithm(), routes = 2)
 
 ```
 """
 
-function multiroute_flow{T<:Number,R<:Real}(
-  flow_graph::DiGraph,                   # the input graph
-  source::Int,                           # the source vertex
-  target::Int,                           # the target vertex
-  capacity_matrix::AbstractArray{T,2} =  # edge flow capacities
+function multiroute_flow{T<:Real, R<:Real}(
+  flow_graph::DiGraph,                    # the input graph
+  source::Int,                            # the source vertex
+  target::Int,                            # the target vertex
+  capacity_matrix::AbstractArray{T, 2} =  # edge flow capacities
     DefaultCapacity(flow_graph);
   flow_algorithm::AbstractFlowAlgorithm  =    # keyword argument for algorithm
     PushRelabelAlgorithm(),
@@ -164,8 +201,8 @@ function multiroute_flow{T<:Number,R<:Real}(
   (routes > λ) && return empty_flow(capacity_matrix, flow_algorithm)
 
   # For other cases, capacities need to be Floats
-  if !(T<:AbstractFloat) # Capacities need to be Floats
-    capacity_matrix = convert(AbstractArray{Float64,2}, capacity_matrix)
+  if !(T<:AbstractFloat)
+    capacity_matrix = convert(AbstractArray{Float64, 2}, capacity_matrix)
   end
 
   # Ask for all possible values (breaking points)

--- a/src/flow/multiroute_flow.jl
+++ b/src/flow/multiroute_flow.jl
@@ -12,11 +12,10 @@ end
 """
 Forces the multiroute_flow function to use the Extended Multiroute Flow algorithm.
 """
-type ExtendedMultirouteFlowAlgorithm <: AbstractFlowAlgorithm
+type ExtendedMultirouteFlowAlgorithm <: AbstractMultirouteFlowAlgorithm
 end
 
 # Method for Kishimoto algorithm
-
 function multiroute_flow{T<:Number}(
   flow_graph::DiGraph,                   # the input graph
   source::Int,                           # the source vertex
@@ -29,7 +28,91 @@ function multiroute_flow{T<:Number}(
   return kishimoto(flow_graph, source, target, capacity_matrix, flow_algorithm, routes)
 end
 
-function multiroute_flow{T<:Number}(
+## Methods for Extended Multiroute Flow Algorithm
+#1 When the breaking points are not already known
+function multiroute_flow{T<:Number,R<:Number}(
+  flow_graph::DiGraph,                            # the input graph
+  source::Int,                                    # the source vertex
+  target::Int,                                    # the target vertex
+  capacity_matrix::AbstractArray{T,2},            # edge flow capacities
+  flow_algorithm::AbstractFlowAlgorithm,          # keyword argument for algorithm
+  mrf_algorithm::ExtendedMultirouteFlowAlgorithm, # keyword argument for algorithm
+  routes::R                                       # keyword argument for routes
+  )
+  return emrf(flow_graph, source, target, capacity_matrix, flow_algorithm, routes)
+end
+#2 When the breaking points are already known
+function multiroute_flow{T<:Number,R<:Number}(
+  breakingpoints::Vector{Tuple{T,T,Int}},         # vector of breaking points
+  routes::R,                                      # keyword argument for routes
+  flow_algorithm::AbstractFlowAlgorithm =         # keyword argument for algorithm
+      PushRelabelAlgorithm()
+  )
+  return intersection(breakingpoints,routes,flow_algorithm)
+end
+
+"""
+Generic multiroute_flow function. Requires arguments:
+
+I. When the main input is a network
+- flow_graph::DiGraph                   # the input graph
+- source::Int                           # the source vertex
+- target::Int                           # the target vertex
+- capacity_matrix::AbstractArray{T,2}   # edge flow capacities
+- flow_algorithm::AbstractFlowAlgorithm # keyword argument for flow algorithm
+- mrf_algorithm::AbstractFlowAlgorithm  # keyword argument for multiroute flow algorithm
+- routes::R<:Number                     # keyword argument for the number of routes
+
+The function defaults to the Push-relabel (classical flow) and Kishimoto (multiroute) algorithms. Alternatively, the algorithms to be used can also be specified through  keyword arguments. A default capacity of 1 is assumed for each link if no capacity matrix is provided.
+The mrf_algorithm keyword is inforced to Extended Multiroute Flow in the following cases:
+a) The number of routes is noninteger (however a max-flow )
+b) The number of routes is 0 (the algorithm will output all the breaking points)
+
+II. When the main input is a set of (breaking) points
+  - breakingpoints::Vector{Tuple{T,T,Int}},      # vector of breaking points
+  - routes::R<:Number,                           # keyword argument for routes
+  - flow_algorithm::AbstractFlowAlgorithm        # keyword argument for flow algorithm
+
+Except for I.2) (routes ≠ 0), all algorithms return a tuple with 1) the maximum flow and 2) the flow matrix. For the Boykov-Kolmogorov algorithm, the associated mincut is returned as a third output.
+
+For I.2) (routes = 0), the set of breaking points of the multiroute flow is returned.
+
+### Usage Example :
+(please consult the  max_flow section for options about flow_algorithm and capacity_matrix)
+
+```julia
+
+# Create a flow-graph and a capacity matrix
+flow_graph = DiGraph(8)
+flow_edges = [
+    (1,2,10),(1,3,5),(1,4,15),(2,3,4),(2,5,9),
+    (2,6,15),(3,4,4),(3,6,8),(4,7,16),(5,6,15),
+    (5,8,10),(6,7,15),(6,8,10),(7,3,6),(7,8,10)
+]
+capacity_matrix = zeros(Int, 8, 8)
+for e in flow_edges
+    u, v, f = e
+    add_edge!(flow_graph, u, v)
+    capacity_matrix[u,v] = f
+end
+
+# Run default multiroute_flow with an integer number of routes = 2
+f, F = multiroute_flow(flow_graph, 1, 8, capacity_matrix, routes = 2)
+
+# Run default multiroute_flow with a noninteger number of routes = 1.5
+f, F = multiroute_flow(flow_graph, 1, 8, capacity_matrix, routes = 1.5)
+
+# Run default multiroute_flow for all the breaking points values
+points = multiroute_flow(flow_graph, 1, 8, capacity_matrix)
+# Then run multiroute flow algorithm for any positive number of routes
+f, F = multiroute_flow(points, routes = 1.5)
+
+# Run multiroute flow algorithm using Boykov-Kolmogorov algorithm as max_flow routine
+f, F, labels = multiroute_flow(flow_graph,1,8,capacity_matrix,algorithm=BoykovKolmogorovAlgorithm(),routes=2)
+
+```
+"""
+function multiroute_flow{T<:Number,R<:Number}(
   flow_graph::DiGraph,                   # the input graph
   source::Int,                           # the source vertex
   target::Int,                           # the target vertex
@@ -39,49 +122,30 @@ function multiroute_flow{T<:Number}(
     PushRelabelAlgorithm(),
   mrf_algorithm::AbstractMultirouteFlowAlgorithm  =    # keyword argument for algorithm
     KishimotoAlgorithm(),
-  routes::Int = 1               # keyword argument for number of routes
+  routes::R = 0              # keyword argument for number of routes (0 = all values)
   )
   if routes == 1 # a flow with a set of 1-disjoint path is a classical max-flow
     return maximum_flow(flow_graph, source, target, capacity_matrix, flow_algorithm)
   end
-  if routes > maximum_flow(flow_graph,source,target)[1]
+  if routes > maximum_flow(flow_graph,source,target,        # routes > λ → f = 0
+    DefaultCapacity(flow_graph),algorithm=flow_algorithm)[1]
     n = nv(flow_graph)
-    return 0, zeros(T, n, n)
+    if flow_algorithm ≠ BoykovKolmogorovAlgorithm()
+      return zero(T), zeros(T,n,n)
+    end
+    return zero(T), zeros(T,n,n), zeros(T,n)
   end
-  return multiroute_flow(flow_graph, source, target, capacity_matrix, flow_algorithm, mrf_algorithm, routes)
-end
 
-# Kishimoto algorithm
-function kishimoto{T<:Number}(
-  flow_graph::DiGraph,                   # the input graph
-  source::Int,                           # the source vertex
-  target::Int,                           # the target vertex
-  capacity_matrix::AbstractArray{T,2},   # edge flow capacities
-  flow_algorithm::AbstractFlowAlgorithm, # keyword argument for algorithm
-  routes::Int                            # keyword argument for routes
-  )
-  # Capacities need to be Floats
-  if !(T<:AbstractFloat)
+  if !(T<:AbstractFloat) # Capacities need to be Floats
     capacity_matrix = convert(AbstractArray{Float64,2}, capacity_matrix)
   end
 
-  # Initialisation
-  flow, F = maximum_flow(flow_graph, source, target,
-         capacity_matrix, algorithm = flow_algorithm)
-  restriction = flow / routes
-
-  flow, F = maximum_flow(flow_graph, source, target, capacity_matrix,
-            algorithm = flow_algorithm, restriction = restriction)
-
-  # Loop
-  i = 1
-  while flow ≉ routes * restriction && flow < routes * restriction
-    restriction = (flow - i * restriction) / (routes - i)
-    i = i + 1
-    flow, F = maximum_flow(flow_graph, source, target, capacity_matrix,
-              algorithm = flow_algorithm, restriction = restriction)
+  if routes == 0 # Ask for all possible values (breaking points)
+    return emrf(flow_graph,source,target,capacity_matrix,flow_algorithm)
   end
-
-  # End
-  return flow, F
+  if R <: AbstractFloat # The number of routes is a float → EMRF
+    return emrf(flow_graph,source,target,capacity_matrix,flow_algorithm,routes)
+  end
+  return multiroute_flow(flow_graph, source, target, # Other calls
+    capacity_matrix, flow_algorithm, mrf_algorithm, routes)
 end

--- a/test/flow/multiroute_flow.jl
+++ b/test/flow/multiroute_flow.jl
@@ -24,6 +24,31 @@ graphs = [
    [12, 6, 0],                        # answer for 1 to 3 route(s) flows
    [(0.,0.,2),(3.,6.,1),(9.,12.,0)],  # breaking points
    11.0                               # value for 1.5 routes
+  ),
+
+  # Graph with 7 vertices
+  (7,
+   [
+     (1,2,1),(1,3,2),(1,4,3),(1,5,4),(1,6,5),
+     (2,7,1),(3,7,2),(4,7,3),(5,7,4),(6,7,5)
+   ],
+   1,7,                               # source/target
+   [15,15,15,12,5,0],                 # answer for 1 to 6 route(s) flows
+   [(0.,0.,5),(1.,5.,4),(2.,9.,3),    # breaking points
+    (3.,12.,2),(4.,14.,1),(5.,15.,0)],
+   15.0                               # value for 1.5 routes
+  ),
+
+  # Graph with 6 vertices
+  (6,
+   [
+     (1,2,1),(1,3,1),(1,4,2),(1,5,2),
+     (2,6,1),(3,6,1),(4,6,2),(5,6,2),
+   ],
+   1,6,                               # source/target
+   [6,6,6,4,0],                       # answer for 1 to 5 route(s) flows
+   [(0.,0.,4),(1.,4.,2),(2.,6.,0)],   # breaking points    
+   6.0                                # value for 1.5 routes
   )
 ]
 
@@ -36,11 +61,15 @@ for (nvertices,flow_edges,s,t,froutes,breakpts,ffloat) in graphs
         capacity_matrix[u,v] = f
     end
 
+    println("Breaking points = $(multiroute_flow(flow_graph,s,t,capacity_matrix))")
+
     # Test all algorithms
-    for ALGOMRF in [ExtendedMultirouteFlowAlgorithm,KishimotoAlgorithm]
-      for ALGOFLOW in [EdmondsKarpAlgorithm, DinicAlgorithm, BoykovKolmogorovAlgorithm, PushRelabelAlgorithm]
+    for AlgoMrf in [ExtendedMultirouteFlowAlgorithm,KishimotoAlgorithm]
+      for AlgoFlow in [EdmondsKarpAlgorithm, DinicAlgorithm, BoykovKolmogorovAlgorithm, PushRelabelAlgorithm]
         for (k, val) in enumerate(froutes)
-          @test multiroute_flow(flow_graph,s,t,capacity_matrix,flow_algorithm=ALGOFLOW(),mrf_algorithm=ALGOMRF(),routes=k)[1] ≈ val
+          println("val = $val, k = $k")
+          println("AlgoFlow=$AlgoFlow, AlgoMrf=$AlgoMrf")
+          @test multiroute_flow(flow_graph,s,t,capacity_matrix,flow_algorithm=AlgoFlow(),mrf_algorithm=AlgoMrf(),routes=k)[1] ≈ val
         end
       end
     end

--- a/test/flow/multiroute_flow.jl
+++ b/test/flow/multiroute_flow.jl
@@ -7,8 +7,11 @@ graphs = [
      (2,6,15),(3,4,4),(3,6,8),(4,7,16),(5,6,15),
      (5,8,10),(6,7,15),(6,8,10),(7,3,6),(7,8,10)
    ],
-   1,8,               # source/target
-   [28, 28, 15, 0]    # answer for 1 to 4 route(s) flows
+   1,8,                               # source/target
+   [28, 28, 15, 0],                   # answer for 1 to 4 route(s) flows
+   [(0.0,0.0,3),(5.0,15.0,2),         # breaking points
+   (10.0,25.0,1),(13.0,28.0,0)],
+   28.0                               # value for 1.5 routes
   ),
 
   # Graph with 6 vertices
@@ -17,12 +20,14 @@ graphs = [
      (1,2,9),(1,3,9),(2,3,10),(2,4,8),(3,4,1),
      (3,5,3),(5,4,8),(4,6,10),(5,6,7)
    ],
-   1,6,           # source/target
-   [12, 6, 0]     # answer for 1 to 3 route(s) flows
+   1,6,                               # source/target
+   [12, 6, 0],                        # answer for 1 to 3 route(s) flows
+   [(0.,0.,2),(3.,6.,1),(9.,12.,0)],  # breaking points
+   11.0                               # value for 1.5 routes
   )
 ]
 
-for (nvertices,flow_edges,s,t,froutes) in graphs
+for (nvertices,flow_edges,s,t,froutes,breakpts,ffloat) in graphs
     flow_graph = DiGraph(nvertices)
     capacity_matrix = zeros(Int,nvertices,nvertices)
     for e in flow_edges
@@ -32,9 +37,18 @@ for (nvertices,flow_edges,s,t,froutes) in graphs
     end
 
     # Test all algorithms
-    for ALGO in [KishimotoAlgorithm]
-      for (k, val) in enumerate(froutes)
-        @test multiroute_flow(flow_graph,s,t,capacity_matrix,mrf_algorithm=ALGO(),routes=k)[1] ≈ val
+    for ALGOMRF in [ExtendedMultirouteFlowAlgorithm,KishimotoAlgorithm]
+      for ALGOFLOW in [EdmondsKarpAlgorithm, DinicAlgorithm, BoykovKolmogorovAlgorithm, PushRelabelAlgorithm]
+        for (k, val) in enumerate(froutes)
+          println("ALGOFLOW = $ALGOFLOW, ALGOMRF = $ALGOMRF")
+          println("k = $k, val = $val")
+          println(multiroute_flow(flow_graph,s,t,capacity_matrix,flow_algorithm=ALGOFLOW(),mrf_algorithm=ALGOMRF(),routes=k),"\n")
+#          @test multiroute_flow(flow_graph,s,t,capacity_matrix,flow_algorithm=ALGOFLOW(),mrf_algorithm=ALGOMRF(),routes=k)[1] ≈ val
+        end
       end
     end
+    # Test ExtendedMultirouteFlowAlgorithm when the number of routes is either
+    # Noninteger or 0 (the algorithm returns the breaking points)
+    @test multiroute_flow(flow_graph,s,t,capacity_matrix) == breakpts
+    @test multiroute_flow(flow_graph,s,t,capacity_matrix,routes=1.5)[1] == ffloat
 end

--- a/test/flow/multiroute_flow.jl
+++ b/test/flow/multiroute_flow.jl
@@ -3,78 +3,81 @@ graphs = [
   # Graph with 8 vertices
   (8,
    [
-     (1,2,10),(1,3,5),(1,4,15),(2,3,4),(2,5,9),
-     (2,6,15),(3,4,4),(3,6,8),(4,7,16),(5,6,15),
-     (5,8,10),(6,7,15),(6,8,10),(7,3,6),(7,8,10)
+     (1, 2, 10), (1, 3, 5),  (1, 4, 15), (2, 3, 4),  (2, 5, 9),
+     (2, 6, 15), (3, 4, 4),  (3, 6, 8),  (4, 7, 16), (5, 6, 15),
+     (5, 8, 10), (6, 7, 15), (6, 8, 10), (7, 3, 6),  (7, 8, 10)
    ],
-   1,8,                               # source/target
+   1, 8,                              # source/target
    [28, 28, 15, 0],                   # answer for 1 to 4 route(s) flows
-   [(0.0,0.0,3),(5.0,15.0,2),         # breaking points
-   (10.0,25.0,1),(13.0,28.0,0)],
-   28.0                               # value for 1.5 routes
+   [(0., 0., 3), (5., 15., 2),        # breaking points
+   (10., 25., 1), (13., 28., 0)],
+   28.                                # value for 1.5 routes
   ),
 
   # Graph with 6 vertices
   (6,
    [
-     (1,2,9),(1,3,9),(2,3,10),(2,4,8),(3,4,1),
-     (3,5,3),(5,4,8),(4,6,10),(5,6,7)
+     (1, 2, 9), (1, 3, 9), (2, 3, 10), (2, 4, 8), (3, 4, 1),
+     (3, 5, 3), (5, 4, 8), (4, 6, 10), (5, 6, 7)
    ],
-   1,6,                               # source/target
-   [12, 6, 0],                        # answer for 1 to 3 route(s) flows
-   [(0.,0.,2),(3.,6.,1),(9.,12.,0)],  # breaking points
-   11.0                               # value for 1.5 routes
+   1, 6,                                      # source/target
+   [12, 6, 0],                                # answer for 1 to 3 route(s) flows
+   [(0., 0., 2), (3., 6., 1), (9., 12., 0)],  # breaking points
+   9.                                         # value for 1.5 routes
   ),
 
   # Graph with 7 vertices
   (7,
    [
-     (1,2,1),(1,3,2),(1,4,3),(1,5,4),(1,6,5),
-     (2,7,1),(3,7,2),(4,7,3),(5,7,4),(6,7,5)
+     (1, 2, 1), (1, 3, 2), (1, 4, 3), (1, 5, 4), (1, 6, 5),
+     (2, 7, 1), (3, 7, 2), (4, 7, 3), (5, 7, 4), (6, 7, 5)
    ],
-   1,7,                               # source/target
-   [15,15,15,12,5,0],                 # answer for 1 to 6 route(s) flows
-   [(0.,0.,5),(1.,5.,4),(2.,9.,3),    # breaking points
-    (3.,12.,2),(4.,14.,1),(5.,15.,0)],
-   15.0                               # value for 1.5 routes
+   1, 7,                                      # source/target
+   [15, 15, 15, 12, 5, 0],                    # answer for 1 to 6 route(s) flows
+   [(0., 0., 5), (1., 5., 4), (2., 9., 3),    # breaking points
+    (3., 12., 2), (4., 14., 1), (5., 15., 0)],
+   15.                                        # value for 1.5 routes
   ),
 
   # Graph with 6 vertices
   (6,
    [
-     (1,2,1),(1,3,1),(1,4,2),(1,5,2),
-     (2,6,1),(3,6,1),(4,6,2),(5,6,2),
+     (1, 2, 1), (1, 3, 1), (1, 4, 2), (1, 5, 2),
+     (2, 6, 1), (3, 6, 1), (4, 6, 2), (5, 6, 2),
    ],
-   1,6,                               # source/target
-   [6,6,6,4,0],                       # answer for 1 to 5 route(s) flows
-   [(0.,0.,4),(1.,4.,2),(2.,6.,0)],   # breaking points    
-   6.0                                # value for 1.5 routes
+   1, 6,                                      # source/target
+   [6, 6, 6, 4, 0],                           # answer for 1 to 5 route(s) flows
+   [(0., 0., 4), (1., 4., 2), (2., 6., 0)],   # breaking points
+   6.                                         # value for 1.5 routes
   )
 ]
 
-for (nvertices,flow_edges,s,t,froutes,breakpts,ffloat) in graphs
+for (nvertices, flow_edges, s, t, froutes, breakpts, ffloat) in graphs
     flow_graph = DiGraph(nvertices)
-    capacity_matrix = zeros(Int,nvertices,nvertices)
+    capacity_matrix = zeros(Int, nvertices, nvertices)
     for e in flow_edges
-        u,v,f = e
-        add_edge!(flow_graph,u,v)
-        capacity_matrix[u,v] = f
+        u, v, f = e
+        add_edge!(flow_graph, u, v)
+        capacity_matrix[u, v] = f
     end
 
-    println("Breaking points = $(multiroute_flow(flow_graph,s,t,capacity_matrix))")
 
-    # Test all algorithms
-    for AlgoMrf in [ExtendedMultirouteFlowAlgorithm,KishimotoAlgorithm]
-      for AlgoFlow in [EdmondsKarpAlgorithm, DinicAlgorithm, BoykovKolmogorovAlgorithm, PushRelabelAlgorithm]
+    # Test ExtendedMultirouteFlowAlgorithm when the number of routes is either
+    # Noninteger or 0 (the algorithm returns the breaking points)
+    @test multiroute_flow(flow_graph, s, t, capacity_matrix) == breakpts
+    @test multiroute_flow(flow_graph, s, t, capacity_matrix, routes=1.5)[1] ≈ ffloat
+    @test multiroute_flow(breakpts, 1.5)[2] ≈ ffloat
+
+    # Test all other algorithms
+    for AlgoFlow in [EdmondsKarpAlgorithm, DinicAlgorithm, BoykovKolmogorovAlgorithm, PushRelabelAlgorithm]
+      # When the input are breaking points and routes number
+      @test multiroute_flow(breakpts, 1.5, flow_graph, s, t, capacity_matrix)[1] ≈ ffloat
+      for AlgoMrf in [ExtendedMultirouteFlowAlgorithm, KishimotoAlgorithm]
         for (k, val) in enumerate(froutes)
-          println("val = $val, k = $k")
-          println("AlgoFlow=$AlgoFlow, AlgoMrf=$AlgoMrf")
-          @test multiroute_flow(flow_graph,s,t,capacity_matrix,flow_algorithm=AlgoFlow(),mrf_algorithm=AlgoMrf(),routes=k)[1] ≈ val
+          @test multiroute_flow(flow_graph, s, t, capacity_matrix,
+            flow_algorithm = AlgoFlow(), mrf_algorithm = AlgoMrf(),
+            routes = k)[1] ≈ val
         end
       end
     end
-    # Test ExtendedMultirouteFlowAlgorithm when the number of routes is either
-    # Noninteger or 0 (the algorithm returns the breaking points)
-    @test multiroute_flow(flow_graph,s,t,capacity_matrix) == breakpts
-    @test multiroute_flow(flow_graph,s,t,capacity_matrix,routes=1.5)[1] == ffloat
 end

--- a/test/flow/multiroute_flow.jl
+++ b/test/flow/multiroute_flow.jl
@@ -1,0 +1,40 @@
+#### Graphs for testing
+graphs = [
+  # Graph with 8 vertices
+  (8,
+   [
+     (1,2,10),(1,3,5),(1,4,15),(2,3,4),(2,5,9),
+     (2,6,15),(3,4,4),(3,6,8),(4,7,16),(5,6,15),
+     (5,8,10),(6,7,15),(6,8,10),(7,3,6),(7,8,10)
+   ],
+   1,8,               # source/target
+   [28, 28, 15, 0]    # answer for 1 to 4 route(s) flows
+  ),
+
+  # Graph with 6 vertices
+  (6,
+   [
+     (1,2,9),(1,3,9),(2,3,10),(2,4,8),(3,4,1),
+     (3,5,3),(5,4,8),(4,6,10),(5,6,7)
+   ],
+   1,6,           # source/target
+   [12, 6, 0]     # answer for 1 to 3 route(s) flows
+  )
+]
+
+for (nvertices,flow_edges,s,t,froutes) in graphs
+    flow_graph = DiGraph(nvertices)
+    capacity_matrix = zeros(Int,nvertices,nvertices)
+    for e in flow_edges
+        u,v,f = e
+        add_edge!(flow_graph,u,v)
+        capacity_matrix[u,v] = f
+    end
+
+    # Test all algorithms
+    for ALGO in [KishimotoAlgorithm]
+      for (k, val) in enumerate(froutes)
+        @test multiroute_flow(flow_graph,s,t,capacity_matrix,mrf_algorithm=ALGO(),routes=k)[1] ≈ val
+      end
+    end
+end

--- a/test/flow/multiroute_flow.jl
+++ b/test/flow/multiroute_flow.jl
@@ -40,10 +40,7 @@ for (nvertices,flow_edges,s,t,froutes,breakpts,ffloat) in graphs
     for ALGOMRF in [ExtendedMultirouteFlowAlgorithm,KishimotoAlgorithm]
       for ALGOFLOW in [EdmondsKarpAlgorithm, DinicAlgorithm, BoykovKolmogorovAlgorithm, PushRelabelAlgorithm]
         for (k, val) in enumerate(froutes)
-          println("ALGOFLOW = $ALGOFLOW, ALGOMRF = $ALGOMRF")
-          println("k = $k, val = $val")
-          println(multiroute_flow(flow_graph,s,t,capacity_matrix,flow_algorithm=ALGOFLOW(),mrf_algorithm=ALGOMRF(),routes=k),"\n")
-#          @test multiroute_flow(flow_graph,s,t,capacity_matrix,flow_algorithm=ALGOFLOW(),mrf_algorithm=ALGOMRF(),routes=k)[1] ≈ val
+          @test multiroute_flow(flow_graph,s,t,capacity_matrix,flow_algorithm=ALGOFLOW(),mrf_algorithm=ALGOMRF(),routes=k)[1] ≈ val
         end
       end
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -156,6 +156,7 @@ tests = [
     "flow/boykov_kolmogorov",
     "flow/push_relabel",
     "flow/maximum_flow",
+    "flow/multiroute_flow",
     "utils"
 ]
 


### PR DESCRIPTION
This PR implements the two methods for the multiroute flow algorithms discussed in #400 :
* Kishimoto algorithm
* Extended Multiroute Flow algorithm (can be used to solve/approximate Network Interdiction)

It also includes tests and doc updates. However some unrelated files in the doc are updated (probably from other PR where `julia doc/build.jl` was not called) :
  1. Doc for max-flow (from my previous PR #402 ) 
  2. basicmeasures.md
  3. linalg.md