### PR TITLE
function next(eit::EdgeIter, state) now does not modify state 

### DIFF
--- a/src/edgeiter.jl
+++ b/src/edgeiter.jl
@@ -15,10 +15,10 @@ eltype(::Type{EdgeIter}) = Edge
 EdgeIter(g::Graph) = EdgeIter(ne(g), g.fadjlist, false)
 EdgeIter(g::DiGraph) = EdgeIter(ne(g), g.fadjlist, true)
 
-function _next(eit::EdgeIter, state::EdgeIterState = EdgeIterState(1,1,false))
-    #ret_state = EdgeIterState(state.s, state.di, state.fin)
+function _next(eit::EdgeIter, state::EdgeIterState = EdgeIterState(1,1,false), first::Bool = true)
     s = state.s
-    di = state.di + 1
+    di = state.di
+    first || (di += 1)
     fin = state.fin
     while s <= length(eit.adj)
         arr = eit.adj[s]
@@ -41,7 +41,7 @@ length(eit::EdgeIter) = eit.m
 
 function next(eit::EdgeIter, state)
     edge = Edge(state.s, eit.adj[state.s][state.di])
-    return(edge, _next(eit, state))
+    return(edge, _next(eit, state, false))
 end
 
 function _isequal(e1::EdgeIter, e2)

--- a/src/edgeiter.jl
+++ b/src/edgeiter.jl
@@ -18,7 +18,9 @@ EdgeIter(g::DiGraph) = EdgeIter(ne(g), g.fadjlist, true)
 function _next(eit::EdgeIter, state::EdgeIterState = EdgeIterState(1,1,false), first::Bool = true)
     s = state.s
     di = state.di
-    first || (di += 1)
+    if !first
+        di += 1
+    end
     fin = state.fin
     while s <= length(eit.adj)
         arr = eit.adj[s]

--- a/src/edgeiter.jl
+++ b/src/edgeiter.jl
@@ -1,4 +1,4 @@
-type EdgeIterState
+immutable EdgeIterState
     s::Int  # src vertex
     di::Int # index into adj of dest vertex
     fin::Bool
@@ -15,31 +15,33 @@ eltype(::Type{EdgeIter}) = Edge
 EdgeIter(g::Graph) = EdgeIter(ne(g), g.fadjlist, false)
 EdgeIter(g::DiGraph) = EdgeIter(ne(g), g.fadjlist, true)
 
-function _next!(eit::EdgeIter, state::EdgeIterState = EdgeIterState(1,1,false))
-    while state.s <= length(eit.adj)
-        arr = eit.adj[state.s]
-        while state.di <= length(arr)
-            if eit.directed || state.s <= arr[state.di]
-                return state
+function _next(eit::EdgeIter, state::EdgeIterState = EdgeIterState(1,1,false))
+    #ret_state = EdgeIterState(state.s, state.di, state.fin)
+    s = state.s
+    di = state.di + 1
+    fin = state.fin
+    while s <= length(eit.adj)
+        arr = eit.adj[s]
+        while di <= length(arr)
+            if eit.directed || s <= arr[di]
+                return EdgeIterState(s, di, fin)
             end
-            state.di += 1
+            di += 1
         end
-        state.s += 1
-        state.di = 1
+        s += 1
+        di = 1
     end
-    state.fin = true
-    return state
+    fin = true
+    return EdgeIterState(s, di, fin)
 end
 
-start(eit::EdgeIter) = _next!(eit)
+start(eit::EdgeIter) = _next(eit)
 done(eit::EdgeIter, state::EdgeIterState) = state.fin
 length(eit::EdgeIter) = eit.m
 
 function next(eit::EdgeIter, state)
     edge = Edge(state.s, eit.adj[state.s][state.di])
-    ret_state = EdgeIterState(state.s, state.di, state.fin)
-    ret_state.di += 1
-    return(edge, _next!(eit, ret_state))
+    return(edge, _next(eit, state))
 end
 
 function _isequal(e1::EdgeIter, e2)

--- a/src/edgeiter.jl
+++ b/src/edgeiter.jl
@@ -15,7 +15,7 @@ eltype(::Type{EdgeIter}) = Edge
 EdgeIter(g::Graph) = EdgeIter(ne(g), g.fadjlist, false)
 EdgeIter(g::DiGraph) = EdgeIter(ne(g), g.fadjlist, true)
 
-function _next(eit::EdgeIter, state::EdgeIterState = EdgeIterState(1,1,false))
+function _next!(eit::EdgeIter, state::EdgeIterState = EdgeIterState(1,1,false))
     while state.s <= length(eit.adj)
         arr = eit.adj[state.s]
         while state.di <= length(arr)
@@ -31,14 +31,15 @@ function _next(eit::EdgeIter, state::EdgeIterState = EdgeIterState(1,1,false))
     return state
 end
 
-start(eit::EdgeIter) = _next(eit)
+start(eit::EdgeIter) = _next!(eit)
 done(eit::EdgeIter, state::EdgeIterState) = state.fin
 length(eit::EdgeIter) = eit.m
 
 function next(eit::EdgeIter, state)
     edge = Edge(state.s, eit.adj[state.s][state.di])
-    state.di += 1
-    return(edge, _next(eit, state))
+    ret_state = EdgeIterState(state.s, state.di, state.fin)
+    ret_state.di += 1
+    return(edge, _next!(eit, ret_state))
 end
 
 function _isequal(e1::EdgeIter, e2)


### PR DESCRIPTION
Fixing #419

It seems that there are some exceptions in julia Base where next modified its arguments, but I don't think it is needed here. Maybe if you have some benchmarks I can run them and see the impact of such modification. 