### PR TITLE
fix Nonbacktracking contract operation

### DIFF
--- a/src/spectral.jl
+++ b/src/spectral.jl
@@ -250,7 +250,7 @@ contract(nbt, edgespace). modifies first argument
 function contract!(vertexspace::Vector, nbt::Nonbacktracking, edgespace::Vector)
     for i=1:nv(nbt.g)
         for j in neighbors(nbt.g, i)
-            u = nbt.edgeidmap[Edge(j,i)]
+            u = nbt.edgeidmap[i > j ? Edge(j,i) : Edge(i,j)]
             vertexspace[i] += edgespace[u]
         end
     end

--- a/test/spectral.jl
+++ b/test/spectral.jl
@@ -22,6 +22,16 @@ for i=1:10
     @test sum(B[i,:]) == 8
 end
 
+v = ones(Float64, ne(g10))
+z = zeros(Float64, nv(g10))
+n10 = Nonbacktracking(g10)
+LightGraphs.contract!(z, n10, v)
+
+zprime = contract(n10, v)
+@test z == zprime
+@test z == 9*ones(Float64, nv(g10))
+
+
 @test_approx_eq_eps(adjacency_spectrum(g5)[3],0.311, 0.001)
 
 @test adjacency_matrix(g3) ==


### PR DESCRIPTION
Edge(j,i) should have i < j for unsorted edges this lead to OutOfBounds error.
Added simple tests to make sure this behavior is tested.

Closes #422