### PR TITLE
temp fix while Push-relabel is buggy

### DIFF
--- a/src/flow/maximum_flow.jl
+++ b/src/flow/maximum_flow.jl
@@ -175,7 +175,9 @@ function maximum_flow{T<:Number}(
     capacity_matrix::AbstractArray{T,2} =  # edge flow capacities
         DefaultCapacity(flow_graph);
     algorithm::AbstractFlowAlgorithm  =    # keyword argument for algorithm
-        PushRelabelAlgorithm(),
+    # TODO: reverse to the line below after PushRelabelAlgorithm fix
+        # PushRelabelAlgorithm(),
+        EdmondsKarpAlgorithm(),
     restriction::T = zero(T)               # keyword argument for restriction max-flow
     )
     if restriction > zero(T)


### PR DESCRIPTION
Just a temp fix for calling Edmond-Karp instead of Push-Relabel in the multiroute-flow algorithm
Also include a slight improvement for the extended-multiroute-flow algorithm.

A PR on LightGraphsExtras will follow soon.

EDIT: #438 for reference purpose