### PR TITLE
fixes #467, adds an assert for edge counts, and includes tests

### DIFF
--- a/src/LightGraphs.jl
+++ b/src/LightGraphs.jl
@@ -20,7 +20,8 @@ fadj, badj, in_edges, out_edges, has_vertex, has_edge, is_directed,
 nv, ne, add_edge!, rem_edge!, add_vertex!, add_vertices!,
 indegree, outdegree, degree, degree_histogram, density, Δ, δ,
 Δout, Δin, δout, δin, neighbors, in_neighbors, out_neighbors,
-common_neighbors, all_neighbors, has_self_loop, rem_vertex!,
+common_neighbors, all_neighbors, has_self_loops, num_self_loops,
+rem_vertex!,
 
 # distance
 eccentricity, diameter, periphery, radius, center,

--- a/src/connectivity.jl
+++ b/src/connectivity.jl
@@ -180,7 +180,7 @@ function period(g::DiGraph)
     !is_strongly_connected(g) && error("Graph must be strongly connected")
 
     # First check if there's a self loop
-    has_self_loop(g) && return 1
+    has_self_loops(g) && return 1
 
     g_bfs_tree  = bfs_tree(g,1)
     levels      = gdistances(g_bfs_tree,1)

--- a/src/core.jl
+++ b/src/core.jl
@@ -253,5 +253,11 @@ neighbors(g::SimpleGraph, v::Int) = out_neighbors(g, v)
 "Returns the neighbors common to vertices `u` and `v` in `g`."
 common_neighbors(g::SimpleGraph, u::Int, v::Int) = intersect(neighbors(g,u), neighbors(g,v))
 
+@deprecate has_self_loop has_self_loops
+
 "Returns true if `g` has any self loops."
-has_self_loop(g::SimpleGraph) = any(v->has_edge(g, v, v), vertices(g))
+
+has_self_loops(g::SimpleGraph) = any(v->has_edge(g, v, v), vertices(g))
+
+"Returns the number of self loops in `g`."
+num_self_loops(g::SimpleGraph) = sum(v->has_edge(g, v, v), vertices(g))

--- a/src/digraph.jl
+++ b/src/digraph.jl
@@ -50,7 +50,7 @@ end
 
 function DiGraph(g::Graph)
     h = DiGraph(nv(g))
-    h.ne = ne(g) * 2
+    h.ne = ne(g) * 2 - num_self_loops(g)
     h.fadjlist = deepcopy(fadj(g))
     h.badjlist = deepcopy(badj(g))
     return h

--- a/src/graph.jl
+++ b/src/graph.jl
@@ -43,10 +43,13 @@ function Graph(g::DiGraph)
                 edgect += 2     # this is a new edge only in badjlist
             else
                 edgect += 1     # this is an existing edge - we already have it
+                if i == j
+                    edgect += 1 # need to count self loops
+                end
             end
         end
     end
-
+    iseven(edgect) || throw(AssertionError("invalid edgect in graph creation - please file bug report"))
     return Graph(vertices(g), edgect ÷ 2, newfadj)
 end
 

--- a/test/core.jl
+++ b/test/core.jl
@@ -82,6 +82,8 @@ end
 @test common_neighbors(h, 2, 3) == [5]
 
 @test add_edge!(g, 1, 1)
+@test has_self_loops(g)
+@test num_self_loops(g) == 1
 @test !add_edge!(g, 1, 1)
 @test rem_edge!(g, 1, 1)
 @test !rem_edge!(g, 1, 1)


### PR DESCRIPTION
Fixes for creating graphs / digraphs from other graphs / digraphs with self-loops.

deprecates `has_self_loop` in favor of `has_self_loops`; adds `num_self_loops` to get an actual count.