### PR TITLE
Fix a small bug that popped with update to 5.0

### DIFF
--- a/src/flow/ext_multiroute_flow.jl
+++ b/src/flow/ext_multiroute_flow.jl
@@ -181,7 +181,13 @@ function slope{T<:AbstractFloat}(
   )
   slope = 0
   for e in edges(flow_graph)
-    if cut[dst(e)] - cut[src(e)] > 0 &&
+    ## Chain comparison to wether an edge cross the cut from the source side of
+    # the cut to the target side of the cut. Then the edge is selected iff the
+    # capacity of the edge is larger then the restriction argument.
+    # cut[dst(e)] == 2 > cut[src(e)] is equivalent to
+    # cut[dst(e)] == 2 && 2 > cut[src(e)]
+    # Description of chain comparisons can be found at https://goo.gl/IJpCqe
+    if cut[dst(e)] == 2 > cut[src(e)] &&
       capacity_matrix[src(e), dst(e)] > restriction
         slope += 1
     end


### PR DESCRIPTION
I corrected a small bug popping from the update to 5.0 in the multiroute flow computation.

The bug popped because I coded lazily some condition in a if-else statement ... Not because of some breaking changes in LightGraphs :) 