### PR TITLE
Fix example with distmx in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ dijkstra_shortest_paths(g, 4).dists
 distmx = zeros(10,10)
 distmx[4,5] = 2.5
 distmx[5,4] = 2.5
-dijkstra_shortest_paths(g, 4, distmx=distmx).dists
+dijkstra_shortest_paths(g, 4, distmx).dists
 
 # graph I/O
 g = loadgraph("mygraph.jgz", :lg)


### PR DESCRIPTION
This fixes the example with `dijkstra_shortest_paths`, distmx is a positional parameter, not a keyword argument.