### PR TITLE
Faster and less memory hungry version of gdistances

### DIFF
--- a/src/traversals/bfs.jl
+++ b/src/traversals/bfs.jl
@@ -248,7 +248,7 @@ Fills `dists` with the geodesic distances of vertices in `g` from vertex/vertice
 function gdistances!(g::SimpleGraph, source, dists)
     n = nv(g)
     fill!(dists, -1)
-    queue = fill(-1, n)
+    queue = Vector{Int}(n)
     for i in 1:length(source)
         queue[i] = source[i]
         dists[source[i]] = 0

--- a/test/traversals/bfs.jl
+++ b/test/traversals/bfs.jl
@@ -10,6 +10,7 @@ t = visitor.tree
 
 @test gdistances(g6, 2) == [1, 0, 2, 1, 2]
 @test gdistances(g6, [1,2]) == [0, 0, 1, 1, 2]
+@test gdistances(g6, []) == [-1, -1, -1, -1, -1]
 @test !is_bipartite(g6)
 @test !is_bipartite(g6, 2)
 


### PR DESCRIPTION
#495 Here is the proposed code. I have moved the definitions to the end of the file as they use custom BFS implemenation.

Here is the performance testing code I used:
```
g = smallgraph(:tutte)
println("tutte 3")
@time a = gdistances(g,3);

srand(1)
for i in 0:5
    g = watts_strogatz(20000, 100, 0.5)
    vl = sample(1:100, 5i, replace=false)
    println("Watts-Strogatz ", vl)
    @time a = gdistances(g,vl);
end
```

It seems to use less time and memory than the current implementation. I have also updated tests for a corner case of emply `source` collection.