### PR TITLE
use EzXML instead of LightXML to avoid memory leak

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,6 +1,6 @@
 julia 0.5-
 GZip 0.2.20
-LightXML 0.4.0
+EzXML 0.3.0
 ParserCombinator 1.7.11
 JLD 0.6.3
 Distributions 0.10.2

--- a/src/LightGraphs.jl
+++ b/src/LightGraphs.jl
@@ -4,7 +4,7 @@ module LightGraphs
 using GZip
 using Distributions: Binomial
 using Base.Collections
-using LightXML
+using EzXML
 using ParserCombinator: Parsers.DOT, Parsers.GML
 using StatsBase: fit, Histogram
 

--- a/src/persistence/gexf.jl
+++ b/src/persistence/gexf.jl
@@ -12,36 +12,35 @@ Returns 1 (number of graphs written).
 """
 function savegexf(f::IO, g::SimpleGraph, gname::String)
     xdoc = XMLDocument()
-    xroot = create_root(xdoc, "gexf")
-    set_attribute(xroot,"xmlns","http://www.gexf.net/1.2draft")
-    set_attribute(xroot,"version","1.2")
-    set_attribute(xroot,"xmlns:xsi","http://www.w3.org/2001/XMLSchema-instance")
-    set_attribute(xroot,"xsi:schemaLocation","http://www.gexf.net/1.2draft/gexf.xsd")
+    xroot = setroot!(xdoc, ElementNode("gexf"))
+    xroot["xmlns"] = "http://www.gexf.net/1.2draft"
+    xroot["version"] = "1.2"
+    xroot["xmlns:xsi"] = "http://www.w3.org/2001/XMLSchema-instance"
+    xroot["xsi:schemaLocation"] = "http://www.gexf.net/1.2draft/gexf.xsd"
 
-    xmeta = new_child(xroot, "meta")
-    xdesc = new_child(xmeta, "description")
-    add_text(xdesc, gname)
-    xg = new_child(xroot, "graph")
+    xmeta = addelement!(xroot, "meta")
+    addelement!(xmeta, "description", gname)
+    xg = addelement!(xroot, "graph")
     strdir = is_directed(g) ? "directed" : "undirected"
-    set_attribute(xg,"defaultedgetype",strdir)
+    xg["defaultedgetype"] = strdir
 
-    xnodes = new_child(xg, "nodes")
-    for i=1:nv(g)
-        xv = new_child(xnodes, "node")
-        set_attribute(xv,"id","$(i-1)")
+    xnodes = addelement!(xg, "nodes")
+    for i in 1:nv(g)
+        xv = addelement!(xnodes, "node")
+        xv["id"] = "$(i-1)"
     end
 
-    xedges = new_child(xg, "edges")
-    m=0
+    xedges = addelement!(xg, "edges")
+    m = 0
     for e in edges(g)
-        xe = new_child(xedges, "edge")
-        set_attribute(xe,"id","$m")
-        set_attribute(xe,"source","$(src(e)-1)")
-        set_attribute(xe,"target","$(dst(e)-1)")
-        m+=1
+        xe = addelement!(xedges, "edge")
+        xe["id"] = "$m"
+        xe["source"] = "$(src(e)-1)"
+        xe["target"] = "$(dst(e)-1)"
+        m += 1
     end
 
-    show(f, xdoc)
+    prettyprint(f, xdoc)
     return 1
 end
 


### PR DESCRIPTION
Hi,

I found loading graphs from GraphML causes memory leak. The following code demonstrates the behavior:
```julia
using LightGraphs
using ProgressMeter

function loop(N)
    @showprogress for n in 1:N
        loadgraph("test.graphml", :graphml)
    end
end

loop(100_000)
```

test.graphml:
```
<?xml version="1.0" encoding="UTF-8"?>
<graphml xmlns="http://graphml.graphdrawing.org/xmlns" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd">
  <graph id="graph" edgedefault="undirected">
    <node id="n0"/>
    <node id="n1"/>
    <node id="n2"/>
    <node id="n3"/>
    <edge id="e0" source="n0" target="n1"/>
    <edge id="e1" source="n1" target="n2"/>
    <edge id="e2" source="n2" target="n3"/>
  </graph>
</graphml>
```

Seeing the process using `top` the memory usage continues to increase with no limit (on my laptop, the script above reached ~900MB). This is because LightXML.jl doesn't release allocated memory automatically, and as it reads XML files it accumulates temporary XML documents in memory.

An easy way to avoid the problem is deallocating XML documents by hand. However, I thought it would be easier and more reliable to use [EzXML.jl](https://github.com/bicycle1885/EzXML.jl), which automatically releases unreachable XML documents using Julia's garbage collector. EzXMl.jl is still a young package, but I believe it is much easier than LightXML.jl.

With this change the memory usage is stable around ~200MB on my laptop. So, I think the problem have been solved.