### PR TITLE
Added an `oriented` keyword argument to incidence_matrix

### DIFF
--- a/src/linalg/spectral.jl
+++ b/src/linalg/spectral.jl
@@ -101,9 +101,10 @@ adjacency_spectrum(g::DiGraph, dir::Symbol=:both, T::DataType=Int) = eigvals(ful
 `[v, i]`, where `i` is in `1:ne(g)`, indexing an edge `e`. For
 directed graphs, a value of `-1` indicates that `src(e) == v`, while a
 value of `1` indicates that `dst(e) == v`. Otherwise, the value is
-`0`. For undirected graphs, both entries are `1`.
+`0`. For undirected graphs, if the optional keyword `oriented` is `false`, 
+both entries are `1`, otherwise, a random orientation is chosen.
 """
-function incidence_matrix(g::SimpleGraph, T::DataType=Int)
+function incidence_matrix(g::SimpleGraph, T::DataType=Int; oriented=false)
     isdir = is_directed(g)
     n_v = nv(g)
     n_e = ne(g)
@@ -111,7 +112,7 @@ function incidence_matrix(g::SimpleGraph, T::DataType=Int)
 
     # every col has the same 2 entries
     colpt = collect(1:2:(nz + 1))
-    nzval = repmat([isdir ? -one(T) : one(T), one(T)], n_e)
+    nzval = repmat([(isdir || oriented) ? -one(T) : one(T), one(T)], n_e)
 
     # iterate over edges for row indices
     rowval = zeros(Int, nz)

--- a/src/linalg/spectral.jl
+++ b/src/linalg/spectral.jl
@@ -102,7 +102,7 @@ adjacency_spectrum(g::DiGraph, dir::Symbol=:both, T::DataType=Int) = eigvals(ful
 directed graphs, a value of `-1` indicates that `src(e) == v`, while a
 value of `1` indicates that `dst(e) == v`. Otherwise, the value is
 `0`. For undirected graphs, if the optional keyword `oriented` is `false`, 
-both entries are `1`, otherwise, a random orientation is chosen.
+both entries are `1`, otherwise, an arbitrary orientation is chosen.
 """
 function incidence_matrix(g::SimpleGraph, T::DataType=Int; oriented=false)
     isdir = is_directed(g)

--- a/test/linalg/spectral.jl
+++ b/test/linalg/spectral.jl
@@ -81,6 +81,12 @@ end
 @test incidence_matrix(g3)[2,1] == 1
 @test incidence_matrix(g3)[3,1] == 0
 
+# undirected graph with orientation
+@test size(incidence_matrix(g3; oriented=true)) == (5,4)
+@test incidence_matrix(g3; oriented=true)[1,1] == -1
+@test incidence_matrix(g3; oriented=true)[2,1] == 1
+@test incidence_matrix(g3; oriented=true)[3,1] == 0
+
 # TESTS FOR Nonbacktracking operator.
 
 n = 10; k = 5


### PR DESCRIPTION
Often even for undirected graphs, it is necessary to work with an oriented incidence matrix,
where an orientation has been randomly chosen. This is the case, e.g., when working
with potentials and flows on transport networks.
NetworkX has this functionality as well.
I have added a keyword argument to the incidence_matrix function that allows for creating
an oriented incidence matrix even for undirected graphs.