### PR TITLE
[WIP] Exploring multithreading

### DIFF
--- a/bench/threads.jl
+++ b/bench/threads.jl
@@ -1,0 +1,59 @@
+using LightGraphs
+using BenchmarkTools
+@show Threads.nthreads()
+
+function vertex_function(g::Graph, i::Int)
+    a = 0
+    for u in neighbors(g, i)
+        a += degree(g, u)
+    end
+    return a
+end
+
+function twohop(g::Graph, i::Int)
+    a = 0
+    for u in neighbors(g, i)
+        for v in neighbors(g, u)
+            a += degree(g,v)
+        end
+    end
+    return a
+end
+
+
+function mapvertices(f, g::Graph)
+    n = nv(g)
+    a = zeros(Int, n)
+    Threads.@threads for i in 1:n
+        a[i] = f(g, i)
+    end
+    return a
+end
+
+function mapvertices_single(f, g)
+    n = nv(g)
+    a = zeros(Int, n)
+    for i in 1:n
+        a[i] = f(g, i)
+    end
+    return a
+end
+
+nv_ = 10000
+g = Graph(nv_, 64*nv_)
+f = vertex_function
+println(g)
+
+function comparison(f, g)
+  println("Mulithreaded on $(Threads.nthreads())")
+  b1 =  @benchmark mapvertices($f, $g)
+  println(b1)
+
+  println("singlethreaded")
+  b2 = @benchmark mapvertices_single($f, $g)
+  println(b2)
+  println("done")
+end
+
+comparison(vertex_function, g)
+comparison(twohop, g)


### PR DESCRIPTION
For some simple forall vertices operations by just slapping `Threads.@threads` on some loops we get a performance increase. On my 4 core with hyperthreading desktop I see some preliminary numbers. We also see that there is no significant penalty to using serial code with multiple threads running, which is good to know for benchmarking.

Multithreaded Performance
```
> julia5                                                                                  /h/j/./v/LightGraphs (git)-[multithreaded] 
               _
   _       _ _(_)_     |  A fresh approach to technical computing
  (_)     | (_) (_)    |  Documentation: http://docs.julialang.org
   _ _   _| |_  __ _   |  Type "?help" for help.
  | | | | | | |/ _` |  |
  | | |_| | | | (_| |  |  Version 0.5.0 (2016-09-19 18:14 UTC)
 _/ |\__'_|_|_|\__'_|  |  Official http://julialang.org/ release
|__/                   |  x86_64-pc-linux-gnu

julia> include("bench/threads.jl")
Threads.nthreads() = 8
{10000, 640000} undirected graph
Mulithreaded on 8
BenchmarkTools.Trial: 
  memory estimate:  78.27 kb
  allocs estimate:  4
  --------------
  minimum time:     1.026 ms (0.00% GC)
  median time:      1.042 ms (0.00% GC)
  mean time:        1.066 ms (0.15% GC)
  maximum time:     5.453 ms (0.00% GC)
  --------------
  samples:          4679
  evals/sample:     1
  time tolerance:   5.00%
  memory tolerance: 1.00%
singlethreaded
BenchmarkTools.Trial: 
  memory estimate:  78.20 kb
  allocs estimate:  2
  --------------
  minimum time:     4.347 ms (0.00% GC)
  median time:      4.921 ms (0.00% GC)
  mean time:        5.031 ms (0.02% GC)
  maximum time:     7.979 ms (0.00% GC)
  --------------
  samples:          994
  evals/sample:     1
  time tolerance:   5.00%
  memory tolerance: 1.00%
done
Mulithreaded on 8
BenchmarkTools.Trial: 
  memory estimate:  78.27 kb
  allocs estimate:  4
  --------------
  minimum time:     117.327 ms (0.00% GC)
  median time:      125.244 ms (0.00% GC)
  mean time:        123.913 ms (0.00% GC)
  maximum time:     141.142 ms (0.00% GC)
  --------------
  samples:          41
  evals/sample:     1
  time tolerance:   5.00%
  memory tolerance: 1.00%
singlethreaded
BenchmarkTools.Trial: 
  memory estimate:  78.20 kb
  allocs estimate:  2
  --------------
  minimum time:     537.295 ms (0.00% GC)
  median time:      542.169 ms (0.00% GC)
  mean time:        549.106 ms (0.00% GC)
  maximum time:     578.701 ms (0.00% GC)
  --------------
  samples:          10
  evals/sample:     1
  time tolerance:   5.00%
  memory tolerance: 1.00%
done
```


Single Threaded performance

```
Mulithreaded on 1
BenchmarkTools.Trial: 
  memory estimate:  78.27 kb
  allocs estimate:  4
  --------------
  minimum time:     4.355 ms (0.00% GC)
  median time:      4.657 ms (0.00% GC)
  mean time:        4.693 ms (0.02% GC)
  maximum time:     5.815 ms (0.00% GC)
  --------------
  samples:          1065
  evals/sample:     1
  time tolerance:   5.00%
  memory tolerance: 1.00%
singlethreaded
BenchmarkTools.Trial: 
  memory estimate:  78.20 kb
  allocs estimate:  2
  --------------
  minimum time:     4.292 ms (0.00% GC)
  median time:      4.578 ms (0.00% GC)
  mean time:        4.862 ms (0.02% GC)
  maximum time:     6.988 ms (0.00% GC)
  --------------
  samples:          1028
  evals/sample:     1
  time tolerance:   5.00%
  memory tolerance: 1.00%
done
Mulithreaded on 1
BenchmarkTools.Trial: 
  memory estimate:  78.27 kb
  allocs estimate:  4
  --------------
  minimum time:     532.159 ms (0.00% GC)
  median time:      534.958 ms (0.00% GC)
  mean time:        547.245 ms (0.00% GC)
  maximum time:     648.957 ms (0.00% GC)
  --------------
  samples:          10
  evals/sample:     1
  time tolerance:   5.00%
  memory tolerance: 1.00%
singlethreaded
BenchmarkTools.Trial: 
  memory estimate:  78.20 kb
  allocs estimate:  2
  --------------
  minimum time:     530.374 ms (0.00% GC)
  median time:      533.482 ms (0.00% GC)
  mean time:        533.046 ms (0.00% GC)
  maximum time:     535.245 ms (0.00% GC)
  --------------
  samples:          10
  evals/sample:     1
  time tolerance:   5.00%
  memory tolerance: 1.00%
done
```