### PR TITLE
betweenness_centrality can now take specific vertices

### DIFF
--- a/src/centrality/betweenness.jl
+++ b/src/centrality/betweenness.jl
@@ -46,19 +46,15 @@ betweenness: Array{Float64}
 """
 function betweenness_centrality(
     g::SimpleGraph,
-    k::Integer=0;
+    nodes::AbstractArray{Int, 1} = vertices(g);
     normalize=true,
     endpoints=false)
 
     n_v = nv(g)
+    k = length(nodes)
     isdir = is_directed(g)
 
     betweenness = zeros(n_v)
-    if k == 0
-        nodes = 1:n_v
-    else
-        nodes = sample!([1:n_v;], k)   #112
-    end
     for s in nodes
         if degree(g,s) > 0  # this might be 1?
             state = dijkstra_shortest_paths(g, s; allpaths=true)
@@ -78,6 +74,10 @@ function betweenness_centrality(
 
     return betweenness
 end
+
+betweenness_centrality(g::SimpleGraph, k::Int; normalize=true, endpoints=false) =
+    betweenness_centrality(g, sample(vertices(g), k); normalize=normalize, endpoints=endpoints)
+
 
 
 function _accumulate_basic!(

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -23,4 +23,11 @@ end
 
 sample!(a::AbstractArray, k::Integer; exclude = ()) = sample!(getRNG(), a, k; exclude = exclude)
 
+"""
+sample([rng,] r, k; exclude = ())
+Sample `k` element from unit range `r` without repetition and eventually excluding elements in `exclude`.
+Unlike `sample!`, does not produce side effects.
+"""
+sample(a::UnitRange, k::Integer; exclude = ()) = sample!(getRNG(), collect(a), k; exclude = exclude)
+
 getRNG(seed::Integer = -1) = seed >= 0 ? MersenneTwister(seed) : Base.Random.GLOBAL_RNG

--- a/test/centrality/betweenness.jl
+++ b/test/centrality/betweenness.jl
@@ -19,6 +19,7 @@ z = betweenness_centrality(g)
 y = betweenness_centrality(g, endpoints=true, normalize=false)
 @test round(y[1:3],4) ==
     round([122.10760591498584, 159.0072453120582, 176.39547945994505], 4)
+
 x = betweenness_centrality(g,3)
 @test length(x) == 50
 
@@ -29,6 +30,11 @@ g = Graph(2)
 add_edge!(g,1,2)
 z = betweenness_centrality(g; normalize=true)
 @test z[1] == z[2] == 0.0
+z2 = betweenness_centrality(g, vertices(g))
+z3 = betweenness_centrality(g, [vertices(g);])
+
+@test z == z2 == z3
+
 
 z = betweenness_centrality(g3; normalize=false)
 @test z[1] == z[5] == 0.0

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -6,6 +6,12 @@ end
 
 s = LightGraphs.sample!([1:10;], 6, exclude=[1,2])
 @test length(s) == 6
-for  e in s
+for e in s
+    @test 3 <= e <= 10
+end
+
+s = LightGraphs.sample(1:10, 6, exclude=[1,2])
+@test length(s) == 6
+for e in s
     @test 3 <= e <= 10
 end


### PR DESCRIPTION
as well as randomly-selected ones. This is good for approximation tests.