### PR TITLE
Replace SimpleGraph by AbstractGraph everywhere

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,12 +35,12 @@ end
 ```
 should be rewritten as two functions
 ```julia
-function f(g::SimpleGraph, v::Integer)
+function f(g::AbstractGraph, v::Integer)
     storage = Vector{Int}(nv(g))
     return inner!(storage, g, v)
 end
 
-function inner!(storage::AbstractArray{Int,1}, g::SimpleGraph, v::Integer)
+function inner!(storage::AbstractArray{Int,1}, g::AbstractGraph, v::Integer)
     # some code operating on storage, g, and v.
     for i in 1:nv(g)
         storage[i] = v-i

--- a/src/LightGraphs.jl
+++ b/src/LightGraphs.jl
@@ -15,7 +15,7 @@ import Base: write, ==, <, *, ≈, isless, issubset, union, intersect,
 
 
 # core
-export SimpleGraph, Edge, Graph, DiGraph, vertices, edges, src, dst,
+export AbstractGraph, Edge, Graph, DiGraph, vertices, edges, src, dst,
 fadj, badj, in_edges, out_edges, has_vertex, has_edge, is_directed,
 nv, ne, add_edge!, rem_edge!, add_vertex!, add_vertices!,
 indegree, outdegree, degree, degree_histogram, density, Δ, δ,
@@ -39,7 +39,7 @@ join, tensor_product, cartesian_product, crosspath,
 induced_subgraph, egonet,
 
 # graph visit
-SimpleGraphVisitor, TrivialGraphVisitor, LogGraphVisitor,
+AbstractGraphVisitor, TrivialGraphVisitor, LogGraphVisitor,
 discover_vertex!, open_vertex!, close_vertex!,
 examine_neighbor!, visited_vertices, traverse_graph!, traverse_graph_withlog,
 

--- a/src/biconnectivity/articulation.jl
+++ b/src/biconnectivity/articulation.jl
@@ -2,7 +2,7 @@
 Computes the articulation points(https://en.wikipedia.org/wiki/Biconnected_component)
 of a connected graph `g` and returns an array containing all cut vertices.
 """
-function articulation(g::SimpleGraph) :: AbstractArray{Int}
+function articulation(g::AbstractGraph) :: AbstractArray{Int}
     state = Articulations(g)
     for u in vertices(g)
         if state.depth[u] == 0
@@ -22,7 +22,7 @@ type Articulations
     id::Int
 end
 
-function Articulations(g::SimpleGraph)
+function Articulations(g::AbstractGraph)
     n = nv(g)
     return Articulations(zeros(Int, n), zeros(Int, n),zeros(Int, n), 0)
 end
@@ -31,7 +31,7 @@ end
 Does a depth first search storing the depth (in `depth`) and low-points (in `low`) of each vertex.
 Call this function repeatedly to complete the DFS see `articulation` for usage.
 """
-function visit!(state::Articulations, g::SimpleGraph, u::Int, v::Int)
+function visit!(state::Articulations, g::AbstractGraph, u::Int, v::Int)
     children = 0
     state.id += 1
     state.depth[v] = state.id

--- a/src/biconnectivity/biconnect.jl
+++ b/src/biconnectivity/biconnect.jl
@@ -9,7 +9,7 @@ type Biconnections
     id::Int
 end
 
-function Biconnections(g::SimpleGraph)
+function Biconnections(g::AbstractGraph)
     n = nv(g)
     return Biconnections(zeros(Int, n), zeros(Int, n), Vector{Edge}(), Vector{Vector{Edge}}(), 0)
 end

--- a/src/centrality/betweenness.jl
+++ b/src/centrality/betweenness.jl
@@ -18,7 +18,7 @@ $bc(v) = \frac{1}{\mathcal{N}} \sum_{s \neq t \neq v}
 
  **Parameters**
 
-g: SimpleGraph
+g: AbstractGraph
     A Graph, directed or undirected.
 
 k: Integer, optional
@@ -45,7 +45,7 @@ betweenness: Array{Float64}
 [1] Brandes 2001 & Brandes 2008
 """
 function betweenness_centrality(
-    g::SimpleGraph,
+    g::AbstractGraph,
     nodes::AbstractArray{Int, 1} = vertices(g);
     normalize=true,
     endpoints=false)
@@ -75,7 +75,7 @@ function betweenness_centrality(
     return betweenness
 end
 
-betweenness_centrality(g::SimpleGraph, k::Int; normalize=true, endpoints=false) =
+betweenness_centrality(g::AbstractGraph, k::Int; normalize=true, endpoints=false) =
     betweenness_centrality(g, sample(vertices(g), k); normalize=normalize, endpoints=endpoints)
 
 
@@ -83,7 +83,7 @@ betweenness_centrality(g::SimpleGraph, k::Int; normalize=true, endpoints=false) 
 function _accumulate_basic!(
     betweenness::Vector{Float64},
     state::DijkstraState,
-    g::SimpleGraph,
+    g::AbstractGraph,
     si::Integer
     )
 
@@ -114,7 +114,7 @@ end
 function _accumulate_endpoints!(
     betweenness::Vector{Float64},
     state::DijkstraState,
-    g::SimpleGraph,
+    g::AbstractGraph,
     si::Integer
     )
 

--- a/src/centrality/closeness.jl
+++ b/src/centrality/closeness.jl
@@ -2,7 +2,7 @@
 of the graph `g`.
 """
 function closeness_centrality(
-    g::SimpleGraph;
+    g::AbstractGraph;
     normalize=true)
 
     n_v = nv(g)

--- a/src/centrality/degree.jl
+++ b/src/centrality/degree.jl
@@ -1,4 +1,4 @@
-function _degree_centrality(g::SimpleGraph, gtype::Integer; normalize=true)
+function _degree_centrality(g::AbstractGraph, gtype::Integer; normalize=true)
    n_v = nv(g)
    c = zeros(n_v)
    for v in 1:n_v
@@ -18,10 +18,10 @@ end
 # TODO avoid repetition of this docstring
 """Calculates the [degree centrality](https://en.wikipedia.org/wiki/Centrality#Degree_centrality)
 of the graph `g`, with optional (default) normalization."""
-degree_centrality(g::SimpleGraph; all...) = _degree_centrality(g, 0; all...)
+degree_centrality(g::AbstractGraph; all...) = _degree_centrality(g, 0; all...)
 """Calculates the [degree centrality](https://en.wikipedia.org/wiki/Centrality#Degree_centrality)
 of the graph `g`, with optional (default) normalization."""
-indegree_centrality(g::SimpleGraph; all...) = _degree_centrality(g, 1; all...)
+indegree_centrality(g::AbstractGraph; all...) = _degree_centrality(g, 1; all...)
 """Calculates the [degree centrality](https://en.wikipedia.org/wiki/Centrality#Degree_centrality)
 of the graph `g`, with optional (default) normalization."""
-outdegree_centrality(g::SimpleGraph; all...) = _degree_centrality(g, 2; all...)
+outdegree_centrality(g::AbstractGraph; all...) = _degree_centrality(g, 2; all...)

--- a/src/centrality/katz.jl
+++ b/src/centrality/katz.jl
@@ -24,7 +24,7 @@
 """Calculates the [Katz centrality](https://en.wikipedia.org/wiki/Katz_centrality)
 of the graph `g`.
 """
-function katz_centrality(g::SimpleGraph, α::Real = 0.3)
+function katz_centrality(g::AbstractGraph, α::Real = 0.3)
     nvg = nv(g)
     v = ones(Float64, nvg)
     spI = speye(Float64, nvg)

--- a/src/community/clustering.jl
+++ b/src/community/clustering.jl
@@ -3,7 +3,7 @@
 
 Computes the [local clustering coefficient](https://en.wikipedia.org/wiki/Clustering_coefficient) for node `v`.
 """
-function local_clustering_coefficient(g::SimpleGraph, v::Integer)
+function local_clustering_coefficient(g::AbstractGraph, v::Integer)
     ntriang, alltriang = local_clustering(g, v)
 
     return alltriang == 0 ? 0. : ntriang / alltriang
@@ -16,7 +16,7 @@ Returns a tuple `(a,b)`, where `a` is the number of triangles in the neighborhoo
 `v` and `b` is the maximum number of possible triangles.
 It is related to the local clustering coefficient  by `r=a/b`.
 """
-function local_clustering(g::SimpleGraph, v::Integer)
+function local_clustering(g::AbstractGraph, v::Integer)
     k = degree(g, v)
     k <= 1 && return (0, 0)
     neighs = neighbors(g, v)
@@ -37,7 +37,7 @@ end
 
 Returns the number of triangles in the neighborhood for node `v`.
 """
-triangles(g::SimpleGraph, v::Integer) = local_clustering(g, v)[1]
+triangles(g::AbstractGraph, v::Integer) = local_clustering(g, v)[1]
 
 
 """
@@ -45,7 +45,7 @@ triangles(g::SimpleGraph, v::Integer) = local_clustering(g, v)[1]
 
 Returns a vector containing  the [local clustering coefficients](https://en.wikipedia.org/wiki/Clustering_coefficient) for vertices `vlist`.
 """
-local_clustering_coefficient(g::SimpleGraph, vlist = vertices(g)) = Float64[local_clustering_coefficient(g, v) for v in vlist]
+local_clustering_coefficient(g::AbstractGraph, vlist = vertices(g)) = Float64[local_clustering_coefficient(g, v) for v in vlist]
 
 """
     local_clustering(g, vlist = vertices(g))
@@ -53,7 +53,7 @@ local_clustering_coefficient(g::SimpleGraph, vlist = vertices(g)) = Float64[loca
 Returns two vectors, respectively containing  the first and second result of `local_clustering_coefficients(g, v)`
 for each `v` in `vlist`.
 """
-function local_clustering(g::SimpleGraph, vlist = vertices(g))
+function local_clustering(g::AbstractGraph, vlist = vertices(g))
     ntriang = zeros(Int, length(vlist))
     nalltriang = zeros(Int, length(vlist))
     i = 0
@@ -69,7 +69,7 @@ end
 
 Returns a vector containing the number of triangles for vertices `vlist`.
 """
-triangles(g::SimpleGraph, vlist = vertices(g)) = local_clustering(g, vlist)[1]
+triangles(g::AbstractGraph, vlist = vertices(g)) = local_clustering(g, vlist)[1]
 
 
 """
@@ -77,7 +77,7 @@ triangles(g::SimpleGraph, vlist = vertices(g)) = local_clustering(g, vlist)[1]
 
 Computes the [global clustering coefficient](https://en.wikipedia.org/wiki/Clustering_coefficient).
 """
-function global_clustering_coefficient(g::SimpleGraph)
+function global_clustering_coefficient(g::AbstractGraph)
     c = 0
     ntriangles = 0
     for v in 1:nv(g)

--- a/src/community/label_propagation.jl
+++ b/src/community/label_propagation.jl
@@ -4,7 +4,7 @@ Community detection using the label propagation algorithm (see [Raghavan et al.]
 `maxiter`: maximum number of iterations
 return : vertex assignments and the convergence history
 """
-function label_propagation(g::SimpleGraph; maxiter=1000)
+function label_propagation(g::AbstractGraph; maxiter=1000)
     n = nv(g)
     label = collect(1:n)
     active_nodes = IntSet(vertices(g))
@@ -59,7 +59,7 @@ function range_shuffle!(r::UnitRange, a::AbstractVector)
 end
 
 """Return the most frequency label."""
-function vote!(g::SimpleGraph, m::Vector{Int}, c::NeighComm, u::Int)
+function vote!(g::AbstractGraph, m::Vector{Int}, c::NeighComm, u::Int)
     @inbounds for i=1:c.neigh_last-1
         c.neigh_cnt[c.neigh_pos[i]] = -1
     end

--- a/src/connectivity.jl
+++ b/src/connectivity.jl
@@ -3,7 +3,7 @@
 
 
 """
-    connected_components!(label::Vector{Int}, g::SimpleGraph)
+    connected_components!(label::Vector{Int}, g::AbstractGraph)
 
 Fills `label` with the `id` of the connected component to which it belongs.
 
@@ -14,7 +14,7 @@ Output:
     c = labels[i] => vertex i belongs to component c.
     c is the smallest vertex id in the component.
 """
-function connected_components!(label::Vector{Int}, g::SimpleGraph)
+function connected_components!(label::Vector{Int}, g::AbstractGraph)
     # this version of connected components uses Breadth First Traversal
     # with custom visitor type in order to improve performance.
     # one BFS is performed for each component.
@@ -88,7 +88,7 @@ Returns the [connected components](https://en.wikipedia.org/wiki/Connectivity_(g
 of `g` as a vector of components, each represented by a
 vector of vertices belonging to the component.
 """
-function connected_components(g::SimpleGraph)
+function connected_components(g::AbstractGraph)
     label = zeros(Int, nv(g))
     connected_components!(label, g)
     c, d = components(label)
@@ -111,7 +111,7 @@ weakly_connected_components(g::DiGraph) = connected_components(Graph(g))
 is_weakly_connected(g::DiGraph) = length(weakly_connected_components(g)) == 1
 
 # Adapated from Graphs.jl
-type TarjanVisitor <: SimpleGraphVisitor
+type TarjanVisitor <: AbstractGraphVisitor
     stack::Vector{Int}
     onstack::BitVector
     lowlink::Vector{Int}
@@ -241,7 +241,7 @@ function attracting_components(g::DiGraph)
     return scc[attracting]
 end
 
-type NeighborhoodVisitor <: SimpleGraphVisitor
+type NeighborhoodVisitor <: AbstractGraphVisitor
     d::Int
     neigs::Vector{Int}
 end
@@ -264,7 +264,7 @@ Returns a vector of the vertices in `g` at distance less or equal to `d`
 from `v`. If `g` is a `DiGraph` the `dir` optional argument specifies the edge direction
 the edge direction with respect to `v` (i.e. `:in` or `:out`) to be considered.
 """
-function neighborhood(g::SimpleGraph, v::Int, d::Int; dir=:out)
+function neighborhood(g::AbstractGraph, v::Int, d::Int; dir=:out)
     @assert d >= 0 "Distance has to be greater then zero."
     visitor = NeighborhoodVisitor(d)
     push!(visitor.neigs, v)

--- a/src/core.jl
+++ b/src/core.jl
@@ -17,31 +17,31 @@ dst(e::Edge) = e.second
 
 ==(e1::Edge, e2::Edge) = (e1.first == e2.first && e1.second == e2.second)
 
+"""An abstract type representing a graph."""
+abstract AbstractGraph
+
 """A type representing an undirected graph."""
-type Graph
+type Graph <: AbstractGraph
     vertices::UnitRange{Int}
     ne::Int
     fadjlist::Vector{Vector{Int}} # [src]: (dst, dst, dst)
 end
 
 """A type representing a directed graph."""
-type DiGraph
+type DiGraph <: AbstractGraph
     vertices::UnitRange{Int}
     ne::Int
     fadjlist::Vector{Vector{Int}} # [src]: (dst, dst, dst)
     badjlist::Vector{Vector{Int}} # [dst]: (src, src, src)
 end
 
-typealias SimpleGraph Union{Graph, DiGraph}
-
-
 """Return the vertices of a graph."""
-vertices(g::SimpleGraph) = g.vertices
+vertices(g::AbstractGraph) = g.vertices
 
 """Return an iterator to the edges of a graph.
 The returned iterator is valid for one pass over the edges, and is invalidated by changes to `g`.
 """
-edges(g::SimpleGraph) = EdgeIter(g)
+edges(g::AbstractGraph) = EdgeIter(g)
 
 """Returns the forward adjacency list of a graph.
 
@@ -62,11 +62,11 @@ The optional second argument take the `v`th vertex adjacency list, that is:
 
 NOTE: returns a reference, not a copy. Do not modify result.
 """
-fadj(g::SimpleGraph) = g.fadjlist
-fadj(g::SimpleGraph, v::Int) = g.fadjlist[v]
+fadj(g::AbstractGraph) = g.fadjlist
+fadj(g::AbstractGraph, v::Int) = g.fadjlist[v]
 
 """Returns true if all of the vertices and edges of `g` are contained in `h`."""
-function issubset{T<:SimpleGraph}(g::T, h::T)
+function issubset{T<:AbstractGraph}(g::T, h::T)
     (gmin, gmax) = extrema(vertices(g))
     (hmin, hmax) = extrema(vertices(h))
     return (hmin <= gmin <= gmax <= hmax) && issubset(edges(g), edges(h))
@@ -75,7 +75,7 @@ end
 
 """Add `n` new vertices to the graph `g`. Returns true if all vertices
 were added successfully, false otherwise."""
-function add_vertices!(g::SimpleGraph, n::Integer)
+function add_vertices!(g::AbstractGraph, n::Integer)
     added = true
     for i = 1:n
         added &= add_vertex!(g)
@@ -84,7 +84,7 @@ function add_vertices!(g::SimpleGraph, n::Integer)
 end
 
 """Return true if the graph `g` has an edge from `u` to `v`."""
-has_edge(g::SimpleGraph, u::Int, v::Int) = has_edge(g, Edge(u, v))
+has_edge(g::AbstractGraph, u::Int, v::Int) = has_edge(g, Edge(u, v))
 
 """
     in_edges(g, v)
@@ -92,7 +92,7 @@ has_edge(g::SimpleGraph, u::Int, v::Int) = has_edge(g, Edge(u, v))
 Returns an Array of the edges in `g` that arrive at vertex `v`.
 `v=dst(e)` for each returned edge `e`.
 """
-in_edges(g::SimpleGraph, v::Int) = [Edge(x,v) for x in badj(g, v)]
+in_edges(g::AbstractGraph, v::Int) = [Edge(x,v) for x in badj(g, v)]
 
 """
     out_edges(g, v)
@@ -100,24 +100,24 @@ in_edges(g::SimpleGraph, v::Int) = [Edge(x,v) for x in badj(g, v)]
 Returns an Array of the edges in `g` that depart from vertex `v`.
 `v = src(e)` for each returned edge `e`.
 """
-out_edges(g::SimpleGraph, v::Int) = [Edge(v,x) for x in fadj(g,v)]
+out_edges(g::AbstractGraph, v::Int) = [Edge(v,x) for x in fadj(g,v)]
 
 
 """Return true if `v` is a vertex of `g`."""
-has_vertex(g::SimpleGraph, v::Int) = v in vertices(g)
+has_vertex(g::AbstractGraph, v::Int) = v in vertices(g)
 
 """
     nv(g)
 
 The number of vertices in `g`.
 """
-nv(g::SimpleGraph) = length(vertices(g))
+nv(g::AbstractGraph) = length(vertices(g))
 """
     ne(g)
 
 The number of edges in `g`.
 """
-ne(g::SimpleGraph) = g.ne
+ne(g::AbstractGraph) = g.ne
 
 """
     add_edge!(g, u, v)
@@ -125,7 +125,7 @@ ne(g::SimpleGraph) = g.ne
 Add a new edge to `g` from `u` to `v`.
 Will return false if add fails (e.g., if vertices are not in the graph); true otherwise.
 """
-add_edge!(g::SimpleGraph, u::Int, v::Int) = add_edge!(g, Edge(u, v))
+add_edge!(g::AbstractGraph, u::Int, v::Int) = add_edge!(g, Edge(u, v))
 
 """
     rem_edge!(g, u, v)
@@ -134,7 +134,7 @@ Remove the edge from `u` to `v`.
 
 Returns false if edge removal fails (e.g., if edge does not exist); true otherwise.
 """
-rem_edge!(g::SimpleGraph, u::Int, v::Int) = rem_edge!(g, Edge(u, v))
+rem_edge!(g::AbstractGraph, u::Int, v::Int) = rem_edge!(g, Edge(u, v))
 
 """
     rem_vertex!(g, v)
@@ -147,7 +147,7 @@ After removal the vertices in the ` g` will be indexed by 1:n-1.
 This is an O(k^2) operation, where `k` is the max of the degrees of vertices `v` and `n`.
 Returns false if removal fails (e.g., if vertex is not in the graph); true otherwise.
 """
-function rem_vertex!(g::SimpleGraph, v::Int)
+function rem_vertex!(g::AbstractGraph, v::Int)
     v in vertices(g) || return false
     n = nv(g)
 
@@ -190,14 +190,14 @@ function rem_vertex!(g::SimpleGraph, v::Int)
 end
 
 """Return the number of edges which start at vertex `v`."""
-indegree(g::SimpleGraph, v::Int) = length(badj(g,v))
+indegree(g::AbstractGraph, v::Int) = length(badj(g,v))
 """Return the number of edges which end at vertex `v`."""
-outdegree(g::SimpleGraph, v::Int) = length(fadj(g,v))
+outdegree(g::AbstractGraph, v::Int) = length(fadj(g,v))
 
 
-indegree(g::SimpleGraph, v::AbstractArray{Int,1} = vertices(g)) = [indegree(g,x) for x in v]
-outdegree(g::SimpleGraph, v::AbstractArray{Int,1} = vertices(g)) = [outdegree(g,x) for x in v]
-degree(g::SimpleGraph, v::AbstractArray{Int,1} = vertices(g)) = [degree(g,x) for x in v]
+indegree(g::AbstractGraph, v::AbstractArray{Int,1} = vertices(g)) = [indegree(g,x) for x in v]
+outdegree(g::AbstractGraph, v::AbstractArray{Int,1} = vertices(g)) = [outdegree(g,x) for x in v]
+degree(g::AbstractGraph, v::AbstractArray{Int,1} = vertices(g)) = [degree(g,x) for x in v]
 
 "Return the maxium `outdegree` of vertices in `g`."
 Δout(g) = noallocextreme(outdegree,(>), typemin(Int), g)
@@ -229,18 +229,18 @@ end
 
 Returns a `StatsBase.Histogram` of the degrees of vertices in `g`.
 """
-degree_histogram(g::SimpleGraph) = fit(Histogram, degree(g))
+degree_histogram(g::AbstractGraph) = fit(Histogram, degree(g))
 
 """Returns a list of all neighbors connected to vertex `v` by an incoming edge.
 
 NOTE: returns a reference, not a copy. Do not modify result.
 """
-in_neighbors(g::SimpleGraph, v::Int) = badj(g,v)
+in_neighbors(g::AbstractGraph, v::Int) = badj(g,v)
 """Returns a list of all neighbors connected to vertex `v` by an outgoing edge.
 
 NOTE: returns a reference, not a copy. Do not modify result.
 """
-out_neighbors(g::SimpleGraph, v::Int) = fadj(g,v)
+out_neighbors(g::AbstractGraph, v::Int) = fadj(g,v)
 
 """Returns a list of all neighbors of vertex `v` in `g`.
 
@@ -248,16 +248,16 @@ For DiGraphs, this is equivalent to `out_neighbors(g, v)`.
 
 NOTE: returns a reference, not a copy. Do not modify result.
 """
-neighbors(g::SimpleGraph, v::Int) = out_neighbors(g, v)
+neighbors(g::AbstractGraph, v::Int) = out_neighbors(g, v)
 
 "Returns the neighbors common to vertices `u` and `v` in `g`."
-common_neighbors(g::SimpleGraph, u::Int, v::Int) = intersect(neighbors(g,u), neighbors(g,v))
+common_neighbors(g::AbstractGraph, u::Int, v::Int) = intersect(neighbors(g,u), neighbors(g,v))
 
 @deprecate has_self_loop has_self_loops
 
 "Returns true if `g` has any self loops."
 
-has_self_loops(g::SimpleGraph) = any(v->has_edge(g, v, v), vertices(g))
+has_self_loops(g::AbstractGraph) = any(v->has_edge(g, v, v), vertices(g))
 
 "Returns the number of self loops in `g`."
-num_self_loops(g::SimpleGraph) = sum(v->has_edge(g, v, v), vertices(g))
+num_self_loops(g::AbstractGraph) = sum(v->has_edge(g, v, v), vertices(g))

--- a/src/distance.jl
+++ b/src/distance.jl
@@ -34,7 +34,7 @@ for each call to the function. It may therefore be more efficient to calculate,
 store, and pass the eccentricities if multiple distance measures are desired.
 """
 function eccentricity{T}(
-    g::SimpleGraph,
+    g::AbstractGraph,
     v::Int,
     distmx::AbstractArray{T, 2} = DefaultDistance()
 )
@@ -45,18 +45,18 @@ function eccentricity{T}(
 end
 
 eccentricity{T}(
-    g::SimpleGraph,
+    g::AbstractGraph,
     vs::AbstractArray{Int, 1}=vertices(g),
     distmx::AbstractArray{T, 2} = DefaultDistance()
 ) =
     [eccentricity(g,v,distmx) for v in vs]
 
-eccentricity{T}(g::SimpleGraph, distmx::AbstractArray{T, 2}) =
+eccentricity{T}(g::AbstractGraph, distmx::AbstractArray{T, 2}) =
     eccentricity(g, vertices(g), distmx)
 
 """Returns the maximum eccentricity of the graph."""
 diameter{T}(all_e::Vector{T}) = maximum(all_e)
-diameter{T}(g::SimpleGraph, distmx::AbstractArray{T, 2} = DefaultDistance()) =
+diameter{T}(g::AbstractGraph, distmx::AbstractArray{T, 2} = DefaultDistance()) =
     maximum(eccentricity(g, distmx))
 
 """Returns the set of all vertices whose eccentricity is equal to the graph's
@@ -68,12 +68,12 @@ function periphery{T}(all_e::Vector{T})
     return filter((x)->all_e[x] == diam, 1:length(all_e))
 end
 
-periphery{T}(g::SimpleGraph, distmx::AbstractArray{T, 2} = DefaultDistance()) =
+periphery{T}(g::AbstractGraph, distmx::AbstractArray{T, 2} = DefaultDistance()) =
     periphery(eccentricity(g, distmx))
 
 """Returns the minimum eccentricity of the graph."""
 radius{T}(all_e::Vector{T}) = minimum(all_e)
-radius{T}(g::SimpleGraph, distmx::AbstractArray{T, 2} = DefaultDistance()) =
+radius{T}(g::AbstractGraph, distmx::AbstractArray{T, 2} = DefaultDistance()) =
     minimum(eccentricity(g, distmx))
 
 """Returns the set of all vertices whose eccentricity is equal to the graph's
@@ -84,5 +84,5 @@ function center{T}(all_e::Vector{T})
     return filter((x)->all_e[x] == rad, 1:length(all_e))
 end
 
-center{T}(g::SimpleGraph, distmx::AbstractArray{T, 2} = DefaultDistance()) =
+center{T}(g::AbstractGraph, distmx::AbstractArray{T, 2} = DefaultDistance()) =
     center(eccentricity(g, distmx))

--- a/src/edit_distance.jl
+++ b/src/edit_distance.jl
@@ -37,7 +37,7 @@ Distance: Approximation Algorithms and Applications. (Chapter 2)
 
 Author: Júlio Hoffimann Mendes (juliohm@stanford.edu)
 """
-function edit_distance(G₁::SimpleGraph, G₂::SimpleGraph;
+function edit_distance(G₁::AbstractGraph, G₂::AbstractGraph;
                        insert_cost::Function=v->1.0,
                        delete_cost::Function=u->1.0,
                        subst_cost::Function=(u,v)->0.5,
@@ -93,7 +93,7 @@ function is_complete_path(λ, G₁, G₂)
   return length(us) == nv(G₁) && length(vs) == nv(G₂)
 end
 
-function DefaultEditHeuristic(λ, G₁::SimpleGraph, G₂::SimpleGraph)
+function DefaultEditHeuristic(λ, G₁::AbstractGraph, G₂::AbstractGraph)
   vs = Set([v for (u,v) in λ])
   delete!(vs, 0)
 

--- a/src/generators/randgraphs.jl
+++ b/src/generators/randgraphs.jl
@@ -181,14 +181,14 @@ function barabasi_albert(n::Integer, n0::Integer, k::Integer; is_directed::Bool 
 end
 
 """
-    barabasi_albert!(g::SimpleGraph, n::Integer, k::Integer; seed::Int = -1)
+    barabasi_albert!(g::AbstractGraph, n::Integer, k::Integer; seed::Int = -1)
 
 Creates a [Barabási–Albert model](https://en.wikipedia.org/wiki/Barab%C3%A1si%E2%80%93Albert_model)
 random graph with `n` vertices. It is grown by adding new vertices to an initial
 graph `g`. Each new vertex is attached with `k` edges to `k` different vertices
 already present in the system by preferential attachment.
 """
-function barabasi_albert!(g::SimpleGraph, n::Integer, k::Integer; seed::Int=-1)
+function barabasi_albert!(g::AbstractGraph, n::Integer, k::Integer; seed::Int=-1)
     n0 = nv(g)
     1 <= k <= n0 <= n ||
         throw(ArgumentError("Barabási-Albert model requires 1 <= k <= n0 <= n" *
@@ -312,7 +312,7 @@ function static_fitness_model{T<:Real,S<:Real}(m::Int, fitness_out::Vector{T}, f
     return g
 end
 
-function _create_static_fitness_graph!{T<:Real,S<:Real}(g::SimpleGraph, m::Int, cum_fitness_out::Vector{T}, cum_fitness_in::Vector{S}, seed::Int)
+function _create_static_fitness_graph!{T<:Real,S<:Real}(g::AbstractGraph, m::Int, cum_fitness_out::Vector{T}, cum_fitness_in::Vector{S}, seed::Int)
     rng = getRNG(seed)
     max_out = cum_fitness_out[end]
     max_in = cum_fitness_in[end]
@@ -710,11 +710,11 @@ function blockcounts(sbm::StochasticBlockModel, A::AbstractMatrix)
 end
 
 
-function blockcounts(sbm::StochasticBlockModel, g::SimpleGraph)
+function blockcounts(sbm::StochasticBlockModel, g::AbstractGraph)
     return blockcounts(sbm, adjacency_matrix(g))
 end
 
-function blockfractions(sbm::StochasticBlockModel, g::Union{SimpleGraph, AbstractMatrix})
+function blockfractions(sbm::StochasticBlockModel, g::Union{AbstractGraph, AbstractMatrix})
     bc = blockcounts(sbm, g)
     bp = bc ./ sum(bc)
     return bp

--- a/src/linalg/nonbacktracking.jl
+++ b/src/linalg/nonbacktracking.jl
@@ -11,7 +11,7 @@ B[i->j, k->l] = δ(j,k)* (1 - δ(i,l))
 
 returns a matrix B, and an edgemap storing the oriented edges' positions in B
 """
-function non_backtracking_matrix(g::SimpleGraph)
+function non_backtracking_matrix(g::AbstractGraph)
     # idedgemap = Dict{Int, Edge}()
     edgeidmap = Dict{Edge, Int}()
     m = 0
@@ -67,7 +67,7 @@ type Nonbacktracking{G}
     m::Int
 end
 
-function Nonbacktracking(g::SimpleGraph)
+function Nonbacktracking(g::AbstractGraph)
     edgeidmap = Dict{Edge, Int}()
     m = 0
     for e in edges(g)

--- a/src/linalg/spectral.jl
+++ b/src/linalg/spectral.jl
@@ -14,7 +14,7 @@ matrix (defaults to `Int`).
 
 Note: This function is optimized for speed.
 """
-function adjacency_matrix(g::SimpleGraph, dir::Symbol=:out, T::DataType=Int)
+function adjacency_matrix(g::AbstractGraph, dir::Symbol=:out, T::DataType=Int)
     n_v = nv(g)
     nz = ne(g) * (is_directed(g)? 1 : 2)
     colpt = ones(Int, n_v + 1)
@@ -104,7 +104,7 @@ value of `1` indicates that `dst(e) == v`. Otherwise, the value is
 `0`. For undirected graphs, if the optional keyword `oriented` is `false`, 
 both entries are `1`, otherwise, an arbitrary orientation is chosen.
 """
-function incidence_matrix(g::SimpleGraph, T::DataType=Int; oriented=false)
+function incidence_matrix(g::AbstractGraph, T::DataType=Int; oriented=false)
     isdir = is_directed(g)
     n_v = nv(g)
     n_e = ne(g)

--- a/src/operators.jl
+++ b/src/operators.jl
@@ -66,7 +66,7 @@ edges.
 
 Put simply, the vertices and edges from graph `h` are appended to graph `g`.
 """
-function blkdiag{T<:SimpleGraph}(g::T, h::T)
+function blkdiag{T<:AbstractGraph}(g::T, h::T)
     gnv = nv(g)
     r = T(gnv + nv(h))
     for e in edges(g)
@@ -85,7 +85,7 @@ Produces a graph with edges that are only in both graph `g` and graph `h`.
 
 Note that this function may produce a graph with 0-degree vertices.
 """
-function intersect{T<:SimpleGraph}(g::T, h::T)
+function intersect{T<:AbstractGraph}(g::T, h::T)
     gnv = nv(g)
     hnv = nv(h)
 
@@ -103,7 +103,7 @@ Produces a graph with edges in graph `g` that are not in graph `h`.
 
 Note that this function may produce a graph with 0-degree vertices.
 """
-function difference{T<:SimpleGraph}(g::T, h::T)
+function difference{T<:AbstractGraph}(g::T, h::T)
     gnv = nv(g)
     hnv = nv(h)
 
@@ -122,7 +122,7 @@ and vice versa.
 
 Note that this function may produce a graph with 0-degree vertices.
 """
-function symmetric_difference{T<:SimpleGraph}(g::T, h::T)
+function symmetric_difference{T<:AbstractGraph}(g::T, h::T)
     gnv = nv(g)
     hnv = nv(h)
 
@@ -141,7 +141,7 @@ end
 
 Merges graphs `g` and `h` by taking the set union of all vertices and edges.
 """
-function union{T<:SimpleGraph}(g::T, h::T)
+function union{T<:AbstractGraph}(g::T, h::T)
     gnv = nv(g)
     hnv = nv(h)
 
@@ -213,35 +213,35 @@ function *{T<:Real}(g::DiGraph, v::Vector{T})
 end
 
 """sum(g,i) provides 1:indegree or 2:outdegree vectors"""
-function sum(g::SimpleGraph, dim::Int)
+function sum(g::AbstractGraph, dim::Int)
     dim == 1 && return indegree(g, vertices(g))
     dim == 2 && return outdegree(g, vertices(g))
     error("Graphs are only two dimensional")
 end
 
 
-size(g::SimpleGraph) = (nv(g), nv(g))
+size(g::AbstractGraph) = (nv(g), nv(g))
 """size(g,i) provides 1:nv or 2:nv else 1 """
 size(g::Graph,dim::Int) = (dim == 1 || dim == 2)? nv(g) : 1
 
 """sum(g) provides the number of edges in the graph"""
-sum(g::SimpleGraph) = ne(g)
+sum(g::AbstractGraph) = ne(g)
 
 """sparse(g) is the adjacency_matrix of g"""
-sparse(g::SimpleGraph) = adjacency_matrix(g)
+sparse(g::AbstractGraph) = adjacency_matrix(g)
 
 #arrayfunctions = (:eltype, :length, :ndims, :size, :strides, :issymmetric)
-eltype(g::SimpleGraph) = Float64
-length(g::SimpleGraph) = nv(g)*nv(g)
-ndims(g::SimpleGraph) = 2
-issymmetric(g::SimpleGraph) = !is_directed(g)
+eltype(g::AbstractGraph) = Float64
+length(g::AbstractGraph) = nv(g)*nv(g)
+ndims(g::AbstractGraph) = 2
+issymmetric(g::AbstractGraph) = !is_directed(g)
 
 """
     cartesian_product(g, h)
 
 Returns the (cartesian product)[https://en.wikipedia.org/wiki/Tensor_product_of_graphs] of `g` and `h`
 """
-function cartesian_product{G<:SimpleGraph}(g::G, h::G)
+function cartesian_product{G<:AbstractGraph}(g::G, h::G)
     z = G(nv(g)*nv(h))
     id(i, j) = (i-1)*nv(h) + j
     for (i1, i2) in edges(g)
@@ -264,7 +264,7 @@ end
 
 Returns the (tensor product)[https://en.wikipedia.org/wiki/Tensor_product_of_graphs] of `g` and `h`
 """
-function tensor_product{G<:SimpleGraph}(g::G, h::G)
+function tensor_product{G<:AbstractGraph}(g::G, h::G)
     z = G(nv(g)*nv(h))
     id(i, j) = (i-1)*nv(h) + j
     for (i1, i2) in edges(g)
@@ -314,7 +314,7 @@ sg, vmap = subgraph(g, elist)
 @asssert sg == g[elist]
 ```
 """
-function induced_subgraph{T<:SimpleGraph}(g::T, vlist::AbstractVector{Int})
+function induced_subgraph{T<:AbstractGraph}(g::T, vlist::AbstractVector{Int})
     allunique(vlist) || error("Vertices in subgraph list must be unique")
     h = T(length(vlist))
     newvid = Dict{Int, Int}()
@@ -338,7 +338,7 @@ function induced_subgraph{T<:SimpleGraph}(g::T, vlist::AbstractVector{Int})
 end
 
 
-function induced_subgraph{T<:SimpleGraph}(g::T, elist::AbstractVector{Edge})
+function induced_subgraph{T<:AbstractGraph}(g::T, elist::AbstractVector{Edge})
     h = T()
     newvid = Dict{Int, Int}()
     vmap = Vector{Int}()
@@ -363,7 +363,7 @@ end
 
 Returns the subgraph induced by `iter`. Equivalent to [`induced_subgraph`](@ref)`(g, iter)[1]`.
 """
-getindex(g::SimpleGraph, iter) = induced_subgraph(g, iter)[1]
+getindex(g::AbstractGraph, iter) = induced_subgraph(g, iter)[1]
 
 
 """
@@ -374,4 +374,4 @@ Returns the subgraph of `g` induced by the neighbors of `v` up to distance
 the edge direction the edge direction with respect to `v` (i.e. `:in` or `:out`)
 to be considered. This is equivalent to [`induced_subgraph`](@ref)`(g, neighborhood(g, v, d, dir=dir))[1].`
 """
-egonet(g::SimpleGraph, v::Int, d::Int; dir=:out) = g[neighborhood(g, v, d, dir=dir)]
+egonet(g::AbstractGraph, v::Int, d::Int; dir=:out) = g[neighborhood(g, v, d, dir=dir)]

--- a/src/persistence/common.jl
+++ b/src/persistence/common.jl
@@ -67,7 +67,7 @@ end
 """
 Save a graph to file. See [`save`](@ref).
 """
-savegraph{T<:SimpleGraph}(f, g::T, x...; kws...) = save(f, g::T, x...; kws...)
+savegraph{T<:AbstractGraph}(f, g::T, x...; kws...) = save(f, g::T, x...; kws...)
 
 """
     save(file, g, t=:lg)
@@ -83,7 +83,7 @@ For some graph formats, multiple graphs in a  `dict` `"name"=>g` can be saved in
 
 Returns the number of graphs written.
 """
-function save{T<:SimpleGraph}(io::IO, g::T, gname::String, t::Symbol=:lg)
+function save{T<:AbstractGraph}(io::IO, g::T, gname::String, t::Symbol=:lg)
     t in keys(filemap) || error("Please select a supported graph format: one of $(keys(filemap))")
     return filemap[t][3](io, g, gname)
 end
@@ -93,7 +93,7 @@ save(io::IO, g::Graph, t::Symbol=:lg) = save(io, g, "graph", t)
 save(io::IO, g::DiGraph, t::Symbol=:lg) = save(io, g, "digraph", t)
 
 # save a dictionary of graphs {"name" => graph}
-function save{T<:String, U<:SimpleGraph}(io::IO, d::Dict{T, U}, t::Symbol=:lg)
+function save{T<:String, U<:AbstractGraph}(io::IO, d::Dict{T, U}, t::Symbol=:lg)
     t in keys(filemap) || error("Please select a supported graph format: one of $(keys(filemap))")
     return filemap[t][4](io, d)
 end

--- a/src/persistence/dot.jl
+++ b/src/persistence/dot.jl
@@ -33,7 +33,7 @@ end
 function loaddot_mult(io::IO)
     p = DOT.parse_dot(readall(io))
 
-    graphs = Dict{String, SimpleGraph}()
+    graphs = Dict{String, AbstractGraph}()
 
     for pg in p
         isdir = pg.directed

--- a/src/persistence/gexf.jl
+++ b/src/persistence/gexf.jl
@@ -2,7 +2,7 @@
 # TODO: implement readgexf
 
 """
-savegexf(f::IO, g::SimpleGraph, gname::String)
+savegexf(f::IO, g::AbstractGraph, gname::String)
 
 Writes a graph `g` with name `gname`
 to a file `f` in the
@@ -10,7 +10,7 @@ to a file `f` in the
 
 Returns 1 (number of graphs written).
 """
-function savegexf(f::IO, g::SimpleGraph, gname::String)
+function savegexf(f::IO, g::AbstractGraph, gname::String)
     xdoc = XMLDocument()
     xroot = setroot!(xdoc, ElementNode("gexf"))
     xroot["xmlns"] = "http://www.gexf.net/1.2draft"

--- a/src/persistence/gml.jl
+++ b/src/persistence/gml.jl
@@ -28,7 +28,7 @@ end
 
 function loadgml_mult(io::IO)
     p = GML.parse_dict(readall(io))
-    graphs = Dict{String, SimpleGraph}()
+    graphs = Dict{String, AbstractGraph}()
     for gs in p[:graph]
         dir = Bool(get(gs, :directed, 0))
         graphname = get(gs, :label, dir ? "digraph" : "graph")
@@ -44,7 +44,7 @@ Writes a graph `g` with name `gname`
 to a file `f` in the
 [GML](https://en.wikipedia.org/wiki/Graph_Modelling_Language) format.
 """
-function savegml(io::IO, g::SimpleGraph, gname::String = "")
+function savegml(io::IO, g::AbstractGraph, gname::String = "")
     println(io, "graph")
     println(io, "[")
     length(gname) > 0 && println(io, "label \"$gname\"")

--- a/src/persistence/graph6.jl
+++ b/src/persistence/graph6.jl
@@ -130,7 +130,7 @@ loadgraph6(io::IO, gname::String="g1") = loadgraph6_mult(io)[gname]
 Writes a graph `g` to a file `f` in the [Graph6](http://users.cecs.anu.edu.au/%7Ebdm/data/formats.txt) format.
 Returns 1 (number of graphs written).
 """
-function savegraph6(io::IO, g::SimpleGraph, gname::String = "g")
+function savegraph6(io::IO, g::AbstractGraph, gname::String = "g")
   str = _graphToG6String(g)
   println(io, str)
   return 1

--- a/src/persistence/graphml.jl
+++ b/src/persistence/graphml.jl
@@ -56,7 +56,7 @@ function loadgraphml_mult(io::IO)
     name(xroot) == "graphml" || error("Not a GraphML file")
 
     # traverse all its child nodes and print element names
-    graphs = Dict{String, SimpleGraph}()
+    graphs = Dict{String, AbstractGraph}()
     for el in eachelement(xroot)
         if name(el) == "graph"
             edgedefault = el["edgedefault"]
@@ -106,7 +106,7 @@ function savegraphml_mult(io::IO, graphs::Dict)
     return length(graphs)
 end
 
-savegraphml(io::IO, g::SimpleGraph, gname::String) =
+savegraphml(io::IO, g::AbstractGraph, gname::String) =
     savegraphml_mult(io, Dict(gname=>g))
 
 filemap[:graphml] = (loadgraphml, loadgraphml_mult, savegraphml, savegraphml_mult)

--- a/src/persistence/lg.jl
+++ b/src/persistence/lg.jl
@@ -37,7 +37,7 @@ end
 
 """Returns a dictionary of (name=>graph) loaded from file `fn`."""
 function loadlg_mult(io::IO)
-    graphs = Dict{String, SimpleGraph}()
+    graphs = Dict{String, AbstractGraph}()
     while !eof(io)
         line = strip(chomp(readline(io)))
         if startswith(line,"#") || line == ""
@@ -81,7 +81,7 @@ to the IO stream designated by `io`.
 
 Returns 1 (number of graphs written).
 """
-function savelg(io::IO, g::SimpleGraph, gname::String)
+function savelg(io::IO, g::AbstractGraph, gname::String)
     # write header line
     dir = is_directed(g)? "d" : "u"
     line = join([nv(g), ne(g), dir, gname], ",")
@@ -106,7 +106,7 @@ function savelg_mult(io::IO, graphs::Dict)
     return ng
 end
 
-# savelg(io::IO, g::SimpleGraph, n::String) =
+# savelg(io::IO, g::AbstractGraph, n::String) =
 #     savelg_mult(io, Dict(n=>g))
 
 # write(g::Graph, fn::String; compress::Bool=true) = write(g, "graph", fn; compress=compress)

--- a/src/persistence/net.jl
+++ b/src/persistence/net.jl
@@ -4,7 +4,7 @@ Writes a graph `g` to a file `f` in the [Pajek
 NET](http://gephi.github.io/users/supported-graph-formats/pajek-net-format/) format.
 Returns 1 (number of graphs written).
 """
-function savenet(f::IO, g::SimpleGraph, gname::String = "g")
+function savenet(f::IO, g::AbstractGraph, gname::String = "g")
     println(f, "*Vertices $(nv(g))")
     # write edges
     if is_directed(g)

--- a/src/shortestpaths/astar.jl
+++ b/src/shortestpaths/astar.jl
@@ -4,7 +4,7 @@
 # A* shortest-path algorithm
 
 function a_star_impl!{T<:Number}(
-    graph::SimpleGraph,# the graph
+    graph::AbstractGraph,# the graph
     t::Int, # the end vertex
     frontier,               # an initialized heap containing the active vertices
     colormap::Vector{Int},  # an (initialized) color-map to indicate status of vertices
@@ -41,7 +41,7 @@ end
 optional heuristic function and edge distance matrix may be supplied.
 """
 function a_star{T<:Number}(
-    graph::SimpleGraph,  # the graph
+    graph::AbstractGraph,  # the graph
 
     s::Int,                       # the start vertex
     t::Int,                       # the end vertex

--- a/src/shortestpaths/bellman-ford.jl
+++ b/src/shortestpaths/bellman-ford.jl
@@ -18,7 +18,7 @@ type BellmanFordState{T<:Number}<:AbstractPathState
 end
 
 function bellman_ford_shortest_paths!{R<:Real}(
-    graph::SimpleGraph,
+    graph::AbstractGraph,
     sources::AbstractVector{Int},
     distmx::AbstractArray{R, 2},
     state::BellmanFordState
@@ -60,7 +60,7 @@ vertices `ss`. Returns a `BellmanFordState` with relevant traversal information
 (see below).
 """
 function bellman_ford_shortest_paths{T}(
-    graph::SimpleGraph,
+    graph::AbstractGraph,
 
     sources::AbstractVector{Int},
     distmx::AbstractArray{T, 2} = DefaultDistance()
@@ -71,12 +71,12 @@ function bellman_ford_shortest_paths{T}(
 end
 
 bellman_ford_shortest_paths{T}(
-    graph::SimpleGraph,
+    graph::AbstractGraph,
     v::Int,
     distmx::AbstractArray{T, 2} = DefaultDistance()
 ) = bellman_ford_shortest_paths(graph, [v], distmx)
 
-function has_negative_edge_cycle(graph::SimpleGraph)
+function has_negative_edge_cycle(graph::AbstractGraph)
     try
         bellman_ford_shortest_paths(graph, vertices(graph))
     catch e

--- a/src/shortestpaths/dijkstra.jl
+++ b/src/shortestpaths/dijkstra.jl
@@ -23,7 +23,7 @@ With `allpaths=true`, returns a `DijkstraState` that keeps track of all
 predecessors of a given vertex (see below).
 """
 function dijkstra_shortest_paths{T}(
-    g::SimpleGraph,
+    g::AbstractGraph,
     srcs::Vector{Int},
     distmx::AbstractArray{T, 2}=DefaultDistance();
     allpaths=false
@@ -87,5 +87,5 @@ function dijkstra_shortest_paths{T}(
     return DijkstraState{T}(parents, dists, preds, pathcounts)
 end
 
-dijkstra_shortest_paths{T}(g::SimpleGraph, src::Int, distmx::AbstractArray{T,2}=DefaultDistance(); allpaths=false) =
+dijkstra_shortest_paths{T}(g::AbstractGraph, src::Int, distmx::AbstractArray{T,2}=DefaultDistance(); allpaths=false) =
   dijkstra_shortest_paths(g, [src;], distmx; allpaths=allpaths)

--- a/src/shortestpaths/floyd-warshall.jl
+++ b/src/shortestpaths/floyd-warshall.jl
@@ -17,7 +17,7 @@ Note that this algorithm may return a large amount of data (it will allocate
 on the order of $\mathcal{O}(nv^2)$).
 """
 function floyd_warshall_shortest_paths{T}(
-    g::SimpleGraph,
+    g::AbstractGraph,
     distmx::AbstractArray{T, 2} = DefaultDistance()
 )
 

--- a/src/spanningtrees/kruskal.jl
+++ b/src/spanningtrees/kruskal.jl
@@ -25,7 +25,7 @@ and computes minimum spanning tree. Returns a `Vector{KruskalHeapEntry}`,
 that contains the containing edges and its weights.
 """
 function kruskal_mst{T<:Real}(
-    g::SimpleGraph,
+    g::AbstractGraph,
     distmx::AbstractArray{T, 2} = DefaultDistance()
 )
 

--- a/src/spanningtrees/prim.jl
+++ b/src/spanningtrees/prim.jl
@@ -11,7 +11,7 @@ and computes minimum spanning tree. Returns a `Vector{Edge}`,
 that contains the edges.
 """
 function prim_mst{T<:Real}(
-    g::SimpleGraph,
+    g::AbstractGraph,
     distmx::AbstractArray{T, 2} = DefaultDistance()
     ) :: Vector{Edge}
 
@@ -43,7 +43,7 @@ Used to mark the visited vertices. Marks the vertex `v` of graph `g` true in the
 and enters all its edges into priority queue `pq` with its `distmx` values as a PrimHeapEntry.
 """
 function visit!{T<:Real}(
-    g::SimpleGraph,
+    g::AbstractGraph,
     v::Int,
     marked::AbstractArray{Bool, 1},
     pq::Vector{PrimHeapEntry{T}},

--- a/src/traversals/bfs.jl
+++ b/src/traversals/bfs.jl
@@ -20,15 +20,15 @@ EdgeColorMap :
 - color == 1     => examined
 """
 
-type BreadthFirst <: SimpleGraphVisitAlgorithm
+type BreadthFirst <: AbstractGraphVisitAlgorithm
 end
 
 function breadth_first_visit_impl!(
-    graph::SimpleGraph,                 # the graph
+    graph::AbstractGraph,                 # the graph
     queue::Vector{Int},                 # an (initialized) queue that stores the active vertices
     vertexcolormap::AbstractVertexMap,   # an (initialized) color-map to indicate status of vertices (-1=unseen, otherwise distance from root)
     edgecolormap::AbstractEdgeMap,        # an (initialized) color-map to indicate status of edges
-    visitor::SimpleGraphVisitor,            # the visitor
+    visitor::AbstractGraphVisitor,            # the visitor
     dir::Symbol)                        # direction [:in,:out]
 
     fneig = dir == :out ? out_neighbors : in_neighbors
@@ -55,10 +55,10 @@ function breadth_first_visit_impl!(
 end
 
 function traverse_graph!(
-    graph::SimpleGraph,
+    graph::AbstractGraph,
     alg::BreadthFirst,
     source,
-    visitor::SimpleGraphVisitor;
+    visitor::AbstractGraphVisitor;
     vertexcolormap::AbstractVertexMap = Dict{Int, Int}(),
     edgecolormap::AbstractEdgeMap = DummyEdgeMap(),
     queue = Vector{Int}(),
@@ -89,7 +89,7 @@ end
 """TreeBFSVisitorVector is a type for representing a BFS traversal
 of the graph as a parents array. This type allows for a more performant implementation.
 """
-type TreeBFSVisitorVector <: SimpleGraphVisitor
+type TreeBFSVisitorVector <: AbstractGraphVisitor
     tree::Vector{Int}
 end
 
@@ -121,7 +121,7 @@ function examine_neighbor!(visitor::TreeBFSVisitorVector, u::Int, v::Int,
 end
 
 function bfs_tree!(visitor::TreeBFSVisitorVector,
-        g::SimpleGraph,
+        g::AbstractGraph,
         s::Int;
         vertexcolormap = Dict{Int,Int}(),
         queue = Vector{Int}())
@@ -143,7 +143,7 @@ and returns a directed acyclic graph of vertices in the order they were discover
 
 This function is a high level wrapper around bfs_tree!, use that function for more performance.
 """
-function bfs_tree(g::SimpleGraph, s::Int)
+function bfs_tree(g::AbstractGraph, s::Int)
     nvg = nv(g)
     visitor = TreeBFSVisitorVector(nvg)
     bfs_tree!(visitor, g, s)
@@ -154,7 +154,7 @@ end
 # Connected Components with BFS            #
 ############################################
 """Performing connected components with BFS starting from seed"""
-type ComponentVisitorVector <: SimpleGraphVisitor
+type ComponentVisitorVector <: AbstractGraphVisitor
     labels::Vector{Int}
     seed::Int
 end
@@ -170,7 +170,7 @@ end
 ############################################
 # Test graph for bipartiteness             #
 ############################################
-type BipartiteVisitor <: SimpleGraphVisitor
+type BipartiteVisitor <: AbstractGraphVisitor
     bipartitemap::Vector{UInt8}
     is_bipartite::Bool
 end
@@ -196,7 +196,7 @@ end
 Will return `true` if graph `g` is [bipartite](https://en.wikipedia.org/wiki/Bipartite_graph).
 If a node `v` is specified, only the connected component to which it belongs is considered.
 """
-function is_bipartite(g::SimpleGraph)
+function is_bipartite(g::AbstractGraph)
     cc = filter(x->length(x)>2, connected_components(g))
     vmap = Dict{Int,Int}()
     for c in cc
@@ -205,11 +205,11 @@ function is_bipartite(g::SimpleGraph)
     return true
 end
 
-is_bipartite(g::SimpleGraph, v::Int) = _is_bipartite(g, v)
+is_bipartite(g::AbstractGraph, v::Int) = _is_bipartite(g, v)
 
-_is_bipartite(g::SimpleGraph, v::Int; vmap = Dict{Int,Int}()) = _bipartite_visitor(g, v, vmap=vmap).is_bipartite
+_is_bipartite(g::AbstractGraph, v::Int; vmap = Dict{Int,Int}()) = _bipartite_visitor(g, v, vmap=vmap).is_bipartite
 
-function _bipartite_visitor(g::SimpleGraph, s::Int; vmap=Dict{Int,Int}())
+function _bipartite_visitor(g::AbstractGraph, s::Int; vmap=Dict{Int,Int}())
     nvg = nv(g)
     visitor = BipartiteVisitor(nvg)
     for v in keys(vmap) #have to reset vmap, otherway problems with digraphs
@@ -224,7 +224,7 @@ If the graph is bipartite returns a vector `c`  of size `nv(g)` containing
 the assignment of each vertex to one of the two sets (`c[i] == 1` or `c[i]==2`).
 If `g` is not bipartite returns an empty vector.
 """
-function bipartite_map(g::SimpleGraph)
+function bipartite_map(g::AbstractGraph)
     cc = connected_components(g)
     visitors = [_bipartite_visitor(g, x[1]) for x in cc]
     !all([v.is_bipartite for v in visitors]) && return zeros(Int, 0)
@@ -245,7 +245,7 @@ end
 Fills `dists` with the geodesic distances of vertices in `g` from vertex/vertices `source`.
 `dists` should be a vector of length `nv(g)`.
 """
-function gdistances!(g::SimpleGraph, source, dists)
+function gdistances!(g::AbstractGraph, source, dists)
     n = nv(g)
     fill!(dists, -1)
     queue = Vector{Int}(n)
@@ -278,5 +278,5 @@ Returns a vector filled with the geodesic distances of vertices in  `g` from ver
 If `source` is a collection of vertices they should be unique (not checked).
 For vertices in disconnected components the default distance is -1.
 """
-gdistances(g::SimpleGraph, source) = gdistances!(g, source, Vector{Int}(nv(g)))
+gdistances(g::AbstractGraph, source) = gdistances!(g, source, Vector{Int}(nv(g)))
 

--- a/src/traversals/dfs.jl
+++ b/src/traversals/dfs.jl
@@ -21,15 +21,15 @@ EdgeColorMap :
 - color == 1     => examined
 """
 
-type DepthFirst <: SimpleGraphVisitAlgorithm
+type DepthFirst <: AbstractGraphVisitAlgorithm
 end
 
 function depth_first_visit_impl!(
-    graph::SimpleGraph,      # the graph
+    graph::AbstractGraph,      # the graph
     stack,                          # an (initialized) stack of vertex
     vertexcolormap::AbstractVertexMap,    # an (initialized) color-map to indicate status of vertices
     edgecolormap::AbstractEdgeMap,      # an (initialized) color-map to indicate status of edges
-    visitor::SimpleGraphVisitor)  # the visitor
+    visitor::AbstractGraphVisitor)  # the visitor
 
 
     while !isempty(stack)
@@ -66,10 +66,10 @@ function depth_first_visit_impl!(
 end
 
 function traverse_graph!(
-    graph::SimpleGraph,
+    graph::AbstractGraph,
     alg::DepthFirst,
     s::Int,
-    visitor::SimpleGraphVisitor;
+    visitor::AbstractGraphVisitor;
     vertexcolormap = Dict{Int, Int}(),
     edgecolormap = DummyEdgeMap())
 
@@ -91,7 +91,7 @@ end
 
 # Test whether a graph is cyclic
 
-type DFSCyclicTestVisitor <: SimpleGraphVisitor
+type DFSCyclicTestVisitor <: AbstractGraphVisitor
     found_cycle::Bool
 
     DFSCyclicTestVisitor() = new(false)
@@ -118,7 +118,7 @@ discover_vertex!(vis::DFSCyclicTestVisitor, v) = !vis.found_cycle
 Tests whether a graph contains a cycle through depth-first search. It
 returns `true` when it finds a cycle, otherwise `false`.
 """
-function is_cyclic(g::SimpleGraph)
+function is_cyclic(g::AbstractGraph)
     cmap = zeros(Int, nv(g))
     visitor = DFSCyclicTestVisitor()
 
@@ -133,7 +133,7 @@ end
 
 # Topological sort using DFS
 
-type TopologicalSortVisitor <: SimpleGraphVisitor
+type TopologicalSortVisitor <: AbstractGraphVisitor
     vertices::Vector{Int}
 
     function TopologicalSortVisitor(n::Int)
@@ -152,7 +152,7 @@ function close_vertex!(visitor::TopologicalSortVisitor, v::Int)
     push!(visitor.vertices, v)
 end
 
-function topological_sort_by_dfs(graph::SimpleGraph)
+function topological_sort_by_dfs(graph::AbstractGraph)
     nvg = nv(graph)
     cmap = zeros(Int, nvg)
     visitor = TopologicalSortVisitor(nvg)
@@ -167,7 +167,7 @@ function topological_sort_by_dfs(graph::SimpleGraph)
 end
 
 
-type TreeDFSVisitor <:SimpleGraphVisitor
+type TreeDFSVisitor <:AbstractGraphVisitor
     tree::DiGraph
     predecessor::Vector{Int}
 end
@@ -187,7 +187,7 @@ end
 Provides a depth-first traversal of the graph `g` starting with source vertex `s`,
 and returns a directed acyclic graph of vertices in the order they were discovered.
 """
-function dfs_tree(g::SimpleGraph, s::Int)
+function dfs_tree(g::AbstractGraph, s::Int)
     nvg = nv(g)
     visitor = TreeDFSVisitor(nvg)
     traverse_graph!(g, DepthFirst(), s, visitor)

--- a/src/traversals/graphvisit.jl
+++ b/src/traversals/graphvisit.jl
@@ -3,30 +3,30 @@
 
 # The concept and trivial implementation of graph visitors
 
-abstract SimpleGraphVisitor
+abstract AbstractGraphVisitor
 
 # trivial implementation
 
 # invoked when a vertex v is encountered for the first time
 # this function returns whether to continue search
-discover_vertex!(vis::SimpleGraphVisitor, v) = true
+discover_vertex!(vis::AbstractGraphVisitor, v) = true
 
 # invoked when the algorithm is about to examine v's neighbors
-open_vertex!(vis::SimpleGraphVisitor, v) = true
+open_vertex!(vis::AbstractGraphVisitor, v) = true
 
 # invoked when a neighbor is discovered & examined
-examine_neighbor!(vis::SimpleGraphVisitor, u, v, ucolor::Int, vcolor::Int, ecolor::Int) = true
+examine_neighbor!(vis::AbstractGraphVisitor, u, v, ucolor::Int, vcolor::Int, ecolor::Int) = true
 
 # invoked when all of v's neighbors have been examined
-close_vertex!(vis::SimpleGraphVisitor, v) = true
+close_vertex!(vis::AbstractGraphVisitor, v) = true
 
 
-type TrivialGraphVisitor <: SimpleGraphVisitor
+type TrivialGraphVisitor <: AbstractGraphVisitor
 end
 
 
 # This is the common base for BreadthFirst and DepthFirst
-abstract SimpleGraphVisitAlgorithm
+abstract AbstractGraphVisitAlgorithm
 
 typealias AbstractEdgeMap{T} Associative{Edge,T}
 typealias AbstractVertexMap{T} Union{AbstractVector{T},Associative{Int, T}}
@@ -47,7 +47,7 @@ get(d::DummyEdgeMap, e::Edge, x::Int) = x
 
 # List vertices by the order of being discovered
 
-type VertexListVisitor <: SimpleGraphVisitor
+type VertexListVisitor <: AbstractGraphVisitor
     vertices::Vector{Int}
 
     function VertexListVisitor(n::Integer=0)
@@ -63,8 +63,8 @@ function discover_vertex!(visitor::VertexListVisitor, v::Int)
 end
 
 function visited_vertices(
-    graph::SimpleGraph,
-    alg::SimpleGraphVisitAlgorithm,
+    graph::AbstractGraph,
+    alg::AbstractGraphVisitAlgorithm,
     sources)
 
     visitor = VertexListVisitor(nv(graph))
@@ -75,7 +75,7 @@ end
 
 # Print visit log
 
-type LogGraphVisitor{S<:IO} <: SimpleGraphVisitor
+type LogGraphVisitor{S<:IO} <: AbstractGraphVisitor
     io::S
 end
 
@@ -100,8 +100,8 @@ function examine_neighbor!(vis::LogGraphVisitor, u::Int, v::Int, ucolor::Int, vc
 end
 
 function traverse_graph_withlog(
-    g::SimpleGraph,
-    alg::SimpleGraphVisitAlgorithm,
+    g::AbstractGraph,
+    alg::AbstractGraphVisitAlgorithm,
     sources,
     io::IO = STDOUT
 )

--- a/src/traversals/maxadjvisit.jl
+++ b/src/traversals/maxadjvisit.jl
@@ -10,13 +10,13 @@
 #
 #################################################
 
-type MaximumAdjacency <: SimpleGraphVisitAlgorithm
+type MaximumAdjacency <: AbstractGraphVisitAlgorithm
 end
 
-abstract AbstractMASVisitor <: SimpleGraphVisitor
+abstract AbstractMASVisitor <: AbstractGraphVisitor
 
 function maximum_adjacency_visit_impl!{T}(
-    graph::SimpleGraph,                               # the graph
+    graph::AbstractGraph,                               # the graph
     pq::DataStructures.PriorityQueue{Int, T},         # priority queue
     visitor::AbstractMASVisitor,                      # the visitor
     colormap::Vector{Int})                            # traversal status
@@ -38,7 +38,7 @@ function maximum_adjacency_visit_impl!{T}(
 end
 
 function traverse_graph!(
-    graph::SimpleGraph,
+    graph::AbstractGraph,
     T::DataType,
     alg::MaximumAdjacency,
     s::Int,
@@ -78,7 +78,7 @@ end
 #################################################
 
 type MinCutVisitor{T} <: AbstractMASVisitor
-    graph::SimpleGraph
+    graph::AbstractGraph
     parities::AbstractArray{Bool,1}
     colormap::Vector{Int}
     bestweight::T
@@ -88,7 +88,7 @@ type MinCutVisitor{T} <: AbstractMASVisitor
     vertices::Vector{Int}
 end
 
-function MinCutVisitor{T}(graph::SimpleGraph, distmx::AbstractArray{T, 2})
+function MinCutVisitor{T}(graph::AbstractGraph, distmx::AbstractArray{T, 2})
     n = nv(graph)
     parities = falses(n)
     return MinCutVisitor(
@@ -179,7 +179,7 @@ weight of the cut that makes this partition. An optional `distmx` matrix may
 be specified; if omitted, edge distances are assumed to be 1.
 """
 function mincut{T}(
-    graph::SimpleGraph,
+    graph::AbstractGraph,
     distmx::AbstractArray{T, 2}
 )
     visitor = MinCutVisitor(graph, distmx)
@@ -188,7 +188,7 @@ function mincut{T}(
     return(visitor.parities + 1, visitor.bestweight)
 end
 
-mincut(graph::SimpleGraph) = mincut(graph,DefaultDistance())
+mincut(graph::AbstractGraph) = mincut(graph,DefaultDistance())
 
 """Returns the vertices in `g` traversed by maximum adjacency search. An optional
 `distmx` matrix may be specified; if omitted, edge distances are assumed to
@@ -197,7 +197,7 @@ be 1. If `log` (default `false`) is `true`, visitor events will be printed to
 displayed.
 """
 function maximum_adjacency_visit{T}(
-    graph::SimpleGraph,
+    graph::AbstractGraph,
     distmx::AbstractArray{T, 2},
     log::Bool,
     io::IO
@@ -207,7 +207,7 @@ function maximum_adjacency_visit{T}(
     return visitor.vertices
 end
 
-maximum_adjacency_visit(graph::SimpleGraph) = maximum_adjacency_visit(
+maximum_adjacency_visit(graph::AbstractGraph) = maximum_adjacency_visit(
     graph,
     DefaultDistance(),
     false,

--- a/src/traversals/randomwalks.jl
+++ b/src/traversals/randomwalks.jl
@@ -1,7 +1,7 @@
 """Performs a random walk on graph `g` starting at vertex `s` and continuing for
 a maximum of `niter` steps. Returns a vector of vertices visited in order.
 """
-function randomwalk(g::SimpleGraph, s::Integer, niter::Integer)
+function randomwalk(g::AbstractGraph, s::Integer, niter::Integer)
   s in vertices(g) || throw(BoundsError())
   visited = Vector{Int}()
   sizehint!(visited, niter)
@@ -83,7 +83,7 @@ end
 on graph `g` starting at vertex `s` and continuing for a maximum of `niter` steps.
 Returns a vector of vertices visited in order.
 """
-function saw(g::SimpleGraph, s::Integer, niter::Integer)
+function saw(g::AbstractGraph, s::Integer, niter::Integer)
   s in vertices(g) || throw(BoundsError())
   visited = Vector{Int}()
   svisited = Set{Int}()

--- a/test/persistence/persistence.jl
+++ b/test/persistence/persistence.jl
@@ -33,7 +33,7 @@ gs = load(joinpath(testdir, "testdata", "tutte-pathdigraph.jgz"), "pathdigraph")
 @test gs == p2
 @test_throws ErrorException load(joinpath(testdir, "testdata", "tutte-pathdigraph.jgz"), "badname")
 
-d = Dict{String, SimpleGraph}("p1"=>p1, "p2"=>p2)
+d = Dict{String, AbstractGraph}("p1"=>p1, "p2"=>p2)
 @test save(f,d) == 2
 
 

--- a/test/traversals/graphvisit.jl
+++ b/test/traversals/graphvisit.jl
@@ -8,8 +8,8 @@ f = IOBuffer()
 
 
 function trivialgraphvisit(
-    g::SimpleGraph,
-    alg::LightGraphs.SimpleGraphVisitAlgorithm,
+    g::AbstractGraph,
+    alg::LightGraphs.AbstractGraphVisitAlgorithm,
     sources
 )
     visitor = TrivialGraphVisitor()


### PR DESCRIPTION
As discussed in #527 , this replaces all occurrences of "SimpleGraph" by "AbstractGraph", it also makes the latter an abstract type instead of a Union type. All tests pass locally.