### PR TITLE
Fixes #555: graphmatrices convert incorrect on CA

### DIFF
--- a/src/linalg/graphmatrices.jl
+++ b/src/linalg/graphmatrices.jl
@@ -178,6 +178,7 @@ adjacency(lapl::GraphMatrix) = lapl.A
 convert(::Type{Adjacency}, lapl::Laplacian) = lapl.A
 convert(::Type{CombinatorialAdjacency}, adjmat::Adjacency) = adjmat.A
 convert(::Type{SparseMatrix}, adjmat::CombinatorialAdjacency) = adjmat.A
+convert(::Type{CombinatorialAdjacency}, adjmat::CombinatorialAdjacency) = adjmat
 
 
 function sparse(lapl::M) where M<:Laplacian

--- a/test/linalg/graphmatrices.jl
+++ b/test/linalg/graphmatrices.jl
@@ -28,6 +28,8 @@ export test_adjacency, test_laplacian, test_accessors, test_arithmetic, test_oth
         converttest(SparseMatrix{Float64},stochmat)
         converttest(SparseMatrix{Float64},adjhat)
         converttest(SparseMatrix{Float64},avgmat)
+        @test isa(CombinatorialAdjacency(adjmat), CombinatorialAdjacency)
+        @test isa(CombinatorialAdjacency(avgmat), CombinatorialAdjacency)
         @test prescalefactor(adjhat) == postscalefactor(adjhat)
         @test postscalefactor(stochmat) == prescalefactor(avgmat)
         @test prescalefactor(adjhat) == postscalefactor(adjhat)


### PR DESCRIPTION
CombinatorialAdjacency(CombinatorialAdjacency(g)) was returning the backing storage.
Fix includes tests.