### PR TITLE
closes #368

### DIFF
--- a/src/traversals/bfs.jl
+++ b/src/traversals/bfs.jl
@@ -213,7 +213,11 @@ If a node `v` is specified, only the connected component to which it belongs is 
 """
 function is_bipartite(g::AbstractGraph)
     T = eltype(g)
-    cc = filter(x->length(x)>2, connected_components(g))
+    if !is_directed(g)
+        cc = filter(x->length(x)>2, connected_components(g))
+    else
+        cc = filter(x->length(x)>2, weakly_connected_components(g))
+    end
     vmap = Dict{T,Int}()
     for c in cc
         _is_bipartite(g,c[1], vmap=vmap) || return false

--- a/test/connectivity.jl
+++ b/test/connectivity.jl
@@ -60,7 +60,7 @@
     add_edge!(h,5,6); add_edge!(h,6,7); add_edge!(h,7,6);
     add_edge!(h,8,4); add_edge!(h,8,7)
     for g in testdigraphs(h)
-      @test @inferred(is_connected(g))
+      @test @inferred(is_weakly_connected(g))
       scc = @inferred(strongly_connected_components(g))
       wcc = @inferred(weakly_connected_components(g))
 


### PR DESCRIPTION
`is_connected` and `connected_components` now throw method errors for directed graphs.