### PR TITLE
add_edge! and has_edge now allow any type(s) that can be converted to…

### DIFF
--- a/src/graphtypes/simplegraphs/SimpleGraphs.jl
+++ b/src/graphtypes/simplegraphs/SimpleGraphs.jl
@@ -53,12 +53,13 @@ fadj(g::AbstractSimpleGraph, v::Integer) = g.fadjlist[v]
 
 badj(x...) = _NI("badj")
 
-has_edge(g::AbstractSimpleGraph, u::Integer, v::Integer) = has_edge(g, edgetype(g)(u,v))
+# handles single-argument edge constructors such as pairs and tuples
+has_edge(g::AbstractSimpleGraph, x) = has_edge(g, edgetype(g)(x))
+add_edge!(g::AbstractSimpleGraph, x) = add_edge!(g, edgetype(g)(x))
 
-function add_edge!(g::AbstractSimpleGraph, u::Integer, v::Integer)
-    T = eltype(g)
-    add_edge!(g, edgetype(g)(T(u),T(v)))
-end
+# handles two-argument edge constructors like src,dst
+has_edge(g::AbstractSimpleGraph, x, y) = has_edge(g, edgetype(g)(x, y))
+add_edge!(g::AbstractSimpleGraph, x, y) = add_edge!(g, edgetype(g)(x, y))
 
 in_neighbors(g::AbstractSimpleGraph, v::Integer) = badj(g,v)
 out_neighbors(g::AbstractSimpleGraph, v::Integer) = fadj(g,v)

--- a/src/graphtypes/simplegraphs/simpleedge.jl
+++ b/src/graphtypes/simplegraphs/simpleedge.jl
@@ -10,6 +10,8 @@ end
 
 SimpleEdge(t::Tuple) = SimpleEdge(t[1], t[2])
 SimpleEdge(p::Pair) = SimpleEdge(p.first, p.second)
+SimpleEdge{T}(p::Pair) where T<:Integer = SimpleEdge(T(p.first), T(p.second))
+SimpleEdge{T}(t::Tuple) where T<:Integer = SimpleEdge(T(t[1]), T(t[2]))
 
 eltype(e::T) where T<:AbstractSimpleEdge= eltype(src(e))
 

--- a/test/graphtypes/simplegraphs/simpleedge.jl
+++ b/test/graphtypes/simplegraphs/simpleedge.jl
@@ -8,22 +8,25 @@ import LightGraphs.SimpleGraphs.SimpleEdge
         d = s+one(T)
         p = Pair(s, d)
 
-        ep = SimpleEdge(p)
+        ep1 = SimpleEdge(p)
+        ep2 = SimpleEdge{UInt8}(p)
+        ep3 = SimpleEdge{Int16}(p)
+
         t1 = (s, d)
         t2 = (s, d, "foo")
 
-        @test src(ep) == s
-        @test dst(ep) == s + one(T)
+        @test src(ep1) == src(ep2) == src(ep3) == s
+        @test dst(ep1) == dst(ep2) == dst(ep3) == s + one(T)
 
         @test eltype(p) == typeof(s)
         @test SimpleEdge(p) == e
         @test SimpleEdge(t1) == SimpleEdge(t2) == e
-
-        @test SimpleEdge{Int64}(ep) == e
+        @test SimpleEdge(t1) == SimpleEdge{UInt8}(t1) == SimpleEdge{Int16}(t1)
+        @test SimpleEdge{Int64}(ep1) == e
 
         @test Pair(e) == p
         @test Tuple(e) == t1
-        @test reverse(ep) == re
-        @test sprint(show, ep) == "Edge 1 => 2"
+        @test reverse(ep1) == re
+        @test sprint(show, ep1) == "Edge 1 => 2"
     end
 end

--- a/test/graphtypes/simplegraphs/simplegraphs.jl
+++ b/test/graphtypes/simplegraphs/simplegraphs.jl
@@ -51,6 +51,13 @@ struct DummySimpleGraph <: AbstractSimpleGraph end
 
         @test @inferred(has_edge(g, 2, 3))
         @test @inferred(has_edge(g, 3, 2))
+
+        gc = copy(g)
+        @test @inferred(add_edge!(gc, 4=>1)) && gc == CycleGraph(4)
+        @test @inferred(has_edge(gc, 4=>1)) && has_edge(gc, 0x04=>0x01)
+        gc = copy(g)
+        @test @inferred(add_edge!(gc, (4,1))) && gc == CycleGraph(4)
+        @test @inferred(has_edge(gc, (4,1))) && has_edge(gc, (0x04, 0x01))
         gc = copy(g)
         @test add_edge!(gc, 4, 1) && gc == CycleGraph(4)
 
@@ -105,6 +112,13 @@ struct DummySimpleGraph <: AbstractSimpleGraph end
 
         @test @inferred(has_edge(g, 2, 3))
         @test @inferred(!has_edge(g, 3, 2))
+
+        gc = copy(g)
+        @test @inferred(add_edge!(gc, 4=>1)) && gc == CycleDiGraph(4)
+        @test @inferred(has_edge(gc, 4=>1)) && has_edge(gc, 0x04=>0x01)
+        gc = copy(g)
+        @test @inferred(add_edge!(gc, (4,1))) && gc == CycleDiGraph(4)
+        @test @inferred(has_edge(gc, (4,1))) && has_edge(gc, (0x04, 0x01))
         gc = @inferred(copy(g))
         @test @inferred(add_edge!(gc, 4, 1)) && gc == CycleDiGraph(4)
 


### PR DESCRIPTION
… an edge.

I noticed that `add_edge!(g, 1=>3)` didn't work (it used to), so I genericized `add_edge!` and `has_edge` so that they just pass whatever arguments they have to create an edge, and then call the method that uses a constructed edge.

I did *not* do this for `rem_edge!`, though we probably should for consistency.
