### PR TITLE
constructors for type-parameterized random graphs

### DIFF
--- a/src/generators/randgraphs.jl
+++ b/src/generators/randgraphs.jl
@@ -1,35 +1,41 @@
-function Graph(nv::Integer, ne::Integer; seed::Int = -1)
-    T = eltype(nv)
+function Graph{T}(nv::Integer, ne::Integer; seed::Int = -1) where T <: Integer
+    tnv = T(nv)
     maxe = div(Int(nv) * (nv-1), 2)
     @assert(ne <= maxe, "Maximum number of edges for this graph is $maxe")
     ne > 2/3 * maxe && return complement(Graph(nv, maxe-ne))
 
     rng = getRNG(seed)
-    g = Graph(nv)
+    g = Graph(tnv)
 
     while g.ne < ne
-        source = rand(rng, one(T):nv)
-        dest = rand(rng, one(T):nv)
-        source != dest && add_edge!(g,source,dest)
+        source = rand(rng, one(T):tnv)
+        dest = rand(rng, one(T):tnv)
+        source != dest && add_edge!(g, source, dest)
     end
     return g
 end
 
-function DiGraph(nv::Integer, ne::Integer; seed::Int = -1)
-    T = eltype(nv)
+Graph(nv::T, ne::Integer; seed::Int = -1) where T<: Integer =
+    Graph{T}(nv, ne, seed=seed)
+
+function DiGraph{T}(nv::Integer, ne::Integer; seed::Int = -1) where T<:Integer
+    tnv = T(nv)
     maxe = Int(nv) * (nv-1)
     @assert(ne <= maxe, "Maximum number of edges for this graph is $maxe")
-    ne > 2/3 * maxe && return complement(DiGraph(nv, maxe-ne))
+    ne > 2/3 * maxe && return complement(DiGraph{T}(nv, maxe-ne))
 
     rng = getRNG(seed)
-    g = DiGraph(nv)
+    g = DiGraph(tnv)
     while g.ne < ne
-        source = rand(rng, one(T):nv)
-        dest = rand(rng, one(T):nv)
+        source = rand(rng, one(T):tnv)
+        dest = rand(rng, one(T):tnv)
         source != dest && add_edge!(g,source,dest)
     end
     return g
 end
+
+DiGraph(nv::T, ne::Integer; seed::Int = -1) where T<:Integer =
+    DiGraph{Int}(nv, ne, seed=seed)
 
 """
     randbn(n, p, seed=-1)

--- a/test/generators/randgraphs.jl
+++ b/test/generators/randgraphs.jl
@@ -6,6 +6,14 @@
     @test ne(r1) == 20
     @test nv(r2) == 5
     @test ne(r2) == 10
+    @test eltype(r1) == Int
+    @test eltype(r2) == Int
+
+    @test eltype(Graph(0x5, 0x2)) == eltype(Graph(0x5, 2)) == UInt8
+    for T in [UInt8, Int8, UInt16, Int16, UInt32, Int32, UInt, Int]
+        @test eltype(Graph{T}(5,2)) == T
+        @test eltype(DiGraph{T}(5,2)) == T
+    end
 
     @test Graph(10,20,seed=3) == Graph(10,20,seed=3)
     @test DiGraph(10,20,seed=3) == DiGraph(10,20,seed=3)


### PR DESCRIPTION
Allows graphs of the type
```
Graph{UInt8}(5,3)
Graph(0x5, 3)
Graph(0x5, 0x3)
...
```
all of which will have `eltype` of `UInt8`.