### PR TITLE
Write show for DummyEdgeMap

### DIFF
--- a/src/traversals/graphvisit.jl
+++ b/src/traversals/graphvisit.jl
@@ -37,6 +37,8 @@ end
 getindex(d::DummyEdgeMap, e::Edge) = 0
 setindex!(d::DummyEdgeMap, x::Int, e::Edge) = x
 get(d::DummyEdgeMap, e::Edge, x::Int) = x
+Base.show(io::IO, ::MIME"text/plain", ::DummyEdgeMap) =
+    write(io, "LightGraphs.DummyEdgeMap()")
 
 
 ###########################################################

--- a/src/traversals/graphvisit.jl
+++ b/src/traversals/graphvisit.jl
@@ -38,8 +38,9 @@ getindex(d::DummyEdgeMap, e::Edge) = 0
 setindex!(d::DummyEdgeMap, x::Int, e::Edge) = x
 get(d::DummyEdgeMap, e::Edge, x::Int) = x
 Base.show(io::IO, ::MIME"text/plain", ::DummyEdgeMap) =
-    write(io, "LightGraphs.DummyEdgeMap()")
-
+    write(io, "LightGraphs.DummyEdgeMap()") # for displaying at the REPL
+Base.show(io::IO, ::LightGraphs.DummyEdgeMap) = 
+    write(io, "LightGraphs.DummyEdgeMap()") # for string(DummyEdgeMap)
 
 ###########################################################
 #

--- a/test/traversals/graphvisit.jl
+++ b/test/traversals/graphvisit.jl
@@ -32,7 +32,12 @@
     end
     # dummy edge map test
     d = @inferred(LightGraphs.DummyEdgeMap())
-    string(LightGraphs.DummyEdgeMap())  # check that it doesn't error
+    
+    # check that printing DummyEdgeMap doesn't error
+    string(LightGraphs.DummyEdgeMap())
+    mktemp() do _, io
+        show(io, MIME"text/plain"(), LightGraphs.DummyEdgeMap())
+    end    
 
     e = Edge(1, 2)
     @test d[e] == 0

--- a/test/traversals/graphvisit.jl
+++ b/test/traversals/graphvisit.jl
@@ -32,6 +32,7 @@
     end
     # dummy edge map test
     d = @inferred(LightGraphs.DummyEdgeMap())
+    string(LightGraphs.DummyEdgeMap())  # check that it doesn't error
 
     e = Edge(1, 2)
     @test d[e] == 0


### PR DESCRIPTION
This is a bit obscure, but right now, entering `LightGraphs.DummyEdgeMap()` at the REPL is an error, because it triggers `show(::Associative)`, and that calls `start(::DummyEdgeMap)`, which isn't implemented. I need this because I'm writing a tracing package, and I'd like to demo it on LightGraphs.