### PR TITLE
fixes DiGraph(DiGraph(...))

### DIFF
--- a/src/graphtypes/simplegraphs/simpledigraph.jl
+++ b/src/graphtypes/simplegraphs/simpledigraph.jl
@@ -76,6 +76,7 @@ function (::Type{SimpleDiGraph{T}})(g::SimpleDiGraph) where T<:Integer
     return SimpleDiGraph(ne(g), h_fadj, h_badj)
 end
 
+SimpleDiGraph(g::SimpleDiGraph) = copy(g)
 
 # constructor from abstract graph: DiGraph(graph)
 function SimpleDiGraph(g::AbstractSimpleGraph)

--- a/test/graphtypes/simplegraphs/simplegraphs.jl
+++ b/test/graphtypes/simplegraphs/simplegraphs.jl
@@ -169,8 +169,11 @@ struct DummySimpleGraph <: AbstractSimpleGraph end
 
     gdx = CompleteDiGraph(4)
     for g in testdigraphs(gdx)
+        h = DiGraph(g)
+        @test g == h
         @test rem_vertex!(g, 2)
         @test nv(g) == 3 && ne(g) == 6
+        @test g != h
     end
 
 


### PR DESCRIPTION
Before:
```
julia> g = DiGraph(10, 20)
{10, 20} directed simple Int64 graph

julia> DiGraph(g)
{10, 40} directed simple Int64 graph
```

Now:

```
julia> g = DiGraph(10, 20)
{10, 20} directed simple Int64 graph

julia> h = DiGraph(g)
{10, 20} directed simple Int64 graph

julia> g == h
true

julia> add_vertex!(h)
true

julia> g == h
false
```

