### PR TITLE
use CodecZlib.jl instead of GZip.jl

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
 julia 0.6.0-pre
-GZip 0.2.20
+CodecZlib 0.2
 DataStructures 0.5.0
 SimpleTraits 0.4.0

--- a/src/LightGraphs.jl
+++ b/src/LightGraphs.jl
@@ -1,7 +1,7 @@
 __precompile__(true)
 module LightGraphs
 
-using GZip
+import CodecZlib
 using DataStructures
 using SimpleTraits
 

--- a/src/persistence/common.jl
+++ b/src/persistence/common.jl
@@ -37,10 +37,19 @@ end
 loadgraphs(fn::AbstractString) = loadgraphs(fn, LGFormat())
 
 function auto_decompress(io::IO)
+    format = :raw
     mark(io)
-    magic = read(io, 2)
+    if !eof(io)
+        b1 = read(io, UInt8)
+        if !eof(io)
+            b2 = read(io, UInt8)
+            if (b1, b2) == (0x1f, 0x8b)  # check magic bytes
+                format = :gzip
+            end
+        end
+    end
     reset(io)
-    if magic == [0x1f, 0x8b]
+    if format == :gzip
         io = CodecZlib.GzipDecompressionStream(io)
     end
     return io

--- a/src/persistence/common.jl
+++ b/src/persistence/common.jl
@@ -11,8 +11,8 @@ multiple graphs; if the file format does not support multiple graphs, this
 value is ignored. The default value may change in the future.
 """
 function loadgraph(fn::AbstractString, gname::AbstractString, format::AbstractGraphFormat)
-    GZip.open(fn, "r") do io
-        loadgraph(io, gname, format)
+    open(fn, "r") do io
+        loadgraph(auto_decompress(io), gname, format)
     end
 end
 loadgraph(fn::AbstractString, gname::AbstractString="graph") = loadgraph(fn, gname, LGFormat())
@@ -29,12 +29,22 @@ For unnamed graphs the default name \"graph\" will be used. This default
 may change in the future.
 """
 function loadgraphs(fn::AbstractString, format::AbstractGraphFormat)
-    GZip.open(fn, "r") do io
-        loadgraphs(io, format)
+    open(fn, "r") do io
+        loadgraphs(auto_decompress(io), format)
     end
 end
 
 loadgraphs(fn::AbstractString) = loadgraphs(fn, LGFormat())
+
+function auto_decompress(io::IO)
+    mark(io)
+    magic = read(io, 2)
+    reset(io)
+    if magic == [0x1f, 0x8b]
+        io = CodecZlib.GzipDecompressionStream(io)
+    end
+    return io
+end
 
 
 """
@@ -50,12 +60,17 @@ The default graph name assigned to `gname` may change in the future.
 function savegraph(fn::AbstractString, g::AbstractGraph, gname::AbstractString,
         format::AbstractGraphFormat; compress=true
     )
-    openfn = compress ? GZip.open : open
-    retval = -1
-    openfn(fn, "w") do io
-        retval = savegraph(io, g, gname, format)
+    io = open(fn, "w")
+    try
+        if compress
+            io = CodecZlib.GzipCompressionStream(io)
+        end
+        return savegraph(io, g, gname, format)
+    catch
+        rethrow()
+    finally
+        close(io)
     end
-    return retval
 end
 
 savegraph(fn::AbstractString, g::AbstractGraph, gname::AbstractString="graph", format=LGFormat(); compress=true) =
@@ -75,12 +90,17 @@ Will only work if the file format supports multiple graph types.
 """
 function savegraph(fn::AbstractString, d::Dict{T,U},
     format::AbstractGraphFormat; compress=true) where T<:AbstractString where U<:AbstractGraph
-    openfn = compress ? GZip.open : open
-    retval = -1
-    openfn(fn, "w") do io
-        retval = savegraph(io, d, format)
+    io = open(fn, "w")
+    try
+        if compress
+            io = CodecZlib.GzipCompressionStream(io)
+        end
+        return savegraph(io, d, format)
+    catch
+        rethrow()
+    finally
+        close(io)
     end
-    return retval
 end
 
 savegraph(fn::AbstractString, d::Dict; compress=true) = savegraph(fn, d, LGFormat(), compress=compress)


### PR DESCRIPTION
This is needed to support streaming APIs in GraphIO.jl (https://github.com/JuliaGraphs/GraphIO.jl/pull/8). See https://github.com/JuliaGraphs/GraphIO.jl/issues/6#issuecomment-317281282.