### PR TITLE
DataStructures 0.6.0 also passes tests

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
 julia 0.6.0-pre
 CodecZlib 0.2
-DataStructures 0.6.1
+DataStructures 0.6
 SimpleTraits 0.4.0


### PR DESCRIPTION
verified locally via Pkg.pin

was unnecessarily tightened in #706, https://github.com/JuliaCollections/DataStructures.jl/compare/v0.6.0...v0.6.1 is mostly deprecation cleanups