### PR TITLE
remove bitvectors for BFS

### DIFF
--- a/src/traversals/bfs.jl
+++ b/src/traversals/bfs.jl
@@ -28,7 +28,7 @@ function _bfs_parents(g::AbstractGraph, s::Integer, neighborfn::Function)
     T = eltype(g)
     Q=Vector{T}()
     parents = zeros(T, nv(g))
-    seen = falses(nv(g))
+    seen = zeros(Bool, nv(g))
     parents[s] = s
     seen[s] = true
     push!(Q, s)
@@ -109,7 +109,7 @@ is in `excluded_vertices`.
 function has_path(g::AbstractGraph, u::Integer, v::Integer; 
         exclude_vertices::AbstractVector=Vector{eltype(g)}())
     T = eltype(g)
-    seen = falses(nv(g))
+    seen = zeros(Bool, nv(g))
     for ve in exclude_vertices # mark excluded vertices as seen
         seen[ve] = true
     end


### PR DESCRIPTION
```
# largest CC of a kronecker graph
julia> g = loadgraph("/tmp/testg.jlg")
{31206, 3679818} undirected simple Int64 graph

# current master (bitvector)
julia> @benchmark bfs_tree($g, 1)
BenchmarkTools.Trial:
  memory estimate:  13.39 MiB
  allocs estimate:  158712
  --------------
  minimum time:     45.268 ms (0.00% GC)
  median time:      53.741 ms (10.93% GC)
  mean time:        53.920 ms (7.43% GC)
  maximum time:     75.079 ms (8.45% GC)
  --------------
  samples:          93
  evals/sample:     1

# This PR - Vector{Bool}
julia> @benchmark bfs_tree($g, 1)
BenchmarkTools.Trial:
  memory estimate:  13.42 MiB
  allocs estimate:  158710
  --------------
  minimum time:     30.131 ms (0.00% GC)
  median time:      37.070 ms (14.10% GC)
  mean time:        36.964 ms (10.61% GC)
  maximum time:     47.310 ms (16.77% GC)
  --------------
  samples:          136
  evals/sample:     1
```