### PR TITLE
Specific eltype for SimpleEdgeIter

### DIFF
--- a/src/graphtypes/simplegraphs/simpleedgeiter.jl
+++ b/src/graphtypes/simplegraphs/simpleedgeiter.jl
@@ -11,7 +11,7 @@ struct SimpleEdgeIterState{T<:Integer}
 end
 
 
-eltype(::Type{SimpleEdgeIter{T}}) where T<:Integer = SimpleEdge
+eltype(::Type{SimpleEdgeIter{T}}) where T<:Integer = SimpleEdge{T}
 
 SimpleEdgeIter(g::SimpleGraph) = SimpleEdgeIter(ne(g), g.fadjlist, false)
 SimpleEdgeIter(g::SimpleDiGraph) = SimpleEdgeIter(ne(g), g.fadjlist, true)

--- a/test/graphtypes/simplegraphs/simpleedgeiter.jl
+++ b/test/graphtypes/simplegraphs/simpleedgeiter.jl
@@ -12,7 +12,8 @@
     @test Set{Edge}(collect(Edge, edges(gb))) == edges(ga)
     @test @inferred(edges(ga)) == Set{Edge}(collect(Edge, edges(gb)))
 
-    @test @inferred(eltype(edges(ga))) == eltype(typeof(edges(ga))) == SimpleEdge
+    @test @inferred(eltype(edges(ga))) == eltype(typeof(edges(ga))) == edgetype(ga)
+    @test eltype(collect(edges(ga))) == edgetype(ga)
 
     ga = @inferred(SimpleDiGraph(10, 20; seed=1))
     gb = @inferred(SimpleDiGraph(10, 20; seed=1))


### PR DESCRIPTION
Specify the eltype of `SimpleEdgeIter{T}` as `SimpleEdge{T}` . Otherwise `eltype(collect(edges(ga)))` produces an array with element type being `Unionall`.