### PR TITLE
insorted

### DIFF
--- a/src/LightGraphs.jl
+++ b/src/LightGraphs.jl
@@ -151,6 +151,7 @@ and tutorials are available at the
 [JuliaGraphsTutorials repository](https://github.com/JuliaGraphs/JuliaGraphsTutorials).
 """
 LightGraphs
+include("utils.jl")
 include("interface.jl")
 include("deprecations.jl")
 include("core.jl")
@@ -207,7 +208,6 @@ include("flow/push_relabel.jl")
 include("flow/multiroute_flow.jl")
 include("flow/kishimoto.jl")
 include("flow/ext_multiroute_flow.jl")
-include("utils.jl")
 include("spanningtrees/kruskal.jl")
 include("spanningtrees/prim.jl")
 include("biconnectivity/articulation.jl")

--- a/src/community/cliques.jl
+++ b/src/community/cliques.jl
@@ -27,6 +27,7 @@ function maximal_cliques end
     T = eltype(g)
     # Cache nbrs and find first pivot (highest degree)
     maxconn = -1
+    # nnbrs = [Set{T}() for n in vertices(g)]
     nnbrs = Vector{Set{T}}()
     for n in vertices(g)
         push!(nnbrs, Set{T}())
@@ -55,7 +56,7 @@ function maximal_cliques end
     done = Set{T}()
     stack = Vector{Tuple{Set{T},Set{T},Set{T}}}()
     clique_so_far = Vector{T}()
-    cliques = Vector{Array{T}}()
+    cliques = Vector{Vector{T}}()
 
     # Start main loop
     while !isempty(smallcand) || !isempty(stack)
@@ -85,7 +86,7 @@ function maximal_cliques end
         end
         # Shortcut--only one node left!
         if isempty(new_done) && length(new_cand) == 1
-            push!(cliques, cat(1, clique_so_far, collect(new_cand)))
+            push!(cliques, vcat(clique_so_far, collect(new_cand)))
             pop!(clique_so_far)
             continue
         end

--- a/src/digraph/cycles/hadwick-james.jl
+++ b/src/digraph/cycles/hadwick-james.jl
@@ -11,10 +11,7 @@ function simplecycles_hadwick_james end
 @traitfn function simplecycles_hadwick_james(g::::IsDirected)
     nvg = nv(g)
     T = eltype(g)
-    B = Vector{Vector{T}}()
-    for i in vertices(g)
-        push!(B, Vector{T}())
-    end
+    B = [Vector{T}() for i in vertices(g)]
     blocked = zeros(Bool, nvg)
     stack = Vector{T}()
     cycles = Vector{Vector{T}}()

--- a/src/graphtypes/simplegraphs/SimpleGraphs.jl
+++ b/src/graphtypes/simplegraphs/SimpleGraphs.jl
@@ -9,7 +9,7 @@ import LightGraphs:
     add_vertex!, add_edge!, rem_vertex!, rem_edge!,
     has_vertex, has_edge, in_neighbors, out_neighbors,
 
-    indegree, outdegree, degree, has_self_loops, num_self_loops
+    indegree, outdegree, degree, has_self_loops, num_self_loops, insorted
 
 export AbstractSimpleGraph, AbstractSimpleDiGraph, AbstractSimpleEdge,
     SimpleEdge, SimpleGraph, SimpleGraphEdge,

--- a/src/graphtypes/simplegraphs/simpledigraph.jl
+++ b/src/graphtypes/simplegraphs/simpledigraph.jl
@@ -16,12 +16,8 @@ eltype(x::SimpleDiGraph{T}) where T = T
 
 # DiGraph{UInt8}(6), DiGraph{Int16}(7), DiGraph{Int8}()
 function (::Type{SimpleDiGraph{T}})(n::Integer = 0) where T<:Integer
-    fadjlist = Vector{Vector{T}}()
-    badjlist = Vector{Vector{T}}()
-    for _ = one(T):n
-        push!(badjlist, Vector{T}())
-        push!(fadjlist, Vector{T}())
-    end
+    fadjlist = [Vector{T}() for _ = one(T):n]
+    badjlist = [Vector{T}() for _ = one(T):n]
     return SimpleDiGraph(0, fadjlist, badjlist)
 end
 

--- a/src/graphtypes/simplegraphs/simpledigraph.jl
+++ b/src/graphtypes/simplegraphs/simpledigraph.jl
@@ -142,8 +142,8 @@ function has_edge(g::SimpleDiGraph, e::SimpleDiGraphEdge)
     u, v = Tuple(e)
     (u > nv(g) || v > nv(g)) && return false
     if degree(g, u) < degree(g, v)
-        return insorted(fadj(g, u), v)
+        return insorted(v, fadj(g, u))
     else
-        return insorted(badj(g, v), u)
+        return insorted(u, badj(g, v))
     end
 end

--- a/src/graphtypes/simplegraphs/simpledigraph.jl
+++ b/src/graphtypes/simplegraphs/simpledigraph.jl
@@ -122,9 +122,9 @@ end
 
 function rem_edge!(g::SimpleDiGraph, e::SimpleDiGraphEdge)
     has_edge(g, e) || return false
-    i = searchsorted(g.fadjlist[src(e)], dst(e))[1]
+    i = searchsortedfirst(g.fadjlist[src(e)], dst(e))
     deleteat!(g.fadjlist[src(e)], i)
-    i = searchsorted(g.badjlist[dst(e)], src(e))[1]
+    i = searchsortedfirst(g.badjlist[dst(e)], src(e))
     deleteat!(g.badjlist[dst(e)], i)
     g.ne -= 1
     return true
@@ -145,8 +145,8 @@ function has_edge(g::SimpleDiGraph, e::SimpleDiGraphEdge)
     u, v = Tuple(e)
     (u > nv(g) || v > nv(g)) && return false
     if degree(g, u) < degree(g, v)
-        return length(searchsorted(fadj(g, u), v)) > 0
+        return insorted(fadj(g, u), v)
     else
-        return length(searchsorted(badj(g, v), u)) > 0
+        return insorted(badj(g, v), u)
     end
 end

--- a/src/graphtypes/simplegraphs/simpledigraph.jl
+++ b/src/graphtypes/simplegraphs/simpledigraph.jl
@@ -117,11 +117,12 @@ end
 
 
 function rem_edge!(g::SimpleDiGraph, e::SimpleDiGraphEdge)
-    has_edge(g, e) || return false
-    i = searchsortedfirst(g.fadjlist[src(e)], dst(e))
-    deleteat!(g.fadjlist[src(e)], i)
-    i = searchsortedfirst(g.badjlist[dst(e)], src(e))
-    deleteat!(g.badjlist[dst(e)], i)
+    i = searchsorted(g.fadjlist[src(e)], dst(e))
+    isempty(i) && return false # edge doesn't exist
+    j = first(i)
+    deleteat!(g.fadjlist[src(e)], j)
+    j = searchsortedfirst(g.badjlist[dst(e)], src(e))
+    deleteat!(g.badjlist[dst(e)], j)
     g.ne -= 1
     return true
 end

--- a/src/graphtypes/simplegraphs/simpleedgeiter.jl
+++ b/src/graphtypes/simplegraphs/simpleedgeiter.jl
@@ -5,7 +5,7 @@ The function [`edges`](@ref) returns a `SimpleEdgeIter` for `AbstractSimpleGraph
 The iterates are in lexicographical order, smallest first. The iterator is valid for
 one pass over the edges, and is invalidated by changes to the graph.
 """
-mutable struct SimpleEdgeIter{T<:Integer} <: AbstractEdgeIter
+struct SimpleEdgeIter{T<:Integer} <: AbstractEdgeIter
     m::Int
     adj::Vector{Vector{T}}
     directed::Bool

--- a/src/graphtypes/simplegraphs/simpleedgeiter.jl
+++ b/src/graphtypes/simplegraphs/simpleedgeiter.jl
@@ -60,9 +60,9 @@ end
 function _isequal(e1::SimpleEdgeIter, e2)
     for e in e2
         s, d = Tuple(e)
-        found = length(searchsorted(e1.adj[s], d)) > 0
+        found = insorted(e1.adj[s], d)
         if !e1.directed
-            found = found || length(searchsorted(e1.adj[d], s)) > 0
+            found = found || insorted(e1.adj[d], s)
         end
         !found && return false
     end

--- a/src/graphtypes/simplegraphs/simpleedgeiter.jl
+++ b/src/graphtypes/simplegraphs/simpleedgeiter.jl
@@ -60,9 +60,9 @@ end
 function _isequal(e1::SimpleEdgeIter, e2)
     for e in e2
         s, d = Tuple(e)
-        found = insorted(e1.adj[s], d)
+        found = insorted(d, e1.adj[s])
         if !e1.directed
-            found = found || insorted(e1.adj[d], s)
+            found = found || insorted(s, e1.adj[d])
         end
         !found && return false
     end

--- a/src/graphtypes/simplegraphs/simplegraph.jl
+++ b/src/graphtypes/simplegraphs/simplegraph.jl
@@ -14,12 +14,7 @@ eltype(x::SimpleGraph{T}) where T<:Integer = T
 
 # Graph{UInt8}(6), Graph{Int16}(7), Graph{UInt8}()
 function (::Type{SimpleGraph{T}})(n::Integer = 0) where T<:Integer
-    fadjlist = Vector{Vector{T}}()
-    sizehint!(fadjlist, n)
-    for _ = one(T):n
-        push!(fadjlist, Vector{T}())
-    end
-    vertices = one(T):T(n)
+    fadjlist = [Vector{T}() for _ = one(T):n]
     return SimpleGraph{T}(0, fadjlist)
 end
 

--- a/src/graphtypes/simplegraphs/simplegraph.jl
+++ b/src/graphtypes/simplegraphs/simplegraph.jl
@@ -122,7 +122,7 @@ function has_edge(g::SimpleGraph, e::SimpleGraphEdge)
     if degree(g, u) > degree(g, v)
         u, v = v, u
     end
-    return insorted(fadj(g, u), v)
+    return insorted(v, fadj(g, u))
 end
 
 function add_edge!(g::SimpleGraph, e::SimpleGraphEdge)

--- a/src/graphtypes/simplegraphs/simplegraph.jl
+++ b/src/graphtypes/simplegraphs/simplegraph.jl
@@ -146,12 +146,12 @@ end
 
 function rem_edge!(g::SimpleGraph, e::SimpleGraphEdge)
     i = searchsorted(g.fadjlist[src(e)], dst(e))
-    length(i) > 0 || return false   # edge not in graph
-    i = i[1]
-    deleteat!(g.fadjlist[src(e)], i)
+    isempty(i) && return false   # edge not in graph
+    j = first(i)
+    deleteat!(g.fadjlist[src(e)], j)
     if src(e) != dst(e)     # not a self loop
-        i = searchsortedfirst(g.fadjlist[dst(e)], src(e))
-        deleteat!(g.fadjlist[dst(e)], i)
+        j = searchsortedfirst(g.fadjlist[dst(e)], src(e))
+        deleteat!(g.fadjlist[dst(e)], j)
     end
     g.ne -= 1
     return true # edge successfully removed

--- a/src/graphtypes/simplegraphs/simplegraph.jl
+++ b/src/graphtypes/simplegraphs/simplegraph.jl
@@ -127,7 +127,7 @@ function has_edge(g::SimpleGraph, e::SimpleGraphEdge)
     if degree(g, u) > degree(g, v)
         u, v = v, u
     end
-    return length(searchsorted(fadj(g, u), v)) > 0
+    return insorted(fadj(g, u), v)
 end
 
 function add_edge!(g::SimpleGraph, e::SimpleGraphEdge)
@@ -150,7 +150,7 @@ function rem_edge!(g::SimpleGraph, e::SimpleGraphEdge)
     i = i[1]
     deleteat!(g.fadjlist[src(e)], i)
     if src(e) != dst(e)     # not a self loop
-        i = searchsorted(g.fadjlist[dst(e)], src(e))[1]
+        i = searchsortedfirst(g.fadjlist[dst(e)], src(e))
         deleteat!(g.fadjlist[dst(e)], i)
     end
     g.ne -= 1

--- a/src/operators.jl
+++ b/src/operators.jl
@@ -512,10 +512,10 @@ function merge_vertices!(g::Graph, vs::Vector{T} where T <: Integer)
 
     for i in vertices(g)
         # Adjust connections to merged vertices
-        if (i != merged_vertex) && !insorted(vs, i)
+        if (i != merged_vertex) && !insorted(i, vs)
             nbrs_to_rewire = Set{eltype(g)}()
             for j in out_neighbors(g, i)
-               if insorted(vs, j)
+               if insorted(j, vs)
                   push!(nbrs_to_rewire, merged_vertex)
                else
                  push!(nbrs_to_rewire, new_vertex_ids[j])
@@ -527,7 +527,7 @@ function merge_vertices!(g::Graph, vs::Vector{T} where T <: Integer)
         # Collect connections to new merged vertex
         else
             nbrs_to_merge = Set{eltype(g)}()
-            for element in filter(x -> !(insorted(vs, x)) && (x != merged_vertex), g.fadjlist[i])
+            for element in filter(x -> !(insorted(x, vs)) && (x != merged_vertex), g.fadjlist[i])
                 push!(nbrs_to_merge, new_vertex_ids[element])
             end
 

--- a/src/operators.jl
+++ b/src/operators.jl
@@ -489,18 +489,6 @@ function merge_vertices(g::AbstractGraph, vs)
     return newg
 end
 
-function insorted(x::AbstractArray, val)
-    i = searchsortedfirst(x, val)
-    if i > length(x)
-        return false
-    end
-    if x[i] != val
-        return false
-    end
-    return true
-end
-
-
 """
     merge_vertices!(g, vs)
 

--- a/src/shortestpaths/bellman-ford.jl
+++ b/src/shortestpaths/bellman-ford.jl
@@ -29,12 +29,8 @@ function bellman_ford_shortest_paths!(
     state::BellmanFordState
     ) where R<:Real where T<:Integer
 
-    active = Set{T}()
-    for v in sources
-        state.dists[v] = 0
-        state.parents[v] = 0
-        push!(active, v)
-    end
+    active = Set{T}(sources)
+    state.dists[sources] = state.parents[sources] = 0
     no_changes = false
     for i in one(T):nv(graph)
         no_changes = true

--- a/src/shortestpaths/dijkstra.jl
+++ b/src/shortestpaths/dijkstra.jl
@@ -36,7 +36,7 @@ function dijkstra_shortest_paths(
     preds = fill(Vector{U}(), nvg)
     visited = zeros(Bool, nvg)
     pathcounts = zeros(Int, nvg)
-    H = PriorityQueue{U,T}(Base.Order.ForwardOrdering())
+    H = PriorityQueue{U,T}()
     dists[srcs] = zero(T)
     pathcounts[srcs] = 1
     closest_vertices = Vector{U}()  # Maintains vertices in order of distances from source

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -44,12 +44,12 @@ sample(a::UnitRange, k::Integer; exclude = ()) = sample!(getRNG(), collect(a), k
 getRNG(seed::Integer = -1) = seed >= 0 ? MersenneTwister(seed) : Base.Random.GLOBAL_RNG
 
 """
-    insorted(x, val)
+    insorted(item, collection)
 
-Return true if `val` is in sorted collection `x`.
+Return true if `item` is in sorted collection `collection`.
 
 ### Implementation Notes
-Does not verify that `x` is sorted.
+Does not verify that `collection` is sorted.
 """
-insorted(x, val) = !isempty(searchsorted(x, val))
+insorted(item, collection) = !isempty(searchsorted(collection, item))
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -42,3 +42,14 @@ Unlike [`sample!`](@ref), does not produce side effects.
 sample(a::UnitRange, k::Integer; exclude = ()) = sample!(getRNG(), collect(a), k; exclude = exclude)
 
 getRNG(seed::Integer = -1) = seed >= 0 ? MersenneTwister(seed) : Base.Random.GLOBAL_RNG
+
+"""
+    insorted(x, val)
+
+Return true if `val` is in sorted collection `x`.
+
+### Implementation Notes
+Does not verify that `x` is sorted.
+"""
+insorted(x, val) = !isempty(searchsorted(x, val))
+

--- a/test/shortestpaths/dijkstra.jl
+++ b/test/shortestpaths/dijkstra.jl
@@ -33,14 +33,7 @@
     # small function to reconstruct the shortest path; I copied it from somewhere, can't find the original source to give the credits
     # @Beatzekatze on github
     spath(target, dijkstraStruct, source) = target == source ? target : [spath(dijkstraStruct.parents[target], dijkstraStruct, source) target]
-    function spaths(ds, targets, source)
-        shortest_paths = []
-        for i in targets
-            push!(shortest_paths, spath(i, ds, source))
-        end
-        return shortest_paths
-    end
-
+    spaths(ds, targets, source) = [spath(i, ds, source) for i in targets]
 
     G = LightGraphs.Graph()
     add_vertices!(G, 4)


### PR DESCRIPTION
Some simplification of membership testing, and some VERY modest performance improvements.

(`foo()` just removes all edges in a graph.)

Master:
```
julia> @benchmark difference(h, g)
BenchmarkTools.Trial:
  memory estimate:  40.97 MiB
  allocs estimate:  464758
  --------------
  minimum time:     100.119 ms (14.32% GC)
  median time:      126.416 ms (13.82% GC)
  mean time:        153.632 ms (25.77% GC)
  maximum time:     295.614 ms (62.45% GC)
  --------------
  samples:          34
  evals/sample:     1


julia> @benchmark foo(g)
BenchmarkTools.Trial:
  memory estimate:  4.50 MiB
  allocs estimate:  26495
  --------------
  minimum time:     21.885 ms (0.00% GC)
  median time:      27.445 ms (0.00% GC)
  mean time:        30.885 ms (3.55% GC)
  maximum time:     99.003 ms (0.00% GC)
  --------------
  samples:          162
  evals/sample:     1
```
This PR
```
julia> @benchmark difference(h, g)
BenchmarkTools.Trial:
  memory estimate:  40.97 MiB
  allocs estimate:  464758
  --------------
  minimum time:     98.077 ms (5.44% GC)
  median time:      110.199 ms (14.50% GC)
  mean time:        124.564 ms (23.34% GC)
  maximum time:     249.726 ms (58.69% GC)
  --------------
  samples:          41
  evals/sample:     1


julia> @benchmark foo(g)
BenchmarkTools.Trial:
  memory estimate:  4.50 MiB
  allocs estimate:  26495
  --------------
  minimum time:     18.158 ms (0.00% GC)
  median time:      24.558 ms (0.00% GC)
  mean time:        27.837 ms (3.87% GC)
  maximum time:     107.658 ms (0.00% GC)
  --------------
  samples:          181
  evals/sample:     1
```