### PR TITLE
Make SimpleEdgeIter immutable

### DIFF
--- a/src/graphtypes/simplegraphs/simpleedgeiter.jl
+++ b/src/graphtypes/simplegraphs/simpleedgeiter.jl
@@ -5,7 +5,7 @@ The function [`edges`](@ref) returns a `SimpleEdgeIter` for `AbstractSimpleGraph
 The iterates are in lexicographical order, smallest first. The iterator is valid for
 one pass over the edges, and is invalidated by changes to the graph.
 """
-mutable struct SimpleEdgeIter{T<:Integer} <: AbstractEdgeIter
+struct SimpleEdgeIter{T<:Integer} <: AbstractEdgeIter
     m::Int
     adj::Vector{Vector{T}}
     directed::Bool


### PR DESCRIPTION
`SimpleEdgeIter` can be immutable. Benchmark:
```julia
g = CompleteGraph(5)
g2 = CompleteDiGraph(5)

function bench_iteredges(g::AbstractGraph)
    i = 0
    for k in 1:100
        for e in edges(g)
            i += src(e)
        end
    end
    i
end
```

Before
```julia
julia> @btime bench_iteredges($g)
  26.374 μs (100 allocations: 3.13 KiB)
2000


julia> @btime bench_iteredges($g2)
  47.728 μs (100 allocations: 3.13 KiB)
6000
```

After
```julia
julia> @btime bench_iteredges($g)
  23.919 μs (100 allocations: 3.13 KiB)
2000

julia> @btime bench_iteredges($g2)
  43.240 μs (100 allocations: 3.13 KiB)
6000
```

I think the improvement is small because the main cost is creating a reference to an array with housekeeping of the garbage collector and some unboxing happens.