### PR TITLE
Simplify SimpleEdgeIter

### DIFF
--- a/src/graphtypes/simplegraphs/simpleedgeiter.jl
+++ b/src/graphtypes/simplegraphs/simpleedgeiter.jl
@@ -5,83 +5,66 @@ The function [`edges`](@ref) returns a `SimpleEdgeIter` for `AbstractSimpleGraph
 The iterates are in lexicographical order, smallest first. The iterator is valid for
 one pass over the edges, and is invalidated by changes to the graph.
 """
-struct SimpleEdgeIter{T<:Integer} <: AbstractEdgeIter
-    m::Int
-    adj::Vector{Vector{T}}
-    directed::Bool
+struct SimpleEdgeIter{G} <: AbstractEdgeIter
+    g::G
 end
 
 struct SimpleEdgeIterState{T<:Integer}
-    s::T  # src vertex
+    s::T  # src vertex or zero if done
     di::Int # index into adj of dest vertex
-    fin::Bool
 end
 
+eltype(::Type{SimpleEdgeIter{SimpleGraph{T}}}) where {T} = SimpleGraphEdge{T}
+eltype(::Type{SimpleEdgeIter{SimpleDiGraph{T}}}) where {T} = SimpleDiGraphEdge{T}
 
-eltype(::Type{SimpleEdgeIter{T}}) where T<:Integer = SimpleEdge{T}
+function edge_start(g::Union{SimpleGraph{T}, SimpleDiGraph{T}}) where {T <: Integer}
+    s = one(T)
+    while s <= nv(g)
+        isempty(fadj(g, s)) || return SimpleEdgeIterState(s, 1)
+        s += one(T)
+    end
+    return SimpleEdgeIterState(zero(T), 1)
+end
 
-SimpleEdgeIter(g::SimpleGraph) = SimpleEdgeIter(ne(g), g.fadjlist, false)
-SimpleEdgeIter(g::SimpleDiGraph) = SimpleEdgeIter(ne(g), g.fadjlist, true)
-
-function _next(
-    eit::SimpleEdgeIter{T},
-    state::SimpleEdgeIterState{T} = SimpleEdgeIterState(one(T), 1, false),
-    first::Bool = true) where T <: Integer
+function edge_next(g::Union{SimpleGraph{T}, SimpleDiGraph{T}}, 
+    state::SimpleEdgeIterState{T}) where {T <: Integer}
     s = state.s
     di = state.di
-    if !first
-        di += 1
-    end
-    fin = state.fin
-    while s <= length(eit.adj)
-        arr = eit.adj[s]
-        while di <= length(arr)
-            if eit.directed || s <= arr[di]
-                return SimpleEdgeIterState(s, di, fin)
+    e = SimpleEdge(s, fadj(g, s)[di])
+    di += 1
+    while s <= nv(g)
+        sadj = fadj(g, s)
+        while di <= length(sadj)
+            if is_directed(g) || s <= sadj[di]
+                return e, SimpleEdgeIterState(s, di)
             end
             di += 1
         end
         s += one(T)
         di = 1
     end
-    fin = true
-    return SimpleEdgeIterState(s, di, fin)
+    return e, SimpleEdgeIterState(zero(T), 1)
 end
 
-start(eit::SimpleEdgeIter) = _next(eit)
-done(eit::SimpleEdgeIter, state::SimpleEdgeIterState) = state.fin
-length(eit::SimpleEdgeIter) = eit.m
-
-function next(eit::SimpleEdgeIter, state::SimpleEdgeIterState)
-    edge = SimpleEdge(state.s, eit.adj[state.s][state.di])
-    return(edge, _next(eit, state, false))
-end
+start(eit::SimpleEdgeIter) = edge_start(eit.g)
+done(eit::SimpleEdgeIter, state::SimpleEdgeIterState) = state.s == 0
+length(eit::SimpleEdgeIter) = ne(eit.g)
+next(eit::SimpleEdgeIter, state::SimpleEdgeIterState) = edge_next(eit.g, state)
 
 function _isequal(e1::SimpleEdgeIter, e2)
+    k = 0
     for e in e2
-        s, d = Tuple(e)
-        found = length(searchsorted(e1.adj[s], d)) > 0
-        if !e1.directed
-            found = found || length(searchsorted(e1.adj[d], s)) > 0
-        end
-        !found && return false
+        has_edge(e1.g, e) || return false
+        k += 1
     end
-    return true
+    return k == ne(e1.g)
 end
 ==(e1::SimpleEdgeIter, e2::AbstractVector{SimpleEdge}) = _isequal(e1, e2)
 ==(e1::AbstractVector{SimpleEdge}, e2::SimpleEdgeIter) = _isequal(e2, e1)
 ==(e1::SimpleEdgeIter, e2::Set{SimpleEdge}) = _isequal(e1, e2)
 ==(e1::Set{SimpleEdge}, e2::SimpleEdgeIter) = _isequal(e2, e1)
 
-
-function ==(e1::SimpleEdgeIter, e2::SimpleEdgeIter)
-    length(e1.adj) == length(e2.adj) || return false
-    e1.directed == e2.directed || return false
-    for i in 1:length(e1.adj)
-        e1.adj[i] == e2.adj[i] || return false
-    end
-    return true
-end
-
-show(io::IO, eit::SimpleEdgeIter) = write(io, "SimpleEdgeIter $(eit.m)")
-show(io::IO, s::SimpleEdgeIterState) = write(io, "SimpleEdgeIterState [$(s.s), $(s.di), $(s.fin)]")
+==(e1::SimpleEdgeIter, e2::SimpleEdgeIter) = e1.g == e2.g
+ 
+show(io::IO, eit::SimpleEdgeIter) = write(io, "SimpleEdgeIter $(ne(eit.g))")
+show(io::IO, s::SimpleEdgeIterState) = write(io, "SimpleEdgeIterState [$(s.s), $(s.di)]")

--- a/src/graphtypes/simplegraphs/simpleedgeiter.jl
+++ b/src/graphtypes/simplegraphs/simpleedgeiter.jl
@@ -64,7 +64,23 @@ end
 ==(e1::SimpleEdgeIter, e2::Set{SimpleEdge}) = _isequal(e1, e2)
 ==(e1::Set{SimpleEdge}, e2::SimpleEdgeIter) = _isequal(e2, e1)
 
-==(e1::SimpleEdgeIter, e2::SimpleEdgeIter) = e1.g == e2.g
- 
+function ==(e1::SimpleEdgeIter, e2::SimpleEdgeIter) 
+    g = e1.g
+    h = e2.g
+    g.ne == g.ne || return false
+    m = min(nv(g), nv(h))
+    for i in 1:m
+        fadj(g, i) == fadj(h, i) || return false
+    end
+    nv(g) == nv(h) && return true
+    for i in m+1:nv(g)
+        isempty(fadj(g, i)) || return false
+    end
+    for i in m+1:nv(h)
+        isempty(fadj(h, i)) || return false
+    end
+    return true   
+end
+
 show(io::IO, eit::SimpleEdgeIter) = write(io, "SimpleEdgeIter $(ne(eit.g))")
 show(io::IO, s::SimpleEdgeIterState) = write(io, "SimpleEdgeIterState [$(s.s), $(s.di)]")

--- a/test/graphtypes/simplegraphs/simpleedgeiter.jl
+++ b/test/graphtypes/simplegraphs/simpleedgeiter.jl
@@ -39,6 +39,11 @@
 
     @test [e for e in eit] == [Edge(2, 3), Edge(3, 10), Edge(5, 10)]
 
+    gb = copy(ga)
+    add_vertex!(gb)
+    @test edges(ga) == edges(gb)
+    @test edges(gb) == edges(ga)
+
     ga = SimpleDiGraph(10)
     add_edge!(ga, 3, 2)
     add_edge!(ga, 3, 10)
@@ -55,4 +60,9 @@
       SimpleEdge(3, 2), SimpleEdge(3, 10),
       SimpleEdge(5, 10), SimpleEdge(10, 3)
     ]
+
+    gb = copy(ga)
+    add_vertex!(gb)
+    @test edges(ga) == edges(gb)
+    @test edges(gb) == edges(ga)
 end

--- a/test/graphtypes/simplegraphs/simpleedgeiter.jl
+++ b/test/graphtypes/simplegraphs/simpleedgeiter.jl
@@ -2,12 +2,14 @@
     ga = @inferred(SimpleGraph(10, 20; seed=1))
     gb = @inferred(SimpleGraph(10, 20; seed=1))
     @test sprint(show, edges(ga)) == "SimpleEdgeIter 20"
-    @test sprint(show, start(edges(ga))) == "SimpleEdgeIterState [1, 1, false]"
+    @test sprint(show, start(edges(ga))) == "SimpleEdgeIterState [1, 1]"
 
     @test length(collect(edges(Graph(0, 0)))) == 0
 
     @test @inferred(edges(ga)) == edges(gb)
     @test @inferred(edges(ga)) == collect(Edge, edges(gb))
+    @test edges(ga) != collect(Edge, Base.Iterators.take(edges(gb), 5))
+    
     @test collect(Edge, edges(gb)) == edges(ga)
     @test Set{Edge}(collect(Edge, edges(gb))) == edges(ga)
     @test @inferred(edges(ga)) == Set{Edge}(collect(Edge, edges(gb)))


### PR DESCRIPTION
Now 
```julia
struct SimpleEdgeIter{G} <: AbstractEdgeIter
    g::G
end
```
which simplifies things. We now almost define an iterator of edges for SimpleGraphs: Only `start` and `next` are called `edge_start` and `edge_next` for SimpleGraphs and `start`, `done` for `SimpleEdgeIter` are just a thin wrappers.

Before (same tests as #749) 
```
julia> @btime bench_iteredges($g)
  23.919 μs (100 allocations: 3.13 KiB)
2000

julia> @btime bench_iteredges($g2)
  43.240 μs (100 allocations: 3.13 KiB)
6000
```
and after:
```
julia> @btime bench_iteredges($g)
  17.632 μs (0 allocations: 0 bytes)
2000

julia> @btime bench_iteredges($g2)
  28.881 μs (0 allocations: 0 bytes)
6000
```

Fixes #750 , enables #748.