### PR TITLE
e ∈ edges(g)

### DIFF
--- a/src/graphtypes/simplegraphs/SimpleGraphs.jl
+++ b/src/graphtypes/simplegraphs/SimpleGraphs.jl
@@ -1,7 +1,7 @@
 module SimpleGraphs
 
 import Base:
-    eltype, show, ==, Pair, Tuple, copy, length, start, next, done, issubset, zero
+    eltype, show, ==, Pair, Tuple, copy, length, start, next, done, issubset, zero, in
 
 import LightGraphs:
     _NI, _insert_and_dedup!, AbstractGraph, AbstractEdge, AbstractEdgeIter,

--- a/src/graphtypes/simplegraphs/simpleedgeiter.jl
+++ b/src/graphtypes/simplegraphs/simpleedgeiter.jl
@@ -82,5 +82,8 @@ function ==(e1::SimpleEdgeIter, e2::SimpleEdgeIter)
     return true   
 end
 
+in(e::SimpleEdge, es::SimpleEdgeIter) = has_edge(es.g, e)
+in(e::Union{Pair, NTuple{2}}, es::SimpleEdgeIter) = has_edge(es.g, e)
+
 show(io::IO, eit::SimpleEdgeIter) = write(io, "SimpleEdgeIter $(ne(eit.g))")
 show(io::IO, s::SimpleEdgeIterState) = write(io, "SimpleEdgeIterState [$(s.s), $(s.di)]")

--- a/src/graphtypes/simplegraphs/simpleedgeiter.jl
+++ b/src/graphtypes/simplegraphs/simpleedgeiter.jl
@@ -82,8 +82,7 @@ function ==(e1::SimpleEdgeIter, e2::SimpleEdgeIter)
     return true   
 end
 
-in(e::SimpleEdge, es::SimpleEdgeIter) = has_edge(es.g, e)
-in(e::Union{Pair, NTuple{2}}, es::SimpleEdgeIter) = has_edge(es.g, e)
+in(e, es::SimpleEdgeIter) = has_edge(es.g, e)
 
 show(io::IO, eit::SimpleEdgeIter) = write(io, "SimpleEdgeIter $(ne(eit.g))")
 show(io::IO, s::SimpleEdgeIterState) = write(io, "SimpleEdgeIterState [$(s.s), $(s.di)]")

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -107,6 +107,8 @@ vertices(g::AbstractGraph) = _NI("vertices")
 
 Return (an iterator to or collection of) the edges of a graph.
 For `AbstractSimpleGraph`s it returns a [`SimpleEdgeIter`](@ref).
+The expressions `e in edges(g)` and `e ∈ edges(ga)` evaluate as
+calls to [`has_edge`](@ref).
 
 ### Implementation Notes
 A returned iterator is valid for one pass over the edges, and
@@ -162,8 +164,11 @@ has_vertex(x, v) = _NI("has_vertex")
 
 """
     has_edge(g, e)
+    e ∈ edges(g)
 
-Return true if the graph `g` has an edge `e`.
+Return true if the graph `g` has an edge `e`. 
+The expressions `e in edges(g)` and `e ∈ edges(ga)` evaluate as
+calls to `has_edge`, c.f. [`edges`](@ref).
 """
 has_edge(x, e) = _NI("has_edge")
 

--- a/test/graphtypes/simplegraphs/simpleedgeiter.jl
+++ b/test/graphtypes/simplegraphs/simpleedgeiter.jl
@@ -31,6 +31,19 @@
     add_edge!(ga, 5, 10)
     add_edge!(ga, 10, 3)
 
+    e1 = Edge(3, 10)
+    e2 = (3, 10)
+    @test e1 ∈ edges(ga)
+    @test e2 ∈ edges(ga) 
+    @test (3, 9) ∉ edges(ga)
+   
+    for u in 1:20, v in 1:20
+      b = has_edge(ga, u, v) 
+      @test b == @inferred (u, v) ∈ edges(ga)
+      @test b == @inferred (u => v) ∈ edges(ga)
+      @test b == @inferred Edge(u, v) ∈ edges(ga)
+    end      
+
     eit = edges(ga)
     es = @inferred(start(eit))
 
@@ -44,11 +57,19 @@
     @test edges(ga) == edges(gb)
     @test edges(gb) == edges(ga)
 
+
     ga = SimpleDiGraph(10)
     add_edge!(ga, 3, 2)
     add_edge!(ga, 3, 10)
     add_edge!(ga, 5, 10)
     add_edge!(ga, 10, 3)
+
+    for u in 1:20, v in 1:20
+      b = has_edge(ga, u, v) 
+      @test b == @inferred (u, v) ∈ edges(ga)
+      @test b == @inferred (u => v) ∈ edges(ga)
+      @test b == @inferred Edge(u, v) ∈ edges(ga)
+    end   
 
     eit = @inferred(edges(ga))
     es = @inferred(start(eit))


### PR DESCRIPTION
As discussion in #748, using #751 . This worked out nicely: with

```julia
using LightGraphs, BenchmarkTools
function bench_tuple_in(g::AbstractGraph)
    i = 0
    for u in 1:nv(g), v in 1:nv(g)
        e = (u, v)
        i += e in edges(g)
    end
    i
end
function bench_edge_in(g::AbstractGraph)
    i = 0
    for u in 1:nv(g), v in 1:nv(g)
        e = Edge(u, v)
        i += e in edges(g)
    end
    i
end
function bench_has_edge(g::AbstractGraph)
    i = 0
    for u in 1:nv(g), v in 1:nv(g)
        e = (u, v)
        i += has_edge(g, e)
    end
    i
end
srand(1);g3 = Graph(50,500)
```

I get 

```
@btime bench_tuple_in($g3)
  125.951 μs (0 allocations: 0 bytes)
@btime bench_edge_in($g3)
  125.868 μs (0 allocations: 0 bytes)
@btime bench_has_edge($g3)
  126.383 μs (0 allocations: 0 bytes)
```
