### PR TITLE
add missing space next to NetworkViz.jl header in plotting docs

### DIFF
--- a/docs/src/plotting.md
+++ b/docs/src/plotting.md
@@ -46,7 +46,7 @@ julia> draw(PNG("/tmp/wheel10.png", 16cm, 16cm), gplot(g))
 ```
 
 
-##[NetworkViz.jl](https://github.com/abhijithanilkumar/NetworkViz.jl)
+## [NetworkViz.jl](https://github.com/abhijithanilkumar/NetworkViz.jl)
 NetworkViz.jl is tightly coupled with *LightGraphs.jl*. Graphs can be visualized in 2D as well as 3D using [ThreeJS.jl](https://github.com/rohitvarkey/ThreeJS.jl) and [Escher.jl](https://github.com/shashi/Escher.jl).
 
 ```julia


### PR DESCRIPTION
I was reading the documentation and noticed that on [this page](http://juliagraphs.github.io/LightGraphs.jl/latest/plotting.html), a line starts with "##NetworkViz.jl." I thought it might be a missing space in a markdown header. This pull request just adds that space.