### PR TITLE
reduce pre-allocation for infections

### DIFF
--- a/src/traversals/diffusion.jl
+++ b/src/traversals/diffusion.jl
@@ -39,7 +39,7 @@ function diffusion(g::AbstractGraph{T},
     end
 
     # Run simulation
-    randsubseq_buf = zeros(T, nv(g))
+    randsubseq_buf = zeros(T, Δout(g))
 
     for step in 2:n
         new_infections = Set{T}()


### PR DESCRIPTION
Not the source of my bug I don't think, but did discover this line resulted in largest total memory allocation by factor of 100. And also erroneously large!