### PR TITLE
Add random tournament digraph generator.

### DIFF
--- a/src/LightGraphs.jl
+++ b/src/LightGraphs.jl
@@ -103,9 +103,9 @@ multiroute_flow, KishimotoAlgorithm, ExtendedMultirouteFlowAlgorithm,
 
 # randgraphs
 erdos_renyi, watts_strogatz, random_regular_graph, random_regular_digraph, random_configuration_model,
-StochasticBlockModel, make_edgestream, nearbipartiteSBM, blockcounts, blockfractions,
-stochastic_block_model, barabasi_albert, barabasi_albert!, static_fitness_model, static_scale_free,
-kronecker,
+random_tournament_digraph, StochasticBlockModel, make_edgestream, nearbipartiteSBM, blockcounts,
+blockfractions, stochastic_block_model, barabasi_albert, barabasi_albert!, static_fitness_model,
+static_scale_free, kronecker,
 
 #community
 modularity, core_periphery_deg,

--- a/src/generators/randgraphs.jl
+++ b/src/generators/randgraphs.jl
@@ -613,10 +613,8 @@ function random_tournament_digraph(n::Integer; seed::Int=-1)
     rng = getRNG(seed)
     g = DiGraph(n)
 
-    for i = 1:n
-        for j = i+1:n
-            rand(rng) > 0.5 ? add_edge!(g, Edge(i, j)) : add_edge!(g, Edge(j, i))
-        end
+    for i = 1:n, j = i+1:n
+        rand(rng) > 0.5 ? add_edge!(g, Edge(i, j)) : add_edge!(g, Edge(j, i))
     end
 
     return g

--- a/src/generators/randgraphs.jl
+++ b/src/generators/randgraphs.jl
@@ -602,7 +602,7 @@ end
     random_tournament_digraph(n)
 
 Create a random directed [tournament graph]
-(https://en.wikipedia.org/wiki/Tournament_(graph_theory))
+(https://en.wikipedia.org/wiki/Tournament_%28graph_theory%29)
 with `n` vertices.
 
 ### Optional Arguments

--- a/src/generators/randgraphs.jl
+++ b/src/generators/randgraphs.jl
@@ -614,7 +614,7 @@ function random_tournament_digraph(n::Integer; seed::Int=-1)
     g = DiGraph(n)
 
     for i = 1:n
-        for j = i:n
+        for j = i+1:n
             rand(rng) > 0.5 ? add_edge!(g, Edge(i, j)) : add_edge!(g, Edge(j, i))
         end
     end

--- a/src/generators/randgraphs.jl
+++ b/src/generators/randgraphs.jl
@@ -599,6 +599,30 @@ function random_regular_digraph(n::Integer, k::Integer; dir::Symbol=:out, seed::
 end
 
 @doc_str """
+    random_tournament_digraph(n)
+
+Create a random directed [tournament graph]
+(https://en.wikipedia.org/wiki/Tournament_(graph_theory))
+with `n` vertices.
+
+### Optional Arguments
+- `seed=-1`: set the RNG seed.
+"""
+function random_tournament_digraph(n::Integer; seed::Int=-1)
+
+    rng = getRNG(seed)
+    g = DiGraph(n)
+
+    for i = 1:n
+        for j = i:n
+            rand(rng) > 0.5 ? add_edge!(g, Edge(i, j)) : add_edge!(g, Edge(j, i))
+        end
+    end
+
+    return g
+end
+
+@doc_str """
     stochastic_block_model(c, n)
 
 Return a Graph generated according to the Stochastic Block Model (SBM).

--- a/src/generators/randgraphs.jl
+++ b/src/generators/randgraphs.jl
@@ -614,7 +614,7 @@ function random_tournament_digraph(n::Integer; seed::Int=-1)
     g = DiGraph(n)
 
     for i = 1:n, j = i+1:n
-        rand(rng) > 0.5 ? add_edge!(g, Edge(i, j)) : add_edge!(g, Edge(j, i))
+        rand(rng, Bool) ? add_edge!(g, Edge(i, j)) : add_edge!(g, Edge(j, i))
     end
 
     return g

--- a/test/generators/randgraphs.jl
+++ b/test/generators/randgraphs.jl
@@ -194,6 +194,12 @@
     @test ne(rd) == 80
     @test is_directed(rd)
 
+    rt = random_tournament_digraph(10)
+    @test nv(rt) == 10
+    @test ne(rt) == 55
+    @test is_directed(rt)
+    @test all(degree(rt) .== 11)
+
     g = stochastic_block_model(2., 3., [100,100])
     @test  4.0 < mean(degree(g)) < 6.0
     g = stochastic_block_model(3., 4., [100,100,100])

--- a/test/generators/randgraphs.jl
+++ b/test/generators/randgraphs.jl
@@ -200,8 +200,11 @@
     @test is_directed(rt)
     @test all(degree(rt) .== 9)
     Edges = edges(rt)
-    for edge in Edges
-        @test !(reverse(edge) ∈ Edges)
+    for i = 1:10, j = 1:10
+        if i != j
+            edge = Edge(i, j)
+            @test xor(edge ∈ Edges, reverse(edge) ∈ Edges)
+        end
     end
 
     g = stochastic_block_model(2., 3., [100,100])

--- a/test/generators/randgraphs.jl
+++ b/test/generators/randgraphs.jl
@@ -196,9 +196,13 @@
 
     rt = random_tournament_digraph(10)
     @test nv(rt) == 10
-    @test ne(rt) == 55
+    @test ne(rt) == 45
     @test is_directed(rt)
-    @test all(degree(rt) .== 11)
+    @test all(degree(rt) .== 9)
+    Edges = edges(rt)
+    for edge in Edges
+        @test !(reverse(edge) ∈ Edges)
+    end
 
     g = stochastic_block_model(2., 3., [100,100])
     @test  4.0 < mean(degree(g)) < 6.0


### PR DESCRIPTION
Hi, I am working on a tournament game generator, and find that random [tournament graph](https://en.wikipedia.org/wiki/Tournament_(graph_theory)) generator has not been implemented yet in `LightGraphs`. Therefore, I wrote several lines for generating it. It would be great if you think tournament graph generator is generally useful and my code could be useful.