### PR TITLE
expected_degree_graph (Chung-Lu model)

### DIFF
--- a/src/LightGraphs.jl
+++ b/src/LightGraphs.jl
@@ -98,10 +98,10 @@ contract,
 loadgraph, loadgraphs, savegraph, LGFormat,
 
 # randgraphs
-erdos_renyi, watts_strogatz, random_regular_graph, random_regular_digraph, random_configuration_model,
-random_tournament_digraph, StochasticBlockModel, make_edgestream, nearbipartiteSBM, blockcounts,
-blockfractions, stochastic_block_model, barabasi_albert, barabasi_albert!, static_fitness_model,
-static_scale_free, kronecker,
+erdos_renyi, expected_degree, watts_strogatz, random_regular_graph, random_regular_digraph,
+random_configuration_model, random_tournament_digraph, StochasticBlockModel, make_edgestream,
+nearbipartiteSBM, blockcounts, blockfractions, stochastic_block_model, barabasi_albert,
+barabasi_albert!, static_fitness_model, static_scale_free, kronecker,
 
 #community
 modularity, core_periphery_deg,

--- a/src/LightGraphs.jl
+++ b/src/LightGraphs.jl
@@ -98,7 +98,7 @@ contract,
 loadgraph, loadgraphs, savegraph, LGFormat,
 
 # randgraphs
-erdos_renyi, expected_degree, watts_strogatz, random_regular_graph, random_regular_digraph,
+erdos_renyi, expected_degree_graph, watts_strogatz, random_regular_graph, random_regular_digraph,
 random_configuration_model, random_tournament_digraph, StochasticBlockModel, make_edgestream,
 nearbipartiteSBM, blockcounts, blockfractions, stochastic_block_model, barabasi_albert,
 barabasi_albert!, static_fitness_model, static_scale_free, kronecker,

--- a/src/generators/randgraphs.jl
+++ b/src/generators/randgraphs.jl
@@ -90,9 +90,6 @@ function erdos_renyi(n::Integer, ne::Integer; is_directed=false, seed::Integer=-
     return is_directed ? SimpleDiGraph(n, ne, seed=seed) : SimpleGraph(n, ne, seed=seed)
 end
 
-# Algorithm from https://doi.org/10.1007/978-3-642-21286-4_10
-# Efficient Generation of Networks with Given Expected Degrees
-# Joel C. Miller and Aric Hagberg
 """
     expected_degree_graph(ω)
 
@@ -105,6 +102,9 @@ some deviations from the expected values.
 
 ### Optional Arguments
 - `seed=-1`: set the RNG seed.
+
+### References
+- Efficient Generation of Networks with Given Expected Degrees, Joel C. Miller and Aric Hagberg. [https://doi.org/10.1007/978-3-642-21286-4_10](https://doi.org/10.1007/978-3-642-21286-4_10)
 """
 function expected_degree_graph(ω::Vector{T}; seed::Int=-1) where T<:Real
     g = Graph(length(ω))
@@ -137,7 +137,7 @@ function expected_degree_graph!(g::Graph, ω::Vector{T}; seed::Int=-1) where T<:
           end
        end
     end
-    g
+    return g
 end
 
 

--- a/src/generators/randgraphs.jl
+++ b/src/generators/randgraphs.jl
@@ -104,7 +104,7 @@ The algorithm should work well for `maximum(ω) << sum(ω)`. As `maximum(ω)` ap
 from the expected values are likely.
 
 ### References
-- Connected Components in Random Graphs with Given Expected Degree Sequences, Linyuan Lu Fan Chung. [https://link.springer.com/article/10.1007%2FPL00012580](https://link.springer.com/article/10.1007%2FPL00012580)
+- Connected Components in Random Graphs with Given Expected Degree Sequences, Linyuan Lu and Fan Chung. [https://link.springer.com/article/10.1007%2FPL00012580](https://link.springer.com/article/10.1007%2FPL00012580)
 - Efficient Generation of Networks with Given Expected Degrees, Joel C. Miller and Aric Hagberg. [https://doi.org/10.1007/978-3-642-21286-4_10](https://doi.org/10.1007/978-3-642-21286-4_10)
 """
 function expected_degree_graph(ω::Vector{T}; seed::Int=-1) where T<:Real

--- a/src/generators/randgraphs.jl
+++ b/src/generators/randgraphs.jl
@@ -121,11 +121,11 @@ function expected_degree_graph(ω::Vector{T}; seed::Int=-1) where T<:Real
        p = min(ω[π[u]]*ω[π[v]]/S, one(T))
        while v <= n && p > zero(p)
           if p != one(T)
-             v += floor(Int, log(rand())/log(one(T)-p))
+             v += floor(Int, log(rand(rng))/log(one(T)-p))
           end
           if v <= n
              q = min(ω[π[u]]*ω[π[v]]/S, one(T))
-             if rand() < q/p
+             if rand(rng) < q/p
                  add_edge!(g, π[u], π[v])
              end
              p = q

--- a/src/generators/randgraphs.jl
+++ b/src/generators/randgraphs.jl
@@ -93,17 +93,18 @@ end
 """
     expected_degree_graph(ω)
 
-Create a random graph with given expected degree with `length(ω)`
-vertices and vector of expected degrees `ω`, see [here](https://doi.org/10.1007/PL00012580).
-Vertices `i` and `j` are connected with probability `ω[i]*ω[j]/sum(ω)`.
-
-Note that the algorithm works well for `maximum(ω) << sum(ω)`. Otherwise, we can see
-some deviations from the expected values.
+Given a vector of expected degrees `ω` indexed by vertex, create a random undirected graph in which vertices `i` and `j` are
+connected with probability `ω[i]*ω[j]/sum(ω)`.
 
 ### Optional Arguments
 - `seed=-1`: set the RNG seed.
 
+### Implementation Notes
+The algorithm should work well for `maximum(ω) << sum(ω)`. As `maximum(ω)` approaches `sum(ω)`, some deviations
+from the expected values are likely.
+
 ### References
+- Connected Components in Random Graphs with Given Expected Degree Sequences, Linyuan Lu Fan Chung. [https://link.springer.com/article/10.1007%2FPL00012580](https://link.springer.com/article/10.1007%2FPL00012580)
 - Efficient Generation of Networks with Given Expected Degrees, Joel C. Miller and Aric Hagberg. [https://doi.org/10.1007/978-3-642-21286-4_10](https://doi.org/10.1007/978-3-642-21286-4_10)
 """
 function expected_degree_graph(ω::Vector{T}; seed::Int=-1) where T<:Real

--- a/src/generators/randgraphs.jl
+++ b/src/generators/randgraphs.jl
@@ -107,13 +107,17 @@ some deviations from the expected values.
 - `seed=-1`: set the RNG seed.
 """
 function expected_degree_graph(ω::Vector{T}; seed::Int=-1) where T<:Real
+    g = Graph(length(ω))
+    expected_degree_graph!(g, ω, seed=seed)
+end
+
+function expected_degree_graph!(g::Graph, ω::Vector{T}; seed::Int=-1) where T<:Real
     n = length(ω)
     @assert all(zero(T) .<= ω .<= n-one(T)) "Elements of ω needs to be at least 0 and at most n-1"
 
     π = sortperm(ω, rev=true)
     rng = getRNG(seed)
 
-    g = Graph(n)
     S = sum(ω)
 
     for u=1:(n-1)

--- a/test/generators/randgraphs.jl
+++ b/test/generators/randgraphs.jl
@@ -32,18 +32,18 @@
     @test nv(er) == 10
     @test is_directed(er) == false
 
-    cl = expected_degree(zeros(10), seed = 17)
+    cl = expected_degree_graph(zeros(10), seed = 17)
     @test nv(cl) == 10
     @test ne(cl) == 0
     @test is_directed(cl) == false
 
-    cl = expected_degree([3, 2, 1, 2], seed = 17)
+    cl = expected_degree_graph([3, 2, 1, 2], seed = 17)
     @test nv(cl) == 4
     @test is_directed(cl) == false
 
-    cl = expected_degree(fill(99, 100), seed = 17)
+    cl = expected_degree_graph(fill(99, 100), seed = 17)
     @test nv(cl) == 100
-    @test all(degree(cl) .> 95)
+    @test all(degree(cl) .> 90)
 
     ws = watts_strogatz(10,4,0.2)
     @test nv(ws) == 10

--- a/test/generators/randgraphs.jl
+++ b/test/generators/randgraphs.jl
@@ -32,6 +32,18 @@
     @test nv(er) == 10
     @test is_directed(er) == false
 
+    cl = expected_degree(zeros(10), seed = 17)
+    @test nv(cl) == 10
+    @test ne(cl) == 0
+    @test is_directed(cl) == false
+
+    cl = expected_degree([3, 2, 1, 2], seed = 17)
+    @test nv(cl) == 4
+    @test is_directed(cl) == false
+
+    cl = expected_degree(fill(99, 100), seed = 17)
+    @test nv(cl) == 100
+    @test all(degree(cl) .> 95)
 
     ws = watts_strogatz(10,4,0.2)
     @test nv(ws) == 10


### PR DESCRIPTION
PR consists of
- implementation of `expected_degree_graph` and `expected_degree_graph!`, both with optional argument `seed`,
- simple, passing tests for the function,
- documentation of the function,
- comment which consist of the link to an article presenting the algorithm,
- proper export in LightGraphs.jl.

The code does not work with directed graphs, as the model is implemented for undirected graphs only.
The code works well iff the expected degree is much smaller than the order of the graph. This is known issue, which can be observed in networkx too.