### PR TITLE
Allowing to use MST algorithm with SimpleWeightedGraphs.jl

### DIFF
--- a/src/spanningtrees/kruskal.jl
+++ b/src/spanningtrees/kruskal.jl
@@ -1,5 +1,5 @@
 struct KruskalHeapEntry{T<:Real}
-    edge::Edge
+    edge::AbstractEdge
     dist::T
 end
 
@@ -35,7 +35,7 @@ function kruskal_mst end
 )
 
     edge_list = Vector{KruskalHeapEntry{T}}()
-    mst = Vector{Edge}()
+    mst = Vector{AbstractEdge}()
     connected_vs = collect(one(U):nv(g))
 
     sizehint!(edge_list, ne(g))

--- a/src/spanningtrees/kruskal.jl
+++ b/src/spanningtrees/kruskal.jl
@@ -29,11 +29,12 @@ distance matrix `distmx` using [Kruskal's algorithm](https://en.wikipedia.org/wi
 """
 function kruskal_mst end
 # see https://github.com/mauro3/SimpleTraits.jl/issues/47#issuecomment-327880153 for syntax
-@traitfn function kruskal_mst{T<:AbstractEdge, U<:Real, V, AG<:AbstractGraph{T}}(
+@traitfn function kruskal_mst{U<:Real, V, AG<:AbstractGraph{V}}(
     g::AG::(!IsDirected),
     distmx::AbstractMatrix{U} = weights(g)
 )
 
+    T = edgetype(g)
     edge_list = Vector{KruskalHeapEntry{T, U}}()
     mst = Vector{T}()
     connected_vs = collect(one(V):nv(g))

--- a/src/spanningtrees/kruskal.jl
+++ b/src/spanningtrees/kruskal.jl
@@ -1,6 +1,6 @@
-struct KruskalHeapEntry{T<:Real}
-    edge::AbstractEdge
-    dist::T
+struct KruskalHeapEntry{T<:AbstractEdge, U<:Real}
+    edge::T
+    dist::U
 end
 
 isless(e1::KruskalHeapEntry, e2::KruskalHeapEntry) = e1.dist < e2.dist
@@ -29,20 +29,20 @@ distance matrix `distmx` using [Kruskal's algorithm](https://en.wikipedia.org/wi
 """
 function kruskal_mst end
 # see https://github.com/mauro3/SimpleTraits.jl/issues/47#issuecomment-327880153 for syntax
-@traitfn function kruskal_mst{T, U, AG<:AbstractGraph{U}}(
+@traitfn function kruskal_mst{T, U, V, AG<:AbstractGraph{U}}(
     g::AG::(!IsDirected),
     distmx::AbstractMatrix{T} = weights(g)
 )
 
-    edge_list = Vector{KruskalHeapEntry{T}}()
+    edge_list = Vector{KruskalHeapEntry{T, U}}()
     mst = Vector{AbstractEdge}()
-    connected_vs = collect(one(U):nv(g))
+    connected_vs = collect(one(V):nv(g))
 
     sizehint!(edge_list, ne(g))
     sizehint!(mst, ne(g))
 
     for e in edges(g)
-        heappush!(edge_list, KruskalHeapEntry{T}(e, distmx[src(e), dst(e)]))
+        heappush!(edge_list, KruskalHeapEntry{T, U}(e, distmx[src(e), dst(e)]))
     end
 
     while !isempty(edge_list) && length(mst) < nv(g) - 1

--- a/src/spanningtrees/kruskal.jl
+++ b/src/spanningtrees/kruskal.jl
@@ -29,13 +29,13 @@ distance matrix `distmx` using [Kruskal's algorithm](https://en.wikipedia.org/wi
 """
 function kruskal_mst end
 # see https://github.com/mauro3/SimpleTraits.jl/issues/47#issuecomment-327880153 for syntax
-@traitfn function kruskal_mst{T, U, V, AG<:AbstractGraph{U}}(
+@traitfn function kruskal_mst{T<:AbstractEdge, U, V, AG<:AbstractGraph{U}}(
     g::AG::(!IsDirected),
     distmx::AbstractMatrix{T} = weights(g)
 )
 
     edge_list = Vector{KruskalHeapEntry{T, U}}()
-    mst = Vector{AbstractEdge}()
+    mst = Vector{T}()
     connected_vs = collect(one(V):nv(g))
 
     sizehint!(edge_list, ne(g))

--- a/src/spanningtrees/kruskal.jl
+++ b/src/spanningtrees/kruskal.jl
@@ -29,9 +29,9 @@ distance matrix `distmx` using [Kruskal's algorithm](https://en.wikipedia.org/wi
 """
 function kruskal_mst end
 # see https://github.com/mauro3/SimpleTraits.jl/issues/47#issuecomment-327880153 for syntax
-@traitfn function kruskal_mst{T<:AbstractEdge, U, V, AG<:AbstractGraph{U}}(
+@traitfn function kruskal_mst{T<:AbstractEdge, U<:Real, V, AG<:AbstractGraph{T}}(
     g::AG::(!IsDirected),
-    distmx::AbstractMatrix{T} = weights(g)
+    distmx::AbstractMatrix{U} = weights(g)
 )
 
     edge_list = Vector{KruskalHeapEntry{T, U}}()

--- a/src/spanningtrees/prim.jl
+++ b/src/spanningtrees/prim.jl
@@ -46,19 +46,19 @@ end
 Mark the vertex `v` of graph `g` true in the array `marked` and enter all its
 edges into priority queue `pq` with its `distmx` values as a PrimHeapEntry.
 """
-function visit!{T<:AbstractEdge, U<:Real}(
+function visit!(
     g::AbstractGraph,
     v::Integer,
     marked::AbstractVector{Bool},
-    pq::AbstractVector,
+    pq::AbstractVector{PrimHeapEntry{T, U}},
     distmx::AbstractMatrix
-)
+) where {T<:AbstractEdge, U<:Real}
     marked[v] = true
     for w in outneighbors(g, v)
         if !marked[w]
             x = min(v, w)
             y = max(v, w)
-            heappush!(pq, PrimHeapEntry{T, U}(Edge(x, y), distmx[x, y]))
+            heappush!(pq, PrimHeapEntry{T, U}(T(x, y), distmx[x, y]))
         end
     end
 end

--- a/src/spanningtrees/prim.jl
+++ b/src/spanningtrees/prim.jl
@@ -1,5 +1,5 @@
 struct PrimHeapEntry{T<:Real}
-    edge::Edge
+    edge::AbstractEdge
     dist::T
 end
 
@@ -18,7 +18,7 @@ function prim_mst end
     distmx::AbstractMatrix = weights(g)
     )
     pq = Vector{PrimHeapEntry}()
-    mst = Vector{Edge}()
+    mst = Vector{AbstractEdge}()
     marked = zeros(Bool, nv(g))
 
     sizehint!(pq, ne(g))

--- a/src/spanningtrees/prim.jl
+++ b/src/spanningtrees/prim.jl
@@ -1,6 +1,6 @@
-struct PrimHeapEntry{T<:Real}
-    edge::AbstractEdge
-    dist::T
+struct PrimHeapEntry{T<:AbstractEdge, U<:Real}
+    edge::T
+    dist::U
 end
 
 isless(e1::PrimHeapEntry, e2::PrimHeapEntry) = e1.dist < e2.dist
@@ -13,12 +13,12 @@ distance matrix `distmx` using [Prim's algorithm](https://en.wikipedia.org/wiki/
 Return a vector of edges.
 """
 function prim_mst end
-@traitfn function prim_mst(
-    g::::(!IsDirected),
-    distmx::AbstractMatrix = weights(g)
+@traitfn function prim_mst{T<:AbstractEdge, U<:Real, V, AG<:AbstractGraph{T}}(
+    g::AG::(!IsDirected),
+    distmx::AbstractMatrix{U} = weights(g)
     )
-    pq = Vector{PrimHeapEntry}()
-    mst = Vector{AbstractEdge}()
+    pq = Vector{PrimHeapEntry{T, U}}()
+    mst = Vector{T}()
     marked = zeros(Bool, nv(g))
 
     sizehint!(pq, ne(g))
@@ -46,7 +46,7 @@ end
 Mark the vertex `v` of graph `g` true in the array `marked` and enter all its
 edges into priority queue `pq` with its `distmx` values as a PrimHeapEntry.
 """
-function visit!(
+function visit!{T<:AbstractEdge, U<:Real}(
     g::AbstractGraph,
     v::Integer,
     marked::AbstractVector{Bool},
@@ -58,7 +58,7 @@ function visit!(
         if !marked[w]
             x = min(v, w)
             y = max(v, w)
-            heappush!(pq, PrimHeapEntry(Edge(x, y), distmx[x, y]))
+            heappush!(pq, PrimHeapEntry{T, U}(Edge(x, y), distmx[x, y]))
         end
     end
 end

--- a/src/spanningtrees/prim.jl
+++ b/src/spanningtrees/prim.jl
@@ -13,10 +13,12 @@ distance matrix `distmx` using [Prim's algorithm](https://en.wikipedia.org/wiki/
 Return a vector of edges.
 """
 function prim_mst end
-@traitfn function prim_mst{T<:AbstractEdge, U<:Real, V, AG<:AbstractGraph{T}}(
+@traitfn function prim_mst{U<:Real, V, AG<:AbstractGraph{V}}(
     g::AG::(!IsDirected),
     distmx::AbstractMatrix{U} = weights(g)
-    )
+)
+    
+    T = edgetype(g)
     pq = Vector{PrimHeapEntry{T, U}}()
     mst = Vector{T}()
     marked = zeros(Bool, nv(g))


### PR DESCRIPTION
In a SimpleWeigthedGraph each edge is of type SimpleWeightedEdge, which currently causes the MST functions to crash when called on a SimpleWeigthedGraph. These modifications prevent that crash.
Please let me know if you would like me to add a test for this.