### PR TITLE
Fixing problems with MST Kruskal's on SimpleWeightedGraphs

### DIFF
--- a/src/spanningtrees/kruskal.jl
+++ b/src/spanningtrees/kruskal.jl
@@ -29,7 +29,7 @@ distance matrix `distmx` using [Kruskal's algorithm](https://en.wikipedia.org/wi
 """
 function kruskal_mst end
 # see https://github.com/mauro3/SimpleTraits.jl/issues/47#issuecomment-327880153 for syntax
-@traitfn function kruskal_mst{T, U, AG<:AbstractGraph{U}}(
+@traitfn function kruskal_mst{T<:Real, U, AG<:AbstractGraph{U}}(
     g::AG::(!IsDirected),
     distmx::AbstractMatrix{T} = weights(g)
 )
@@ -42,7 +42,7 @@ function kruskal_mst end
     sizehint!(mst, ne(g))
 
     for e in edges(g)
-        heappush!(edge_list, KruskalHeapEntry{T}(e, distmx[src(e), dst(e)]))
+        heappush!(edge_list, KruskalHeapEntry{T}(Edge(src(e), dst(e)), distmx[src(e), dst(e)]))
     end
 
     while !isempty(edge_list) && length(mst) < nv(g) - 1

--- a/src/spanningtrees/kruskal.jl
+++ b/src/spanningtrees/kruskal.jl
@@ -29,13 +29,13 @@ distance matrix `distmx` using [Kruskal's algorithm](https://en.wikipedia.org/wi
 """
 function kruskal_mst end
 # see https://github.com/mauro3/SimpleTraits.jl/issues/47#issuecomment-327880153 for syntax
-@traitfn function kruskal_mst{T<:AbstractEdge, U, V, AG<:AbstractGraph{U}}(
+@traitfn function kruskal_mst{T, U, V, AG<:AbstractGraph{U}}(
     g::AG::(!IsDirected),
     distmx::AbstractMatrix{T} = weights(g)
 )
 
     edge_list = Vector{KruskalHeapEntry{T, U}}()
-    mst = Vector{T}()
+    mst = Vector{AbstractEdge}()
     connected_vs = collect(one(V):nv(g))
 
     sizehint!(edge_list, ne(g))

--- a/src/spanningtrees/kruskal.jl
+++ b/src/spanningtrees/kruskal.jl
@@ -29,12 +29,11 @@ distance matrix `distmx` using [Kruskal's algorithm](https://en.wikipedia.org/wi
 """
 function kruskal_mst end
 # see https://github.com/mauro3/SimpleTraits.jl/issues/47#issuecomment-327880153 for syntax
-@traitfn function kruskal_mst{U<:Real, V, AG<:AbstractGraph{V}}(
+@traitfn function kruskal_mst{T<:AbstractEdge, U<:Real, V, AG<:AbstractGraph{T}}(
     g::AG::(!IsDirected),
     distmx::AbstractMatrix{U} = weights(g)
 )
 
-    T = edgetype(g)
     edge_list = Vector{KruskalHeapEntry{T, U}}()
     mst = Vector{T}()
     connected_vs = collect(one(V):nv(g))

--- a/src/spanningtrees/kruskal.jl
+++ b/src/spanningtrees/kruskal.jl
@@ -1,5 +1,5 @@
 struct KruskalHeapEntry{T<:Real}
-    edge::Edge
+    edge::AbstractEdge
     dist::T
 end
 
@@ -35,7 +35,7 @@ function kruskal_mst end
 )
 
     edge_list = Vector{KruskalHeapEntry{T}}()
-    mst = Vector{Edge}()
+    mst = Vector{AbstractEdge}()
     connected_vs = collect(one(U):nv(g))
 
     sizehint!(edge_list, ne(g))

--- a/src/spanningtrees/kruskal.jl
+++ b/src/spanningtrees/kruskal.jl
@@ -29,9 +29,9 @@ distance matrix `distmx` using [Kruskal's algorithm](https://en.wikipedia.org/wi
 """
 function kruskal_mst end
 # see https://github.com/mauro3/SimpleTraits.jl/issues/47#issuecomment-327880153 for syntax
-@traitfn function kruskal_mst{T<:AbstractEdge, U<:Real, V, AG<:AbstractGraph{T}}(
+@traitfn function kruskal_mst{T<:AbstractEdge, U, V, AG<:AbstractGraph{U}}(
     g::AG::(!IsDirected),
-    distmx::AbstractMatrix{U} = weights(g)
+    distmx::AbstractMatrix{T} = weights(g)
 )
 
     edge_list = Vector{KruskalHeapEntry{T, U}}()

--- a/src/spanningtrees/kruskal.jl
+++ b/src/spanningtrees/kruskal.jl
@@ -1,6 +1,6 @@
-struct KruskalHeapEntry{T<:Real}
-    edge::Edge
-    dist::T
+struct KruskalHeapEntry{T<:AbstractEdge, U<:Real}
+    edge::T
+    dist::U
 end
 
 isless(e1::KruskalHeapEntry, e2::KruskalHeapEntry) = e1.dist < e2.dist
@@ -29,20 +29,21 @@ distance matrix `distmx` using [Kruskal's algorithm](https://en.wikipedia.org/wi
 """
 function kruskal_mst end
 # see https://github.com/mauro3/SimpleTraits.jl/issues/47#issuecomment-327880153 for syntax
-@traitfn function kruskal_mst{T, U, AG<:AbstractGraph{U}}(
+@traitfn function kruskal_mst{U<:Real, V, AG<:AbstractGraph{V}}(
     g::AG::(!IsDirected),
-    distmx::AbstractMatrix{T} = weights(g)
+    distmx::AbstractMatrix{U} = weights(g)
 )
 
-    edge_list = Vector{KruskalHeapEntry{T}}()
-    mst = Vector{Edge}()
-    connected_vs = collect(one(U):nv(g))
+    T = edgetype(g)
+    edge_list = Vector{KruskalHeapEntry{T, U}}()
+    mst = Vector{T}()
+    connected_vs = collect(one(V):nv(g))
 
     sizehint!(edge_list, ne(g))
     sizehint!(mst, ne(g))
 
     for e in edges(g)
-        heappush!(edge_list, KruskalHeapEntry{T}(e, distmx[src(e), dst(e)]))
+        heappush!(edge_list, KruskalHeapEntry{T, U}(e, distmx[src(e), dst(e)]))
     end
 
     while !isempty(edge_list) && length(mst) < nv(g) - 1

--- a/src/spanningtrees/kruskal.jl
+++ b/src/spanningtrees/kruskal.jl
@@ -29,11 +29,12 @@ distance matrix `distmx` using [Kruskal's algorithm](https://en.wikipedia.org/wi
 """
 function kruskal_mst end
 # see https://github.com/mauro3/SimpleTraits.jl/issues/47#issuecomment-327880153 for syntax
-@traitfn function kruskal_mst{T<:AbstractEdge, U<:Real, V, AG<:AbstractGraph{T}}(
+@traitfn function kruskal_mst{U<:Real, V, AG<:AbstractGraph{V}}(
     g::AG::(!IsDirected),
     distmx::AbstractMatrix{U} = weights(g)
 )
 
+    T = edgetype(g)
     edge_list = Vector{KruskalHeapEntry{T, U}}()
     mst = Vector{T}()
     connected_vs = collect(one(V):nv(g))

--- a/src/spanningtrees/kruskal.jl
+++ b/src/spanningtrees/kruskal.jl
@@ -1,6 +1,6 @@
-struct KruskalHeapEntry{T<:AbstractEdge, U<:Real}
-    edge::T
-    dist::U
+struct KruskalHeapEntry{T<:Real}
+    edge::Edge
+    dist::T
 end
 
 isless(e1::KruskalHeapEntry, e2::KruskalHeapEntry) = e1.dist < e2.dist
@@ -29,21 +29,20 @@ distance matrix `distmx` using [Kruskal's algorithm](https://en.wikipedia.org/wi
 """
 function kruskal_mst end
 # see https://github.com/mauro3/SimpleTraits.jl/issues/47#issuecomment-327880153 for syntax
-@traitfn function kruskal_mst{U<:Real, V, AG<:AbstractGraph{V}}(
+@traitfn function kruskal_mst{T, U, AG<:AbstractGraph{U}}(
     g::AG::(!IsDirected),
-    distmx::AbstractMatrix{U} = weights(g)
+    distmx::AbstractMatrix{T} = weights(g)
 )
 
-    T = edgetype(g)
-    edge_list = Vector{KruskalHeapEntry{T, U}}()
-    mst = Vector{T}()
-    connected_vs = collect(one(V):nv(g))
+    edge_list = Vector{KruskalHeapEntry{T}}()
+    mst = Vector{Edge}()
+    connected_vs = collect(one(U):nv(g))
 
     sizehint!(edge_list, ne(g))
     sizehint!(mst, ne(g))
 
     for e in edges(g)
-        heappush!(edge_list, KruskalHeapEntry{T, U}(e, distmx[src(e), dst(e)]))
+        heappush!(edge_list, KruskalHeapEntry{T}(e, distmx[src(e), dst(e)]))
     end
 
     while !isempty(edge_list) && length(mst) < nv(g) - 1

--- a/src/spanningtrees/kruskal.jl
+++ b/src/spanningtrees/kruskal.jl
@@ -1,6 +1,6 @@
-struct KruskalHeapEntry{T<:Real}
-    edge::AbstractEdge
-    dist::T
+struct KruskalHeapEntry{T<:AbstractEdge, U<:Real}
+    edge::T
+    dist::U
 end
 
 isless(e1::KruskalHeapEntry, e2::KruskalHeapEntry) = e1.dist < e2.dist
@@ -29,20 +29,20 @@ distance matrix `distmx` using [Kruskal's algorithm](https://en.wikipedia.org/wi
 """
 function kruskal_mst end
 # see https://github.com/mauro3/SimpleTraits.jl/issues/47#issuecomment-327880153 for syntax
-@traitfn function kruskal_mst{T, U, AG<:AbstractGraph{U}}(
+@traitfn function kruskal_mst{T, U, V, AG<:AbstractGraph{U}}(
     g::AG::(!IsDirected),
     distmx::AbstractMatrix{T} = weights(g)
 )
 
-    edge_list = Vector{KruskalHeapEntry{T}}()
+    edge_list = Vector{KruskalHeapEntry{T, U}}()
     mst = Vector{AbstractEdge}()
-    connected_vs = collect(one(U):nv(g))
+    connected_vs = collect(one(V):nv(g))
 
     sizehint!(edge_list, ne(g))
     sizehint!(mst, ne(g))
 
     for e in edges(g)
-        heappush!(edge_list, KruskalHeapEntry{T}(e, distmx[src(e), dst(e)]))
+        heappush!(edge_list, KruskalHeapEntry{T, U}(e, distmx[src(e), dst(e)]))
     end
 
     while !isempty(edge_list) && length(mst) < nv(g) - 1

--- a/src/spanningtrees/kruskal.jl
+++ b/src/spanningtrees/kruskal.jl
@@ -29,13 +29,13 @@ distance matrix `distmx` using [Kruskal's algorithm](https://en.wikipedia.org/wi
 """
 function kruskal_mst end
 # see https://github.com/mauro3/SimpleTraits.jl/issues/47#issuecomment-327880153 for syntax
-@traitfn function kruskal_mst{T, U, V, AG<:AbstractGraph{U}}(
+@traitfn function kruskal_mst{T<:AbstractEdge, U, V, AG<:AbstractGraph{U}}(
     g::AG::(!IsDirected),
     distmx::AbstractMatrix{T} = weights(g)
 )
 
     edge_list = Vector{KruskalHeapEntry{T, U}}()
-    mst = Vector{AbstractEdge}()
+    mst = Vector{T}()
     connected_vs = collect(one(V):nv(g))
 
     sizehint!(edge_list, ne(g))

--- a/src/spanningtrees/kruskal.jl
+++ b/src/spanningtrees/kruskal.jl
@@ -1,6 +1,6 @@
-struct KruskalHeapEntry{T<:AbstractEdge, U<:Real}
-    edge::T
-    dist::U
+struct KruskalHeapEntry{T<:Real}
+    edge::AbstractEdge
+    dist::T
 end
 
 isless(e1::KruskalHeapEntry, e2::KruskalHeapEntry) = e1.dist < e2.dist
@@ -29,20 +29,20 @@ distance matrix `distmx` using [Kruskal's algorithm](https://en.wikipedia.org/wi
 """
 function kruskal_mst end
 # see https://github.com/mauro3/SimpleTraits.jl/issues/47#issuecomment-327880153 for syntax
-@traitfn function kruskal_mst{T, U, V, AG<:AbstractGraph{U}}(
+@traitfn function kruskal_mst{T, U, AG<:AbstractGraph{U}}(
     g::AG::(!IsDirected),
     distmx::AbstractMatrix{T} = weights(g)
 )
 
-    edge_list = Vector{KruskalHeapEntry{T, U}}()
+    edge_list = Vector{KruskalHeapEntry{T}}()
     mst = Vector{AbstractEdge}()
-    connected_vs = collect(one(V):nv(g))
+    connected_vs = collect(one(U):nv(g))
 
     sizehint!(edge_list, ne(g))
     sizehint!(mst, ne(g))
 
     for e in edges(g)
-        heappush!(edge_list, KruskalHeapEntry{T, U}(e, distmx[src(e), dst(e)]))
+        heappush!(edge_list, KruskalHeapEntry{T}(e, distmx[src(e), dst(e)]))
     end
 
     while !isempty(edge_list) && length(mst) < nv(g) - 1

--- a/src/spanningtrees/kruskal.jl
+++ b/src/spanningtrees/kruskal.jl
@@ -29,9 +29,9 @@ distance matrix `distmx` using [Kruskal's algorithm](https://en.wikipedia.org/wi
 """
 function kruskal_mst end
 # see https://github.com/mauro3/SimpleTraits.jl/issues/47#issuecomment-327880153 for syntax
-@traitfn function kruskal_mst{T<:AbstractEdge, U, V, AG<:AbstractGraph{U}}(
+@traitfn function kruskal_mst{T<:AbstractEdge, U<:Real, V, AG<:AbstractGraph{T}}(
     g::AG::(!IsDirected),
-    distmx::AbstractMatrix{T} = weights(g)
+    distmx::AbstractMatrix{U} = weights(g)
 )
 
     edge_list = Vector{KruskalHeapEntry{T, U}}()

--- a/src/spanningtrees/kruskal.jl
+++ b/src/spanningtrees/kruskal.jl
@@ -1,5 +1,5 @@
 struct KruskalHeapEntry{T<:Real}
-    edge::AbstractEdge
+    edge::Edge
     dist::T
 end
 
@@ -35,7 +35,7 @@ function kruskal_mst end
 )
 
     edge_list = Vector{KruskalHeapEntry{T}}()
-    mst = Vector{AbstractEdge}()
+    mst = Vector{Edge}()
     connected_vs = collect(one(U):nv(g))
 
     sizehint!(edge_list, ne(g))

--- a/src/spanningtrees/prim.jl
+++ b/src/spanningtrees/prim.jl
@@ -54,7 +54,7 @@ function visit!(
     distmx::AbstractMatrix
 )
     marked[v] = true
-    for w in out_neighbors(g, v)
+    for w in outneighbors(g, v)
         if !marked[w]
             x = min(v, w)
             y = max(v, w)

--- a/src/spanningtrees/prim.jl
+++ b/src/spanningtrees/prim.jl
@@ -54,7 +54,7 @@ function visit!(
     distmx::AbstractMatrix
 )
     marked[v] = true
-    for w in outneighbors(g, v)
+    for w in out_neighbors(g, v)
         if !marked[w]
             x = min(v, w)
             y = max(v, w)

--- a/src/spanningtrees/prim.jl
+++ b/src/spanningtrees/prim.jl
@@ -1,6 +1,6 @@
-struct PrimHeapEntry{T<:AbstractEdge, U<:Real}
-    edge::T
-    dist::U
+struct PrimHeapEntry{T<:Real}
+    edge::Edge
+    dist::T
 end
 
 isless(e1::PrimHeapEntry, e2::PrimHeapEntry) = e1.dist < e2.dist
@@ -13,14 +13,12 @@ distance matrix `distmx` using [Prim's algorithm](https://en.wikipedia.org/wiki/
 Return a vector of edges.
 """
 function prim_mst end
-@traitfn function prim_mst{U<:Real, V, AG<:AbstractGraph{V}}(
-    g::AG::(!IsDirected),
-    distmx::AbstractMatrix{U} = weights(g)
-)
-    
-    T = edgetype(g)
-    pq = Vector{PrimHeapEntry{T, U}}()
-    mst = Vector{T}()
+@traitfn function prim_mst(
+    g::::(!IsDirected),
+    distmx::AbstractMatrix = weights(g)
+    )
+    pq = Vector{PrimHeapEntry}()
+    mst = Vector{Edge}()
     marked = zeros(Bool, nv(g))
 
     sizehint!(pq, ne(g))
@@ -52,15 +50,15 @@ function visit!(
     g::AbstractGraph,
     v::Integer,
     marked::AbstractVector{Bool},
-    pq::AbstractVector{PrimHeapEntry{T, U}},
+    pq::AbstractVector,
     distmx::AbstractMatrix
-) where {T<:AbstractEdge, U<:Real}
+)
     marked[v] = true
     for w in outneighbors(g, v)
         if !marked[w]
             x = min(v, w)
             y = max(v, w)
-            heappush!(pq, PrimHeapEntry{T, U}(T(x, y), distmx[x, y]))
+            heappush!(pq, PrimHeapEntry(Edge(x, y), distmx[x, y]))
         end
     end
 end

--- a/src/spanningtrees/prim.jl
+++ b/src/spanningtrees/prim.jl
@@ -46,19 +46,19 @@ end
 Mark the vertex `v` of graph `g` true in the array `marked` and enter all its
 edges into priority queue `pq` with its `distmx` values as a PrimHeapEntry.
 """
-function visit!{T<:AbstractEdge, U<:Real}(
+function visit!(
     g::AbstractGraph,
     v::Integer,
     marked::AbstractVector{Bool},
-    pq::AbstractVector,
+    pq::AbstractVector{PrimHeapEntry{T, U}},
     distmx::AbstractMatrix
-)
+) where {T<:AbstractEdge, U<:Real}
     marked[v] = true
     for w in outneighbors(g, v)
         if !marked[w]
             x = min(v, w)
             y = max(v, w)
-            heappush!(pq, PrimHeapEntry{T, U}(Edge(x, y), distmx[x, y]))
+            heappush!(pq, PrimHeapEntry{T, U}(T(x, y), distmx[x, y]))
         end
     end
 end

--- a/src/spanningtrees/prim.jl
+++ b/src/spanningtrees/prim.jl
@@ -46,19 +46,19 @@ end
 Mark the vertex `v` of graph `g` true in the array `marked` and enter all its
 edges into priority queue `pq` with its `distmx` values as a PrimHeapEntry.
 """
-function visit!(
+function visit!{T<:AbstractEdge, U<:Real}(
     g::AbstractGraph,
     v::Integer,
     marked::AbstractVector{Bool},
-    pq::AbstractVector{PrimHeapEntry{T, U}},
+    pq::AbstractVector,
     distmx::AbstractMatrix
-) where {T<:AbstractEdge, U<:Real}
+)
     marked[v] = true
     for w in outneighbors(g, v)
         if !marked[w]
             x = min(v, w)
             y = max(v, w)
-            heappush!(pq, PrimHeapEntry{T, U}(T(x, y), distmx[x, y]))
+            heappush!(pq, PrimHeapEntry{T, U}(Edge(x, y), distmx[x, y]))
         end
     end
 end

--- a/src/spanningtrees/prim.jl
+++ b/src/spanningtrees/prim.jl
@@ -13,11 +13,11 @@ distance matrix `distmx` using [Prim's algorithm](https://en.wikipedia.org/wiki/
 Return a vector of edges.
 """
 function prim_mst end
-@traitfn function prim_mst(
-    g::::(!IsDirected),
-    distmx::AbstractMatrix = weights(g)
+@traitfn function prim_mst{T<:Real, U, AG<:AbstractGraph{U}}(
+    g::AG::(!IsDirected),
+    distmx::AbstractMatrix{T} = weights(g)
     )
-    pq = Vector{PrimHeapEntry}()
+    pq = Vector{PrimHeapEntry{T}}()
     mst = Vector{Edge}()
     marked = zeros(Bool, nv(g))
 

--- a/src/spanningtrees/prim.jl
+++ b/src/spanningtrees/prim.jl
@@ -1,6 +1,6 @@
-struct PrimHeapEntry{T<:AbstractEdge, U<:Real}
-    edge::T
-    dist::U
+struct PrimHeapEntry{T<:Real}
+    edge::AbstractEdge
+    dist::T
 end
 
 isless(e1::PrimHeapEntry, e2::PrimHeapEntry) = e1.dist < e2.dist
@@ -13,12 +13,12 @@ distance matrix `distmx` using [Prim's algorithm](https://en.wikipedia.org/wiki/
 Return a vector of edges.
 """
 function prim_mst end
-@traitfn function prim_mst{T<:AbstractEdge, U<:Real, V, AG<:AbstractGraph{T}}(
-    g::AG::(!IsDirected),
-    distmx::AbstractMatrix{U} = weights(g)
+@traitfn function prim_mst(
+    g::::(!IsDirected),
+    distmx::AbstractMatrix = weights(g)
     )
-    pq = Vector{PrimHeapEntry{T, U}}()
-    mst = Vector{T}()
+    pq = Vector{PrimHeapEntry}()
+    mst = Vector{AbstractEdge}()
     marked = zeros(Bool, nv(g))
 
     sizehint!(pq, ne(g))
@@ -46,7 +46,7 @@ end
 Mark the vertex `v` of graph `g` true in the array `marked` and enter all its
 edges into priority queue `pq` with its `distmx` values as a PrimHeapEntry.
 """
-function visit!{T<:AbstractEdge, U<:Real}(
+function visit!(
     g::AbstractGraph,
     v::Integer,
     marked::AbstractVector{Bool},
@@ -58,7 +58,7 @@ function visit!{T<:AbstractEdge, U<:Real}(
         if !marked[w]
             x = min(v, w)
             y = max(v, w)
-            heappush!(pq, PrimHeapEntry{T, U}(Edge(x, y), distmx[x, y]))
+            heappush!(pq, PrimHeapEntry(Edge(x, y), distmx[x, y]))
         end
     end
 end

--- a/src/spanningtrees/prim.jl
+++ b/src/spanningtrees/prim.jl
@@ -13,12 +13,10 @@ distance matrix `distmx` using [Prim's algorithm](https://en.wikipedia.org/wiki/
 Return a vector of edges.
 """
 function prim_mst end
-@traitfn function prim_mst{U<:Real, V, AG<:AbstractGraph{V}}(
+@traitfn function prim_mst{T<:AbstractEdge, U<:Real, V, AG<:AbstractGraph{T}}(
     g::AG::(!IsDirected),
     distmx::AbstractMatrix{U} = weights(g)
-)
-    
-    T = edgetype(g)
+    )
     pq = Vector{PrimHeapEntry{T, U}}()
     mst = Vector{T}()
     marked = zeros(Bool, nv(g))

--- a/src/spanningtrees/prim.jl
+++ b/src/spanningtrees/prim.jl
@@ -1,5 +1,5 @@
 struct PrimHeapEntry{T<:Real}
-    edge::Edge
+    edge::AbstractEdge
     dist::T
 end
 
@@ -18,7 +18,7 @@ function prim_mst end
     distmx::AbstractMatrix = weights(g)
     )
     pq = Vector{PrimHeapEntry}()
-    mst = Vector{Edge}()
+    mst = Vector{AbstractEdge}()
     marked = zeros(Bool, nv(g))
 
     sizehint!(pq, ne(g))

--- a/src/spanningtrees/prim.jl
+++ b/src/spanningtrees/prim.jl
@@ -1,6 +1,6 @@
-struct PrimHeapEntry{T<:Real}
-    edge::AbstractEdge
-    dist::T
+struct PrimHeapEntry{T<:AbstractEdge, U<:Real}
+    edge::T
+    dist::U
 end
 
 isless(e1::PrimHeapEntry, e2::PrimHeapEntry) = e1.dist < e2.dist
@@ -13,12 +13,12 @@ distance matrix `distmx` using [Prim's algorithm](https://en.wikipedia.org/wiki/
 Return a vector of edges.
 """
 function prim_mst end
-@traitfn function prim_mst(
-    g::::(!IsDirected),
-    distmx::AbstractMatrix = weights(g)
+@traitfn function prim_mst{T<:AbstractEdge, U<:Real, V, AG<:AbstractGraph{T}}(
+    g::AG::(!IsDirected),
+    distmx::AbstractMatrix{U} = weights(g)
     )
-    pq = Vector{PrimHeapEntry}()
-    mst = Vector{AbstractEdge}()
+    pq = Vector{PrimHeapEntry{T, U}}()
+    mst = Vector{T}()
     marked = zeros(Bool, nv(g))
 
     sizehint!(pq, ne(g))
@@ -46,7 +46,7 @@ end
 Mark the vertex `v` of graph `g` true in the array `marked` and enter all its
 edges into priority queue `pq` with its `distmx` values as a PrimHeapEntry.
 """
-function visit!(
+function visit!{T<:AbstractEdge, U<:Real}(
     g::AbstractGraph,
     v::Integer,
     marked::AbstractVector{Bool},
@@ -58,7 +58,7 @@ function visit!(
         if !marked[w]
             x = min(v, w)
             y = max(v, w)
-            heappush!(pq, PrimHeapEntry(Edge(x, y), distmx[x, y]))
+            heappush!(pq, PrimHeapEntry{T, U}(Edge(x, y), distmx[x, y]))
         end
     end
 end

--- a/src/spanningtrees/prim.jl
+++ b/src/spanningtrees/prim.jl
@@ -1,6 +1,6 @@
-struct PrimHeapEntry{T<:Real}
-    edge::Edge
-    dist::T
+struct PrimHeapEntry{T<:AbstractEdge, U<:Real}
+    edge::T
+    dist::U
 end
 
 isless(e1::PrimHeapEntry, e2::PrimHeapEntry) = e1.dist < e2.dist
@@ -13,12 +13,14 @@ distance matrix `distmx` using [Prim's algorithm](https://en.wikipedia.org/wiki/
 Return a vector of edges.
 """
 function prim_mst end
-@traitfn function prim_mst(
-    g::::(!IsDirected),
-    distmx::AbstractMatrix = weights(g)
-    )
-    pq = Vector{PrimHeapEntry}()
-    mst = Vector{Edge}()
+@traitfn function prim_mst{U<:Real, V, AG<:AbstractGraph{V}}(
+    g::AG::(!IsDirected),
+    distmx::AbstractMatrix{U} = weights(g)
+)
+    
+    T = edgetype(g)
+    pq = Vector{PrimHeapEntry{T, U}}()
+    mst = Vector{T}()
     marked = zeros(Bool, nv(g))
 
     sizehint!(pq, ne(g))
@@ -50,15 +52,15 @@ function visit!(
     g::AbstractGraph,
     v::Integer,
     marked::AbstractVector{Bool},
-    pq::AbstractVector,
+    pq::AbstractVector{PrimHeapEntry{T, U}},
     distmx::AbstractMatrix
-)
+) where {T<:AbstractEdge, U<:Real}
     marked[v] = true
     for w in outneighbors(g, v)
         if !marked[w]
             x = min(v, w)
             y = max(v, w)
-            heappush!(pq, PrimHeapEntry(Edge(x, y), distmx[x, y]))
+            heappush!(pq, PrimHeapEntry{T, U}(T(x, y), distmx[x, y]))
         end
     end
 end

--- a/src/spanningtrees/prim.jl
+++ b/src/spanningtrees/prim.jl
@@ -13,10 +13,12 @@ distance matrix `distmx` using [Prim's algorithm](https://en.wikipedia.org/wiki/
 Return a vector of edges.
 """
 function prim_mst end
-@traitfn function prim_mst{T<:AbstractEdge, U<:Real, V, AG<:AbstractGraph{T}}(
+@traitfn function prim_mst{U<:Real, V, AG<:AbstractGraph{V}}(
     g::AG::(!IsDirected),
     distmx::AbstractMatrix{U} = weights(g)
-    )
+)
+    
+    T = edgetype(g)
     pq = Vector{PrimHeapEntry{T, U}}()
     mst = Vector{T}()
     marked = zeros(Bool, nv(g))

--- a/src/spanningtrees/prim.jl
+++ b/src/spanningtrees/prim.jl
@@ -1,5 +1,5 @@
 struct PrimHeapEntry{T<:Real}
-    edge::AbstractEdge
+    edge::Edge
     dist::T
 end
 
@@ -18,7 +18,7 @@ function prim_mst end
     distmx::AbstractMatrix = weights(g)
     )
     pq = Vector{PrimHeapEntry}()
-    mst = Vector{AbstractEdge}()
+    mst = Vector{Edge}()
     marked = zeros(Bool, nv(g))
 
     sizehint!(pq, ne(g))


### PR DESCRIPTION
Prevents MST Kruskal algorithms from crashing when called with an SimpleWeightedGraph (or with a graph for with the edges are not of Edge type). Tests to be added in SimpleWeightedGraphs.jl.