### PR TITLE
WIP: Getting LightGraphs 0.7 ready

### DIFF
--- a/src/LightGraphs.jl
+++ b/src/LightGraphs.jl
@@ -7,6 +7,7 @@ using SimpleTraits
 
 using SparseArrays
 using LinearAlgebra
+using IterativeEigensolvers
 import Base: write, ==, <, *, ≈, convert, isless, issubset, union, intersect,
             reverse, reverse!, isassigned, getindex, setindex!, show,
             print, copy, in, sum, size, eltype, length, ndims, transpose,

--- a/src/LightGraphs.jl
+++ b/src/LightGraphs.jl
@@ -11,6 +11,7 @@ using IterativeEigensolvers
 using SharedArrays
 using Random
 using Markdown
+using DelimitedFiles
 import Base: write, ==, <, *, ≈, convert, isless, issubset, union, intersect,
             reverse, reverse!, isassigned, getindex, setindex!, show,
             print, copy, in, sum, size, eltype, length, ndims, transpose,

--- a/src/LightGraphs.jl
+++ b/src/LightGraphs.jl
@@ -8,6 +8,7 @@ using SimpleTraits
 using SparseArrays
 using LinearAlgebra
 using IterativeEigensolvers
+using SharedArrays
 import Base: write, ==, <, *, ≈, convert, isless, issubset, union, intersect,
             reverse, reverse!, isassigned, getindex, setindex!, show,
             print, copy, in, sum, size, eltype, length, ndims, transpose,

--- a/src/LightGraphs.jl
+++ b/src/LightGraphs.jl
@@ -5,6 +5,8 @@ import CodecZlib
 using DataStructures
 using SimpleTraits
 
+import Random: AbstractRNG, MersenneTwister, GLOBAL_RNG
+import Distributed: @parallel, @sync
 import Base: write, ==, <, *, ≈, convert, isless, issubset, union, intersect,
             reverse, reverse!, blkdiag, isassigned, getindex, setindex!, show,
             print, copy, in, sum, size, sparse, eltype, length, ndims, transpose,

--- a/src/LightGraphs.jl
+++ b/src/LightGraphs.jl
@@ -5,13 +5,17 @@ import CodecZlib
 using DataStructures
 using SimpleTraits
 
+using SparseArrays
+using LinearAlgebra
+import Base: write, ==, <, *, ≈, convert, isless, issubset, union, intersect,
+            reverse, reverse!, isassigned, getindex, setindex!, show,
+            print, copy, in, sum, size, eltype, length, ndims, transpose,
+            ctranspose, join, start, next, done, eltype, get, Pair, Tuple, zero
 import Random: AbstractRNG, MersenneTwister, GLOBAL_RNG
 import Distributed: @parallel, @sync
-import Base: write, ==, <, *, ≈, convert, isless, issubset, union, intersect,
-            reverse, reverse!, blkdiag, isassigned, getindex, setindex!, show,
-            print, copy, in, sum, size, sparse, eltype, length, ndims, transpose,
-            ctranspose, join, start, next, done, eltype, get, issymmetric, A_mul_B!,
-            Pair, Tuple, zero
+import SparseArrays: sparse, blkdiag
+import LinearAlgebra: issymmetric, mul!
+
 export
 # Interface
 AbstractGraph, AbstractEdge, AbstractEdgeIter,

--- a/src/LightGraphs.jl
+++ b/src/LightGraphs.jl
@@ -9,11 +9,13 @@ using SparseArrays
 using LinearAlgebra
 using IterativeEigensolvers
 using SharedArrays
+using Random
+using Markdown
 import Base: write, ==, <, *, ≈, convert, isless, issubset, union, intersect,
             reverse, reverse!, isassigned, getindex, setindex!, show,
             print, copy, in, sum, size, eltype, length, ndims, transpose,
             ctranspose, join, start, next, done, eltype, get, Pair, Tuple, zero
-import Random: AbstractRNG, MersenneTwister, GLOBAL_RNG
+import Random: GLOBAL_RNG
 import Distributed: @parallel, @sync
 import SparseArrays: sparse, blkdiag
 import LinearAlgebra: issymmetric, mul!

--- a/src/SimpleGraphs/SimpleGraphs.jl
+++ b/src/SimpleGraphs/SimpleGraphs.jl
@@ -1,5 +1,8 @@
 module SimpleGraphs
 
+using SparseArrays
+using LinearAlgebra
+
 import Base:
     eltype, show, ==, Pair, Tuple, copy, length, start, next, done, issubset, zero, in
 

--- a/src/community/clique_percolation.jl
+++ b/src/community/clique_percolation.jl
@@ -26,7 +26,7 @@ function clique_percolation end
     x[kcliques[i]] = false
   end
   components = connected_components(h)
-  communities = [IntSet() for i=1:length(components)]
+  communities = [BitSet() for i=1:length(components)]
   for (i,component) in enumerate(components)
     push!(communities[i], vcat(kcliques[component]...)...)
   end

--- a/src/community/label_propagation.jl
+++ b/src/community/label_propagation.jl
@@ -12,7 +12,7 @@ the second is the convergence history for each node. Will return after
 function label_propagation(g::AbstractGraph{T}, maxiter=1000) where T
     n = nv(g)
     label = collect(one(T):n)
-    active_vs = IntSet(vertices(g))
+    active_vs = BitSet(vertices(g))
     c = NeighComm(collect(one(T):n), fill(-1, n), one(T))
     convergence_hist = Vector{Int}()
     random_order = Vector{T}(n)

--- a/src/linalg/LinAlg.jl
+++ b/src/linalg/LinAlg.jl
@@ -3,13 +3,15 @@ module LinAlg
 using SimpleTraits
 using SparseArrays
 using LinearAlgebra
+using IterativeEigensolvers
 using ..LightGraphs
 
 import LightGraphs: IsDirected, adjacency_matrix, laplacian_matrix, laplacian_spectrum, AbstractGraph, inneighbors,
 outneighbors, all_neighbors, is_directed, nv, ne, has_edge, vertices
 
 import Base: convert, size, eltype, ndims, ==, *, .*, length
-import LinearAlgebra: sparse, diag, issymmetric, mul!, Diagonal
+import SparseArrays: sparse, diag
+import LinearAlgebra: issymmetric, mul!, Diagonal
 
 export convert,
     SparseMatrix,

--- a/src/linalg/LinAlg.jl
+++ b/src/linalg/LinAlg.jl
@@ -1,13 +1,15 @@
 module LinAlg
 
 using SimpleTraits
+using SparseArrays
+using LinearAlgebra
 using ..LightGraphs
 
 import LightGraphs: IsDirected, adjacency_matrix, laplacian_matrix, laplacian_spectrum, AbstractGraph, inneighbors,
 outneighbors, all_neighbors, is_directed, nv, ne, has_edge, vertices
 
-import Base: convert, sparse, size, diag, eltype, ndims, ==, *, .*, issymmetric, A_mul_B!, length, Diagonal
-
+import Base: convert, size, eltype, ndims, ==, *, .*, length
+import LinearAlgebra: sparse, diag, issymmetric, mul!, Diagonal
 
 export convert,
     SparseMatrix,

--- a/src/linalg/graphmatrices.jl
+++ b/src/linalg/graphmatrices.jl
@@ -284,7 +284,7 @@ Return a symmetric version of graph (represented by sparse matrix `A`) as a spar
 """
 function symmetrize(A::SparseMatrix, which=:or)
 	if which == :or
-		M = A + A'
+		M = A + sparse(A')
 		M.nzval[M.nzval .== 2] = 1
 		return M
     end

--- a/src/linalg/graphmatrices.jl
+++ b/src/linalg/graphmatrices.jl
@@ -239,37 +239,37 @@ function *(adjmat::PunchedAdjacency{T}, x::AbstractVector{T}) where T<:Number
     return y - dot(adjmat.perron, y) * adjmat.perron
 end
 
-function A_mul_B!(Y, A::Adjacency, B)
+function mul!(Y, A::Adjacency, B)
     # we need to do 3 matrix products
-    # Y and B can't overlap in any one call to A_mul_B!
-    # The last call to A_mul_B! must be (Y, postscalefactor, tmp)
+    # Y and B can't overlap in any one call to mul!
+    # The last call to mul! must be (Y, postscalefactor, tmp)
     # so we need to write to tmp in the second step  must be (tmp, A.A, Y)
     # and the first step (Y, prescalefactor, B)
     tmp1 = Diagonal(prescalefactor(A)) * B
     tmp = similar(Y)
-    A_mul_B!(tmp, A.A, tmp1)
-    return A_mul_B!(Y, Diagonal(postscalefactor(A)), tmp)
+    mul!(tmp, A.A, tmp1)
+    return mul!(Y, Diagonal(postscalefactor(A)), tmp)
 end
 
-A_mul_B!(Y, A::CombinatorialAdjacency, B) = A_mul_B!(Y, A.A, B)
+mul!(Y, A::CombinatorialAdjacency, B) = mul!(Y, A.A, B)
 
 # You can compute the StochasticAdjacency product without allocating a similar of Y.
 # This is true for all Adjacency where the postscalefactor is a Noop
 # at time of writing this is just StochasticAdjacency and CombinatorialAdjacency
-function A_mul_B!(Y, A::StochasticAdjacency, B)
+function mul!(Y, A::StochasticAdjacency, B)
     tmp = Diagonal(prescalefactor(A)) * B
-    A_mul_B!(Y, A.A, tmp)
+    mul!(Y, A.A, tmp)
     return Y
 end
 
-function A_mul_B!(Y, adjmat::PunchedAdjacency, x)
+function mul!(Y, adjmat::PunchedAdjacency, x)
     y = adjmat.A * x
     Y[:] = y - dot(adjmat.perron, y) * adjmat.perron
     return Y
 end
 
-function A_mul_B!(Y, lapl::Laplacian, B)
-	A_mul_B!(Y, lapl.A, B)
+function mul!(Y, lapl::Laplacian, B)
+	mul!(Y, lapl.A, B)
 	z = diag(lapl) .* B
 	Y[:] = z - Y[:]
 	return Y
@@ -317,7 +317,7 @@ symmetrize(adjmat::CombinatorialAdjacency, which=:or) =
 
 
 # per #564
-@deprecate A_mul_B!(Y, A::Noop, B) None
+@deprecate mul!(Y, A::Noop, B) None
 @deprecate convert(::Type{Adjacency}, lapl::Laplacian) None
 @deprecate convert(::Type{SparseMatrix}, adjmat::CombinatorialAdjacency) sparse(adjmat)
 

--- a/src/linalg/graphmatrices.jl
+++ b/src/linalg/graphmatrices.jl
@@ -298,7 +298,7 @@ function symmetrize(A::SparseMatrix, which=:or)
     else
         throw(ArgumentError("$which is not a supported method of symmetrizing a matrix"))
     end
-	M = T + T'
+	M = T + sparse(T')
 	return M
 end
 

--- a/src/linalg/nonbacktracking.jl
+++ b/src/linalg/nonbacktracking.jl
@@ -100,7 +100,7 @@ function *(nbt::Nonbacktracking, x::Vector{T}) where T<:Number
     end
     return y
 end
-function A_mul_B!(C, nbt::Nonbacktracking, B)
+function mul!(C, nbt::Nonbacktracking, B)
     # computs C = A * B
     for i in 1:size(B, 2)
         C[:, i] = nbt * B[:, i]

--- a/src/linalg/spectral.jl
+++ b/src/linalg/spectral.jl
@@ -73,14 +73,14 @@ for a graph `g`, indexed by `[u, v]` vertices. `T` defaults to `Int` for both gr
 ### Optional Arguments
 `dir=:unspec`: `:unspec`, `:both`, :in`, and `:out` are currently supported.
 For undirected graphs, `dir` defaults to `:out`; for directed graphs,
-`dir` defaults to `:both`. 
+`dir` defaults to `:both`.
 """
 function laplacian_matrix(g::AbstractGraph{U}, T::DataType=Int; dir::Symbol=:unspec) where U
     if dir == :unspec
         dir = is_directed(g) ? :both : :out
     end
     A = adjacency_matrix(g, T; dir=dir)
-    D = convert(SparseMatrixCSC{T, U}, spdiagm(sum(A, 2)[:]))
+    D = convert(SparseMatrixCSC{T, U}, Diagonal(sparse(sum(A, 2)[:])))
     return D - A
 end
 

--- a/src/traversals/diffusion.jl
+++ b/src/traversals/diffusion.jl
@@ -27,7 +27,7 @@ function diffusion(g::AbstractGraph{T},
 
     # Initialize
     watch_set = Set{T}(watch)
-    infected_vertices = IntSet(initial_infections)
+    infected_vertices = BitSet(initial_infections)
     vertices_per_step::Vector{Vector{T}} = [Vector{T}() for i in 1:n]
 
     # Record initial infection

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -42,7 +42,7 @@ Unlike [`sample!`](@ref), does not produce side effects.
 """
 sample(a::UnitRange, k::Integer; exclude = ()) = sample!(getRNG(), collect(a), k; exclude = exclude)
 
-getRNG(seed::Integer = -1) = seed >= 0 ? MersenneTwister(seed) : Base.Random.GLOBAL_RNG
+getRNG(seed::Integer = -1) = seed >= 0 ? MersenneTwister(seed) : GLOBAL_RNG
 
 """
     insorted(item, collection)
@@ -53,4 +53,3 @@ Return true if `item` is in sorted collection `collection`.
 Does not verify that `collection` is sorted.
 """
 insorted(item, collection) = !isempty(searchsorted(collection, item))
-

--- a/test/centrality/betweenness.jl
+++ b/test/centrality/betweenness.jl
@@ -7,7 +7,7 @@
 
     gint = loadgraph(joinpath(testdir, "testdata", "graph-50-500.jgz"), "graph-50-500")
 
-    c = vec(readcsv(joinpath(testdir, "testdata", "graph-50-500-bc.txt")))
+    c = vec(readdlm(joinpath(testdir, "testdata", "graph-50-500-bc.txt"), ','))
     for g in testdigraphs(gint)
         z  = @inferred(betweenness_centrality(g))
         zp = @inferred(parallel_betweenness_centrality(g))

--- a/test/centrality/radiality.jl
+++ b/test/centrality/radiality.jl
@@ -1,7 +1,7 @@
 @testset "Radiality" begin
     gint = loadgraph(joinpath(testdir, "testdata", "graph-50-500.jgz"), "graph-50-500")
 
-    c = vec(readcsv(joinpath(testdir, "testdata", "graph-50-500-rc.txt")))
+    c = vec(readdlm(joinpath(testdir, "testdata", "graph-50-500-rc.txt"), ','))
     for g in testdigraphs(gint)
         z  = @inferred(radiality_centrality(g))
         zp = @inferred(parallel_radiality_centrality(g))

--- a/test/centrality/stress.jl
+++ b/test/centrality/stress.jl
@@ -1,7 +1,7 @@
 @testset "Stress" begin
     gint = loadgraph(joinpath(testdir, "testdata", "graph-50-500.jgz"), "graph-50-500")
 
-    c = vec(readcsv(joinpath(testdir, "testdata", "graph-50-500-sc.txt")))
+    c = vec(readdlm(joinpath(testdir, "testdata", "graph-50-500-sc.txt"), ','))
     for g in testdigraphs(gint)
         z  = @inferred(stress_centrality(g))
         zp = @inferred(parallel_stress_centrality(g))

--- a/test/community/clique_percolation.jl
+++ b/test/community/clique_percolation.jl
@@ -1,6 +1,6 @@
 @testset "Clique percolation" begin
     function setofsets(array_of_arrays)
-        Set(map(IntSet, array_of_arrays))
+        Set(map(BitSet, array_of_arrays))
     end
 
     function test_cliques(graph, expected)

--- a/test/connectivity.jl
+++ b/test/connectivity.jl
@@ -143,7 +143,7 @@
 
     # construct a n-number edge ring graph (period = n)
     n = 10
-    n_ring_m = spdiagm(ones(n - 1), 1, n, n); n_ring_m[end, 1] = 1
+    n_ring_m = spdiagm(1 => ones(n - 1)); n_ring_m[end, 1] = 1
     n_ring = SimpleDiGraph(n_ring_m)
 
     n_ring_shortcut = copy(n_ring); add_edge!(n_ring_shortcut, 1, 4)

--- a/test/linalg/graphmatrices.jl
+++ b/test/linalg/graphmatrices.jl
@@ -169,7 +169,7 @@
     test_laplacian(mat)
     test_accessors(mat, n)
 
-    mat = symmetrize(sparse(spones(sprand(n, n, 0.3))))
+    mat = symmetrize(sparse(LinearAlgebra.fillstored!(sprand(n, n, 0.3), 1)))
     test_arithmetic(mat, n)
     test_other(mat, n)
     test_symmetry(mat, n)

--- a/test/linalg/runtests.jl
+++ b/test/linalg/runtests.jl
@@ -1,4 +1,5 @@
 using LightGraphs.LinAlg
+using IterativeEigensolvers
 
 const linalgtestdir = dirname(@__FILE__)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,8 @@
 using LightGraphs
 using LightGraphs.SimpleGraphs
-using Base.Test
+using Test
+using SparseArrays
+using LinearAlgebra
 
 const testdir = dirname(@__FILE__)
 


### PR DESCRIPTION
This is an initial stab at getting LightGraphs ready for Julia 0.7.  

- [x] Add `using` statements for functionality moved into stdlibs from `Base`
- [x] Fix erroring and failing tests
- [ ] Remove deprecations - I'm hoping we can run Femtocleaner to automate this once https://github.com/mauro3/SimpleTraits.jl/issues/46 is fixed

As a happy coincidence I was able to find a fix a bug in base julia too! https://github.com/JuliaLang/julia/pull/25943

You should be able to get the following on the latest master
```julia
               _
   _       _ _(_)_     |  A fresh approach to technical computing
  (_)     | (_) (_)    |  Documentation: https://docs.julialang.org
   _ _   _| |_  __ _   |  Type "?help" for help.
  | | | | | | |/ _` |  |
  | | |_| | | | (_| |  |  Version 0.7.0-DEV.3961 (2018-02-13 10:42 UTC)
 _/ |\__'_|_|_|\__'_|  |  Commit 12964e839e* (0 days old master)
|__/                   |  x86_64-apple-darwin16.4.0

julia> Pkg.test("LightGraphs")
***Lots of deprecation warnings***
Test Summary: |  Pass  Total
LightGraphs   | 28781  28781
[ Info: LightGraphs tests passed
```

cc: @jpfairbanks 