### PR TITLE
Speed improvements for function transitiveclosure!

### DIFF
--- a/src/digraph/transitivity.jl
+++ b/src/digraph/transitivity.jl
@@ -14,11 +14,7 @@ function transitiveclosure! end
 @traitfn function transitiveclosure!(g::::IsDirected, selflooped=false)
     for k in vertices(g)
         for i in inneighbors(g, k), j in outneighbors(g, k)
-            i == k && continue
-            j == k && continue
-            if i == j && !selflooped
-                continue
-            end
+            ((!selflooped && i == j) || i == k || j == k) && continue
             add_edge!(g, i, j)      
         end
     end

--- a/src/digraph/transitivity.jl
+++ b/src/digraph/transitivity.jl
@@ -13,16 +13,13 @@ This version of the function modifies the original graph.
 function transitiveclosure! end
 @traitfn function transitiveclosure!(g::::IsDirected, selflooped=false)
     for k in vertices(g)
-        for i in vertices(g)
+        for i in inneighbors(g, k), j in outneighbors(g, k)
             i == k && continue
-            for j in vertices(g)
-                j == k && continue
-                if (has_edge(g, i, k) && has_edge(g, k, j))
-                    if (i != j || selflooped)
-                        add_edge!(g, i, j)
-                    end
-                end
+            j == k && continue
+            if i == j && !selflooped
+                continue
             end
+            add_edge!(g, i, j)      
         end
     end
     return g


### PR DESCRIPTION
In the implementation of the Warshall algorithm in iteration k of the outer loop, the graph is tested for all possible edges i->k and k->j. It is more efficient to just loop over the in- and outneighbours of k.

Some not very scientific testing shows that after this fix the algorithm runs rougly twice as fast for complete directed graphs and much faster for sparse graphs.