### PR TITLE
Added function transitivereduction

### DIFF
--- a/src/LightGraphs.jl
+++ b/src/LightGraphs.jl
@@ -98,7 +98,7 @@ MaximumAdjacency, AbstractMASVisitor, mincut, maximum_adjacency_visit,
 # a-star, dijkstra, bellman-ford, floyd-warshall
 a_star, dijkstra_shortest_paths, bellman_ford_shortest_paths,
 has_negative_edge_cycle, enumerate_paths, floyd_warshall_shortest_paths,
-transitiveclosure!, transitiveclosure, yen_k_shortest_paths,
+transitiveclosure!, transitiveclosure, transitivereduction, yen_k_shortest_paths,
 parallel_multisource_dijkstra_shortest_paths,
 
 # centrality

--- a/src/digraph/transitivity.jl
+++ b/src/digraph/transitivity.jl
@@ -35,3 +35,80 @@ function transitiveclosure(g::DiGraph, selflooped = false)
     copyg = copy(g)
     return transitiveclosure!(copyg, selflooped)
 end
+
+"""
+    transitivereduction(g; selflooped=false)
+
+    Compute the transitive reduction of  a directed graph. If the graph contains
+    cycles, each strongly connected component is replaced by a directed cycle and
+    the transitive reduction is calculated on the condensation graph connecting the
+    components. If `selflooped` is true, self loops on strongly connected components
+    of size one will be preserved.
+
+### Performance
+Time complexity is \\mathcal{O}(|V||E|).
+"""
+function transitivereducion end
+@traitfn function transitivereduction(g::::IsDirected; selflooped::Bool=false)
+    scc = strongly_connected_components(g) 
+    cg = condensation(g, scc) 
+
+    reachable = Vector{Bool}(undef, nv(cg)) 
+    visited = Vector{Bool}(undef, nv(cg))
+    stack = Vector{eltype(cg)}(undef, nv(cg)) 
+    resultg = SimpleDiGraph{eltype(g)}(nv(g))
+    
+# Calculate the transitive reduction of the acyclic condensation graph.
+    @inbounds(
+    for u in vertices(cg)
+        fill!(reachable, false) # vertices reachable from u on a path of length >= 2
+        fill!(visited, false)
+        stacksize = 0
+        for v in outneighbors(cg,u)
+      @simd for w in outneighbors(cg, v)
+                if !visited[w]
+                    visited[w] = true
+                    stacksize += 1
+                    stack[stacksize] = w
+                end
+            end
+        end
+        while stacksize > 0
+            v = stack[stacksize]
+            stacksize -= 1
+            reachable[v] = true
+      @simd for w in outneighbors(cg, v)
+                if !visited[w]
+                    visited[w] = true
+                    stacksize += 1
+                    stack[stacksize] = w
+                end
+            end
+        end
+# Add the edges from the condensation graph to the resulting graph.
+  @simd for v in outneighbors(cg,u)
+            if !reachable[v]
+                add_edge!(resultg, scc[u][1], scc[v][1])
+            end
+        end
+    end)
+
+# Replace each strongly connected component with a directed cycle.
+    @inbounds(
+    for component in scc
+        nvc = length(component)
+        if nvc == 1 
+            if selflooped && has_edge(g, component[1], component[1])
+                add_edge!(resultg, component[1], component[1])
+            end
+            continue
+        end
+        for i in 1:(nvc-1)
+            add_edge!(resultg, component[i], component[i+1])
+        end
+        add_edge!(resultg, component[nvc], component[1])
+    end)
+
+    return resultg
+end
+

--- a/src/shortestpaths/floyd-warshall.jl
+++ b/src/shortestpaths/floyd-warshall.jl
@@ -12,7 +12,7 @@ struct FloydWarshallState{T,U<:Integer} <: AbstractPathState
     parents::Matrix{U}
 end
 
-"""
+@doc_str """
 floyd_warshall_shortest_paths(g, distmx=weights(g))
 Use the [Floyd-Warshall algorithm](http://en.wikipedia.org/wiki/Floyd–Warshall_algorithm)
 to compute the shortest paths between all pairs of vertices in graph `g` using an
@@ -30,7 +30,6 @@ function floyd_warshall_shortest_paths(
     dists = fill(typemax(T), (Int(n_v), Int(n_v)))
     parents = zeros(U, (Int(n_v), Int(n_v)))
 
-    # fws = FloydWarshallState(Matrix{T}(), Matrix{Int}())
     for v in 1:n_v
         dists[v, v] = zero(T)
     end
@@ -48,15 +47,19 @@ function floyd_warshall_shortest_paths(
             parents[v, u] = v
         end
     end
-    for w in vertices(g), u in vertices(g), v in vertices(g)
-        if dists[u, w] == typemax(T) || dists[w, v] == typemax(T)
-            ans = typemax(T)
-        else
-            ans = dists[u, w] + dists[w, v]
-        end
-        if dists[u, v] > ans
-            dists[u, v] = dists[u, w] + dists[w, v]
-            parents[u, v] = parents[w, v]
+
+    for pivot in vertices(g)
+        for v in vertices(g)
+            d = dists[pivot, v]
+            d == typemax(T) && continue
+            p = parents[pivot, v]
+            for u in vertices(g)
+                ans = (dists[u, pivot] == typemax(T) ? typemax(T): dists[u, pivot] + d) 
+                if dists[u, v] > ans
+                    dists[u, v] = ans
+                    parents[u, v] = p
+                end
+            end
         end
     end
     fws = FloydWarshallState(dists, parents)

--- a/test/digraph/transitivity.jl
+++ b/test/digraph/transitivity.jl
@@ -27,4 +27,64 @@
         @test newcircle == @inferred(transitiveclosure!(circle, true))
         @test ne(circle) == 16
     end
+
+    # transitivereduction
+    let
+        nullgraph = SimpleDiGraph(0)
+        pathgraph = SimpleDiGraph(10)
+        pathgraph_closure = transitiveclosure(pathgraph)
+        complete_graph = CompleteDiGraph(9)
+        complete_graph_reduced = transitivereduction(complete_graph)
+        no_edge_graph = SimpleDiGraph(7)
+        self_loop_graph = SimpleDiGraph(1)
+        add_edge!(self_loop_graph, 1, 1)
+        
+        barbell_graph = SimpleDiGraph(9)
+        for i in 1:4, j in 1:4
+            i == j && continue
+            add_edge!(barbell_graph, i, j)
+        end
+        barbell_graph = SimpleDiGraph(9)
+        for i in 1:4, j in 1:4
+            i == j && continue
+            add_edge!(barbell_graph, i, j)
+        end
+        for i in 5:9, j in 5:9
+            i == j && continue
+            add_edge!(barbell_graph, i, j)
+        end
+        add_edge!(barbell_graph, 1,5);
+
+        # transitive reduction of a the nullgraph is again a nullgraph
+        @test nullgraph == transitivereduction(nullgraph)
+
+        # transitive reduction of a path is a path again
+        @test pathgraph == transitivereduction(pathgraph)
+
+        # transitive reduction of a the transtitve closure of a path is the same path again
+        @test pathgraph == transitivereduction(pathgraph_closure)
+        for pathgraph2 in testdigraphs(pathgraph)
+            pathgraph_reduced = @inferred(transitivereduction(pathgraph2))
+            @test pathgraph2 == pathgraph_reduced
+        end
+
+        # Transitive reduction of a complete graph should be s simple cycle
+        @test length(strongly_connected_components(complete_graph_reduced)) == 1 &&
+            ne(complete_graph_reduced) == nv(complete_graph)
+
+        # transitive reduction a graph with no edges is the same graph again
+        @test no_edge_graph == transitivereduction(no_edge_graph)
+
+        # transitve reduction should maintain a selfloop only when selflooped==true
+        @test self_loop_graph == transitivereduction(self_loop_graph; selflooped=true)
+        @test self_loop_graph != transitivereduction(self_loop_graph; selflooped=false)
+
+        # directed barbell should result in two cycles connected by a single edge
+        barbell_graph_reduced = transitivereduction(barbell_graph)
+        scc = strongly_connected_components(barbell_graph_reduced)
+        @test Set(scc) == Set([[1:4;], [5:9;]])
+        @test ne(barbell_graph_reduced) == 10
+        @test length(weakly_connected_components(barbell_graph_reduced)) == 1
+    end
+
 end

--- a/test/digraph/transitivity.jl
+++ b/test/digraph/transitivity.jl
@@ -30,61 +30,76 @@
 
     # transitivereduction
     let
+        # transitive reduction of the nullgraph is again a nullgraph
         nullgraph = SimpleDiGraph(0)
-        pathgraph = SimpleDiGraph(10)
-        pathgraph_closure = transitiveclosure(pathgraph)
-        complete_graph = CompleteDiGraph(9)
-        complete_graph_reduced = transitivereduction(complete_graph)
-        no_edge_graph = SimpleDiGraph(7)
-        self_loop_graph = SimpleDiGraph(1)
-        add_edge!(self_loop_graph, 1, 1)
+        for g in testdigraphs(nullgraph)
+            @test g == @inferred(transitivereduction(g))
+        end
         
-        barbell_graph = SimpleDiGraph(9)
-        for i in 1:4, j in 1:4
-            i == j && continue
-            add_edge!(barbell_graph, i, j)
-        end
-        barbell_graph = SimpleDiGraph(9)
-        for i in 1:4, j in 1:4
-            i == j && continue
-            add_edge!(barbell_graph, i, j)
-        end
-        for i in 5:9, j in 5:9
-            i == j && continue
-            add_edge!(barbell_graph, i, j)
-        end
-        add_edge!(barbell_graph, 1,5);
-
-        # transitive reduction of a the nullgraph is again a nullgraph
-        @test nullgraph == transitivereduction(nullgraph)
-
         # transitive reduction of a path is a path again
-        @test pathgraph == transitivereduction(pathgraph)
-
-        # transitive reduction of a the transtitve closure of a path is the same path again
-        @test pathgraph == transitivereduction(pathgraph_closure)
-        for pathgraph2 in testdigraphs(pathgraph)
-            pathgraph_reduced = @inferred(transitivereduction(pathgraph2))
-            @test pathgraph2 == pathgraph_reduced
+        pathgraph = PathDiGraph(10)
+        for g in testdigraphs(pathgraph)
+            @test g == @inferred(transitivereduction(g))
+        end
+        
+        # transitive reduction of the transitive closure of a path is a path again
+        for g in testdigraphs(pathgraph)
+            gclosure = transitiveclosure(g)
+            @test g == @inferred(transitivereduction(gclosure))
         end
 
         # Transitive reduction of a complete graph should be s simple cycle
-        @test length(strongly_connected_components(complete_graph_reduced)) == 1 &&
-            ne(complete_graph_reduced) == nv(complete_graph)
+        completegraph = CompleteDiGraph(9)
+        for g in testdigraphs(completegraph)
+            greduced = @inferred(transitivereduction(g))
+            @test length(strongly_connected_components(greduced)) == 1 &&
+                ne(greduced) == nv(g)
+        end
 
         # transitive reduction a graph with no edges is the same graph again
-        @test no_edge_graph == transitivereduction(no_edge_graph)
-
+        noedgegraph = SimpleDiGraph(7)
+        for g in testdigraphs(noedgegraph)
+            @test g == @inferred(transitivereduction(g))
+        end
+         
         # transitve reduction should maintain a selfloop only when selflooped==true
-        @test self_loop_graph == transitivereduction(self_loop_graph; selflooped=true)
-        @test self_loop_graph != transitivereduction(self_loop_graph; selflooped=false)
+        selfloopgraph = SimpleDiGraph(1)
+        add_edge!(selfloopgraph, 1, 1)
+        for g in testdigraphs(selfloopgraph)
+            @test g == @inferred(transitivereduction(g; selflooped=true));
+            @test g != @inferred(transitivereduction(g; selflooped=false));
+        end
 
-        # directed barbell should result in two cycles connected by a single edge
-        barbell_graph_reduced = transitivereduction(barbell_graph)
-        scc = strongly_connected_components(barbell_graph_reduced)
-        @test Set(scc) == Set([[1:4;], [5:9;]])
-        @test ne(barbell_graph_reduced) == 10
-        @test length(weakly_connected_components(barbell_graph_reduced)) == 1
+        # transitive should not maintain selfloops for strongly connected components
+        # of size > 1
+        selfloopgraph2 = SimpleDiGraph(2)
+        add_edge!(selfloopgraph2, 1, 1)
+        add_edge!(selfloopgraph2, 1, 2)
+        add_edge!(selfloopgraph2, 2, 1)
+        add_edge!(selfloopgraph2, 2, 2)
+        for g in testdigraphs(selfloopgraph2)
+            @test g != @inferred(transitivereduction(g; selflooped=true));
+        end
+
+        # directed barbell graph should result in two cycles connected by a single edge
+        barbellgraph = SimpleDiGraph(9)
+        for i in 1:4, j in 1:4
+            i == j && continue
+            add_edge!(barbellgraph, i, j)
+            add_edge!(barbellgraph, j, i)
+        end
+        for i in 5:9, j in 5:9
+            i == j && continue
+            add_edge!(barbellgraph, i, j)
+            add_edge!(barbellgraph, j, i)
+        end
+        add_edge!(barbellgraph, 1, 5);
+        for g in testdigraphs(barbellgraph)
+            greduced = @inferred(transitivereduction(g))
+            scc = strongly_connected_components(greduced)
+            @test Set(scc) == Set([[1:4;], [5:9;]])
+            @test ne(greduced) == 10
+            @test length(weakly_connected_components(greduced)) == 1
+        end
     end
-
 end


### PR DESCRIPTION
As mentioned in #874 I have implemented a function to calculate the transitive reduction of  a graph and added some tests. I've also added a kwargs option `selflooped` in order to mimic the function `transitveclosure`.

For some reason, the docstring I wrote for this function does not appear in my Julia v.07 repl, when entering `?transitivereduction`. Anyone has a clue why this happens?

Some remarks:
1) As mentioned in #874 this function could later be improved to also calculate the minimum equivalent graph or an approximation of it.
2) The outer loop of this algorithm should not be too difficult to parallelize
3) Handling each strongly connected component seems to be a good decision as the algorithm runs fast when there are just a few edges and many strongly connected components (i.e paths)and also when there are many edges and few strongly connected components (i.e. complete graphs)
A case where the algorithm has to do a lot of work is when there are many edges and many strongly connected components (try running it on `g = transitiveclosure!(PathDiGraph(5000))` ).
The Boost graph library does something similar to calculate the transitive closure, so if someone wants to speed up the `transitiveclosure` function of LightGraphs, they could try something like that.

