### PR TITLE
Improve Kruskal and use in-built disjoint set data structure

### DIFF
--- a/src/spanningtrees/kruskal.jl
+++ b/src/spanningtrees/kruskal.jl
@@ -1,3 +1,8 @@
+"""
+    kruskal_mst(g, distmx=weights(g))
+Return a vector of edges representing the minimum spanning tree of a connected, undirected graph `g` with optional
+distance matrix `distmx` using [Kruskal's algorithm](https://en.wikipedia.org/wiki/Kruskal%27s_algorithm).
+"""
 function kruskal_mst end
 # see https://github.com/mauro3/SimpleTraits.jl/issues/47#issuecomment-327880153 for syntax
 @traitfn function kruskal_mst(
@@ -21,9 +26,7 @@ function kruskal_mst end
         if !DataStructures.in_same_set(connected_vs, e.src, e.dst)
             DataStructures.union!(connected_vs, e.src, e.dst)
             push!(mst, e)
-            if length(mst) >= nv(g) - 1
-                break
-            end
+            (length(mst) >= nv(g) - 1) && break
         end
     end
 

--- a/src/spanningtrees/kruskal.jl
+++ b/src/spanningtrees/kruskal.jl
@@ -1,43 +1,3 @@
-struct KruskalHeapEntry{T<:Real}
-    edge::Edge
-    dist::T
-end
-
-isless(e1::KruskalHeapEntry, e2::KruskalHeapEntry) = e1.dist < e2.dist
-
-"""
-    find_set!(vs, q)
-
-Perform [Quick-Find algorithm](https://en.wikipedia.org/wiki/Disjoint-set_data_structure)
-on a given vertex `q` and return the component id in `vs` to which it belongs.
-"""
-function find_set!(set_id::Vector{U}, q::U) where U<:Integer
-    
-    root = q
-    while root != set_id[root]
-        root = set_id[root]
-    end
-
-    p_1 = q
-    p_2 = set_id[q]
-    
-    while p_2 != root
-        set_id[p_1] = root
-        p_1 = p_2
-        p_2 = set_id[p_1]
-    end
-    
-    return root
-end
-
-union_set!(set_id::Vector{U}, p::U, q::U) where {U<:Integer} = (set_id[find_set!(set_id, p)] = find_set!(set_id, q))
-
-"""
-    kruskal_mst(g, distmx=weights(g))
-
-Return a vector of edges representing the minimum spanning tree of a connected, undirected graph `g` with optional
-distance matrix `distmx` using [Kruskal's algorithm](https://en.wikipedia.org/wiki/Kruskal%27s_algorithm).
-"""
 function kruskal_mst end
 # see https://github.com/mauro3/SimpleTraits.jl/issues/47#issuecomment-327880153 for syntax
 @traitfn function kruskal_mst(
@@ -45,26 +5,22 @@ function kruskal_mst end
     distmx::AbstractMatrix{T} = weights(g)
 ) where {T<:Real, U, AG<:AbstractGraph{U}}
 
-    edge_list = Vector{KruskalHeapEntry{T}}()
-    mst = Vector{Edge}()
-    connected_vs = collect(one(U):nv(g))
+    connected_vs = DataStructures.IntDisjointSets(nv(g))
 
-    sizehint!(edge_list, ne(g))
+    mst = Vector{Edge}()
     sizehint!(mst, nv(g) - 1)
 
-    for e in edges(g)
-        push!(edge_list, KruskalHeapEntry{T}(Edge(src(e), dst(e)), distmx[src(e), dst(e)]))
+    weights = Vector{T}()
+    sizehint!(weights, ne(g))
+    edge_list = collect(edges(g))
+    for e in edge_list
+        push!(weights, distmx[src(e), dst(e)])
     end
-     DataStructures.heapify!(edge_list)
 
-    while !isempty(edge_list)
-        heap_entry = DataStructures.heappop!(edge_list)
-        v = src(heap_entry.edge)
-        w = dst(heap_entry.edge)
-
-        if find_set!(connected_vs, v) != find_set!(connected_vs, w)
-            union_set!(connected_vs, v, w)
-            push!(mst, heap_entry.edge)
+    for e in edge_list[sortperm(weights)]
+        if !DataStructures.in_same_set(connected_vs, e.src, e.dst)
+            DataStructures.union!(connected_vs, e.src, e.dst)
+            push!(mst, e)
             if length(mst) >= nv(g) - 1
                 break
             end
@@ -73,4 +29,3 @@ function kruskal_mst end
 
     return mst
 end
-


### PR DESCRIPTION
Improvements due to sorting:

For a complete graph with 1,000 vertices, the run-time improved from 193 ms to 28 ms.
For a path graph with 10,000 vertices, the run-time improved from 3.88 ms to 1.15 ms.

I removed the disjoint set data structure I had created and replaced it with the Inbuilt Disjoint Set. because the improvement in performance was little (28ms to to 26ms)