### PR TITLE
Parallel floyd warshall

### DIFF
--- a/src/shortestpaths/floyd-warshall.jl
+++ b/src/shortestpaths/floyd-warshall.jl
@@ -1,7 +1,5 @@
 # Parts of this code were taken / derived from Graphs.jl. See LICENSE for
 # licensing details.
-
-
 """
     struct FloydWarshallState{T, U}
 
@@ -12,25 +10,83 @@ struct FloydWarshallState{T,U<:Integer} <: AbstractPathState
     parents::Matrix{U}
 end
 
-@doc """
-floyd_warshall_shortest_paths(g, distmx=weights(g))
-Use the [Floyd-Warshall algorithm](http://en.wikipedia.org/wiki/Floyd–Warshall_algorithm)
-to compute the shortest paths between all pairs of vertices in graph `g` using an
-optional distance matrix `distmx`. Return a [`LightGraphs.FloydWarshallState`](@ref) with relevant
-traversal information.
-
-### Performance
-Space complexity is on the order of ``\\mathcal{O}(|V|^2)``.
-"""
-function floyd_warshall_shortest_paths(
+function seq_floyd_warshall_shortest_paths(
     g::AbstractGraph{U},
-    distmx::AbstractMatrix{T} = weights(g)
-) where T where U
-    n_v = nv(g)
-    dists = fill(typemax(T), (Int(n_v), Int(n_v)))
-    parents = zeros(U, (Int(n_v), Int(n_v)))
+    distmx::AbstractMatrix{T}
+) where T<:Real where U<:Integer
+    nvg = nv(g)
+    dists = fill(typemax(T), (Int(nvg), Int(nvg)))
+    parents = zeros(U, (Int(nvg), Int(nvg)))
 
-    for v in 1:n_v
+    for v in 1:nvg
+        dists[v, v] = zero(T)
+    end
+    undirected = !is_directed(g)
+    for e in edges(g)
+        u = src(e)
+        v = dst(e)
+
+        d = distmx[u, v]
+
+        dists[u, v] = min(d, dists[u, v])
+        parents[u, v] = u
+        if undirected
+            dists[v, u] = min(d, dists[v, u])
+            parents[v, u] = v
+        end
+    end
+
+    @inbounds for pivot in vertices(g)
+        # Relax dists[u, v] = min(dists[u, v], dists[u, pivot]+dists[pivot, v]) for all u, v
+        for v in vertices(g)
+            d = dists[pivot, v]
+            d == typemax(T) && continue
+            p = parents[pivot, v]
+            for u in vertices(g)
+                ans = (dists[u, pivot] == typemax(T) ? typemax(T) : dists[u, pivot] + d) 
+                if dists[u, v] > ans
+                    dists[u, v] = ans
+                    parents[u, v] = p
+                end
+            end
+        end
+    end
+    fws = FloydWarshallState(dists, parents)
+    return fws
+end
+
+function _loopbody!(
+    pivot::U, 
+    nvg::U,
+    dists::Matrix{T}, 
+    parents::Matrix{U}
+    ) where T<:Real where U<:Integer
+    # Relax dists[u, v] = min(dists[u, v], dists[u, pivot]+dists[pivot, v]) for all u, v
+    @inbounds @threads for v in one(U):nvg
+        d = dists[pivot, v]
+        if d != typemax(T) && v != pivot
+            p = parents[pivot, v]
+            for u in one(U):nvg
+                ans = (dists[u, pivot] == typemax(T) || u == pivot ? typemax(T) : dists[u, pivot] + d) 
+                if dists[u, v] > ans
+                    dists[u, v] = ans
+                    parents[u, v] = p
+                end
+            end
+        end
+    end
+end
+
+function parallel_floyd_warshall_shortest_paths(
+    g::AbstractGraph{U},
+    distmx::AbstractMatrix{T}
+) where T<:Real where U<:Integer
+    nvg = nv(g)
+
+    dists = fill(typemax(T), (Int(nvg), Int(nvg)))
+    parents = zeros(U, (Int(nvg), Int(nvg)))
+
+    for v in 1:nvg
         dists[v, v] = zero(T)
     end
     undirected = !is_directed(g)
@@ -49,22 +105,32 @@ function floyd_warshall_shortest_paths(
     end
 
     for pivot in vertices(g)
-        for v in vertices(g)
-            d = dists[pivot, v]
-            d == typemax(T) && continue
-            p = parents[pivot, v]
-            for u in vertices(g)
-                ans = (dists[u, pivot] == typemax(T) ? typemax(T) : dists[u, pivot] + d) 
-                if dists[u, v] > ans
-                    dists[u, v] = ans
-                    parents[u, v] = p
-                end
-            end
-        end
+        _loopbody!(pivot, nvg, dists, parents)
     end
     fws = FloydWarshallState(dists, parents)
     return fws
 end
+
+
+@doc """
+    floyd_warshall_shortest_paths(g, distmx=weights(g); parallel=false)
+
+Use the [Floyd-Warshall algorithm](http://en.wikipedia.org/wiki/Floyd–Warshall_algorithm)
+to compute the shortest paths between all pairs of vertices in graph `g` using an
+optional distance matrix `distmx`. Return a [`LightGraphs.FloydWarshallState`](@ref) with relevant
+traversal information.
+
+### Performance
+Space complexity is on the order of ``\\mathcal{O}(|V|^2)``.
+
+### Optional Arguments
+- `parallel=false`: If true, the algorithm runs in parallel.
+"""
+floyd_warshall_shortest_paths(
+    g::AbstractGraph{U},
+    distmx::AbstractMatrix{T} = weights(g);
+    parallel = false
+) where T<:Real where U<:Integer = (parallel ? parallel_floyd_warshall_shortest_paths(g, distmx) : seq_floyd_warshall_shortest_paths(g, distmx))
 
 function enumerate_paths(s::FloydWarshallState{T,U}, v::Integer) where T where U<:Integer
     pathinfo = s.parents[v, :]

--- a/test/shortestpaths/floyd-warshall.jl
+++ b/test/shortestpaths/floyd-warshall.jl
@@ -1,20 +1,30 @@
 @testset "Floyd Warshall" begin
-    g3 = PathGraph(5)
-    d = [0 1 2 3 4; 5 0 6 7 8; 9 10 0 11 12; 13 14 15 0 16; 17 18 19 20 0]
-    for g in testgraphs(g3)
-      z = @inferred(floyd_warshall_shortest_paths(g, d))
-      @test z.dists[3, :][:] == [7, 6, 0, 11, 27]
-      @test z.parents[3, :][:] == [2, 3, 0, 3, 4]
 
-      @test @inferred(enumerate_paths(z))[2][2] == []
-      @test @inferred(enumerate_paths(z))[2][4] == enumerate_paths(z, 2)[4] == enumerate_paths(z, 2, 4) == [2, 3, 4]
+    for parallel in (false, true)
+        g3 = PathGraph(5)
+        d = [0 1 2 3 4; 5 0 6 7 8; 9 10 0 11 12; 13 14 15 0 16; 17 18 19 20 0]
+        for g in testgraphs(g3)
+            z = @inferred(floyd_warshall_shortest_paths(g, d, parallel=parallel))
+            @test z.dists[3, :][:] == [7, 6, 0, 11, 27]
+            @test z.parents[3, :][:] == [2, 3, 0, 3, 4]
+
+            @test @inferred(enumerate_paths(z))[2][2] == []
+            @test @inferred(enumerate_paths(z))[2][4] == enumerate_paths(z, 2)[4] == enumerate_paths(z, 2, 4) == [2, 3, 4]
+        end
+        g4 = PathDiGraph(4)
+        d = ones(4, 4)
+        for g in testdigraphs(g4)
+            z = @inferred(floyd_warshall_shortest_paths(g, d, parallel=parallel))
+            @test length(enumerate_paths(z, 4, 3)) == 0
+            @test length(enumerate_paths(z, 4, 1)) == 0
+            @test length(enumerate_paths(z, 2, 3)) == 2
+        end 
+
+        g5 = DiGraph([1 1 1 0 1; 0 1 0 1 1; 0 1 1 0 0; 1 0 1 1 0; 0 0 0 1 1])
+        d = [0 3 8 0 -4; 0 0 0 1 7; 0 4 0 0 0; 2 0 -5 0 0; 0 0 0 6 0]
+        for g in testdigraphs(g5)
+            z = @inferred(floyd_warshall_shortest_paths(g, d, parallel=parallel))
+            @test z.dists == [0 1 -3 2 -4; 3 0 -4 1 -1; 7 4 0 5 3; 2 -1 -5 0 -2; 8 5 1 6 0]
+        end 
     end
-    g4 = PathDiGraph(4)
-    d = ones(4, 4)
-    for g in testdigraphs(g4)
-      z = @inferred(floyd_warshall_shortest_paths(g, d))
-      @test length(enumerate_paths(z, 4, 3)) == 0
-      @test length(enumerate_paths(z, 4, 1)) == 0
-      @test length(enumerate_paths(z, 2, 3)) == 2
-    end 
 end


### PR DESCRIPTION
Benchmarks were obtained on a random regular graph wit `k` = nvg/100
I did not use a graph from SNAPS because my laptop can't run floyd warshall for `|V| > 10,000` 

----------------------------`nvg = 1000`---------------------------------------------
`seq_floyd_warshall_shortest_paths`:   806.479 ms (5 allocations: 15.26 MiB)
`parallel_floyd_warshall_shortest_paths`:   592.930 ms (1005 allocations: 15.32 MiB)

----------------------------`nvg = 2000`---------------------------------------------
`seq_floyd_warshall_shortest_paths`:   6.548 s (5 allocations: 61.04 MiB)
`parallel_floyd_warshall_shortest_paths`:   4.997 s (2005 allocations: 61.16 MiB) 

----------------------------`nvg = 3000`---------------------------------------------
`seq_floyd_warshall_shortest_paths`:   21.194 s (5 allocations: 137.33 MiB)
`parallel_floyd_warshall_shortest_paths`:   16.924 s (3005 allocations: 137.51 MiB)
