### PR TITLE
Some performance improvements for graph generators

### DIFF
--- a/docs/src/graphtypes.md
+++ b/docs/src/graphtypes.md
@@ -11,6 +11,6 @@ In addition to providing `SimpleGraph` and `SimpleDiGraph` implementations, Ligh
 These are general guidelines to help you select the proper graph type.
 
 - In general, prefer the native `SimpleGraphs`/`SimpleDiGraphs` structures in [LightGraphs.jl](https://github.com/JuliaGraphs/LightGraphs.jl).
-- If you need edge weights and don't require large numbers of graph modifications, use [SimpleWeightedGraphs](https://github.com/JuliaGraphss/SimpleWeightedGraphs.jl).
+- If you need edge weights and don't require large numbers of graph modifications, use [SimpleWeightedGraphs](https://github.com/JuliaGraphs/SimpleWeightedGraphs.jl).
 - If you need labeling of vertices or edges, use [MetaGraphs](https://github.com/JuliaGraphs/MetaGraphs.jl).
 - If you work with very large graphs (billons to tens of billions of edges) and don't need mutability, use [StaticGraphs](https://github.com/JuliaGraphs/StaticGraphs.jl).

--- a/src/SimpleGraphs/generators/euclideangraphs.jl
+++ b/src/SimpleGraphs/generators/euclideangraphs.jl
@@ -33,11 +33,10 @@ Set `bc=:periodic` to impose periodic boundary conditions in the box ``[0,L]^d``
 function euclidean_graph(points::Matrix;
     L=1., p=2., cutoff=-1., bc=:open)
     d, N = size(points)
-    g = SimpleGraph(N)
-    weights = Dict{SimpleEdge,Float64}()
+    weights = Dict{SimpleEdge{Int},Float64}()
     cutoff < 0. && (cutoff = typemax(Float64))
     if bc == :periodic
-        maximum(points) > L && throw(ArgumentError("Some points are outside the box of size $L")) # TODO 0.7: change to DomainError with text.
+        maximum(points) > L && throw(DomainError(maximum(points), "Some points are outside the box of size $L"))
     end
     for i = 1:N
         for j = (i + 1):N
@@ -52,10 +51,13 @@ function euclidean_graph(points::Matrix;
             dist = norm(Δ, p)
             if dist < cutoff
                 e = SimpleEdge(i, j)
-                add_edge!(g, e)
                 weights[e] = dist
             end
         end
+    end
+    g = LightGraphs.SimpleGraphs._SimpleGraphFromIterator(keys(weights), SimpleEdge{Int})
+    if nv(g) < N
+        add_vertices!(g, N - nv(g))
     end
     return g, weights
 end

--- a/src/SimpleGraphs/generators/randgraphs.jl
+++ b/src/SimpleGraphs/generators/randgraphs.jl
@@ -191,7 +191,7 @@ function watts_strogatz(n::Integer, k::Integer, β::Real; is_directed=false, see
     return g
 end
 
-function _suitable(edges::Set{SimpleEdge}, potential_edges::Dict{T,T}) where T <: Integer
+function _suitable(edges::Set{SimpleEdge{T}}, potential_edges::Dict{T,T}) where T <: Integer
     isempty(potential_edges) && return true
     list = keys(potential_edges)
     for s1 in list, s2 in list
@@ -204,7 +204,7 @@ end
 _try_creation(n::Integer, k::Integer, rng::AbstractRNG) = _try_creation(n, fill(k, n), rng)
 
 function _try_creation(n::T, k::Vector{T}, rng::AbstractRNG) where T <: Integer
-    edges = Set{SimpleEdge}()
+    edges = Set{SimpleEdge{T}}()
     m = 0
     stubs = zeros(T, sum(k))
     for i = one(T):n
@@ -233,7 +233,7 @@ function _try_creation(n::T, k::Vector{T}, rng::AbstractRNG) where T <: Integer
         end
 
         if !_suitable(edges, potential_edges)
-            return Set{SimpleEdge}()
+            return Set{SimpleEdge{T}}()
         end
 
         stubs = Vector{Int}()
@@ -603,11 +603,10 @@ function random_configuration_model(n::Integer, k::Array{T}; seed::Int=-1, check
         edges = _try_creation(n, k, rng)
     end
 
-    g = SimpleGraph(n)
-    for edge in edges
-        add_edge!(g, edge)
+    g = SimpleGraphFromIterator(edges)
+    if nv(g) < n
+        add_vertices!(g, n - nv(g))
     end
-
     return g
 end
 

--- a/src/SimpleGraphs/generators/smallgraphs.jl
+++ b/src/SimpleGraphs/generators/smallgraphs.jl
@@ -2,22 +2,6 @@
 # STATIC SMALL GRAPHS
 #####################
 
-function _make_simple_undirected_graph(n::T, edgelist::Vector{Tuple{T,T}}) where T<:Integer
-    g = SimpleGraph(n)
-    for (s, d) in edgelist
-        add_edge!(g, SimpleEdge(s, d))
-    end
-    return g
-end
-
-function _make_simple_directed_graph(n::T, edgelist::Vector{Tuple{T,T}}) where T<:Integer
-    g = SimpleDiGraph(n)
-    for (s, d) in edgelist
-        add_edge!(g, SimpleEdge(s, d))
-    end
-    return g
-end
-
 """
     smallgraph(s)
     smallgraph(s)
@@ -91,16 +75,14 @@ function smallgraph(s::AbstractString)
 end
 
 
-DiamondGraph() =
-_make_simple_undirected_graph(4, [(1, 2), (1, 3), (2, 3), (2, 4), (3, 4)])
+DiamondGraph() = SimpleGraph( SimpleEdge.([(1, 2), (1, 3), (2, 3), (2, 4), (3, 4)]) )
 
 
-BullGraph() =
-_make_simple_undirected_graph(5, [(1, 2), (1, 3), (2, 3), (2, 4), (3, 5)])
+BullGraph() = SimpleGraph(SimpleEdge.([(1, 2), (1, 3), (2, 3), (2, 4), (3, 5)]))
 
 
 function ChvatalGraph()
-    e = [
+    e = SimpleEdge.([
     (1, 2), (1, 5), (1, 7), (1, 10),
     (2, 3), (2, 6), (2, 8),
     (3, 4), (3, 7), (3, 9),
@@ -111,26 +93,25 @@ function ChvatalGraph()
     (8, 9), (8, 12),
     (9, 11),
     (10, 11), (10, 12)
-    ]
-    return _make_simple_undirected_graph(12, e)
+   ])
+    return SimpleGraph(e)
 end
 
-
 function CubicalGraph()
-    e = [
+    e = SimpleEdge.([
     (1, 2), (1, 4), (1, 5),
     (2, 3), (2, 8),
     (3, 4), (3, 7),
     (4, 6), (5, 6), (5, 8),
     (6, 7),
     (7, 8)
-    ]
-    return _make_simple_undirected_graph(8, e)
+    ])
+    return SimpleGraph(e)
 end
 
 
 function DesarguesGraph()
-    e = [
+    e = SimpleEdge.([
     (1, 2), (1, 6), (1, 20),
     (2, 3), (2, 17),
     (3, 4), (3, 12),
@@ -150,13 +131,13 @@ function DesarguesGraph()
     (17, 18),
     (18, 19),
     (19, 20)
-    ]
-    return _make_simple_undirected_graph(20, e)
+   ])
+    return SimpleGraph(e)
 end
 
 
 function DodecahedralGraph()
-    e = [
+    e = SimpleEdge.([
     (1, 2), (1, 11), (1, 20),
     (2, 3), (2, 9),
     (3, 4), (3, 7),
@@ -176,13 +157,13 @@ function DodecahedralGraph()
     (17, 18),
     (18, 19),
     (19, 20)
-    ]
-    return _make_simple_undirected_graph(20, e)
+    ])
+    return SimpleGraph(e)
 end
 
 
 function FruchtGraph()
-    e = [
+    e = SimpleEdge.([
     (1, 2), (1, 7), (1, 8),
     (2, 3), (2, 8),
     (3, 4), (3, 9),
@@ -193,13 +174,13 @@ function FruchtGraph()
     (8, 12),
     (9, 10), (9, 12),
     (11, 12)
-    ]
-    return _make_simple_undirected_graph(12, e)
+    ])
+    return SimpleGraph(e)
 end
 
 
 function HeawoodGraph()
-    e = [
+    e = SimpleEdge.([
     (1, 2), (1, 6), (1, 14),
     (2, 3), (2, 11),
     (3, 4), (3, 8),
@@ -213,14 +194,14 @@ function HeawoodGraph()
     (11, 12),
     (12, 13),
     (13, 14)
-    ]
-    return _make_simple_undirected_graph(14, e)
+    ])
+    return SimpleGraph(e)
 end
 
 
 function HouseGraph()
-    e = [(1, 2), (1, 3), (2, 4), (3, 4), (3, 5), (4, 5)]
-    return _make_simple_undirected_graph(5, e)
+    e = SimpleEdge.([(1, 2), (1, 3), (2, 4), (3, 4), (3, 5), (4, 5)])
+    return SimpleGraph(e)
 end
 
 
@@ -233,7 +214,7 @@ end
 
 
 function IcosahedralGraph()
-    e = [
+    e = SimpleEdge.([
     (1, 2), (1, 6), (1, 8), (1, 9), (1, 12),
     (2, 3), (2, 6), (2, 7), (2, 9),
     (3, 4), (3, 7), (3, 9), (3, 10),
@@ -243,13 +224,13 @@ function IcosahedralGraph()
     (8, 9), (8, 10), (8, 11), (8, 12),
     (9, 10),
     (10, 11), (11, 12)
-    ]
-    return _make_simple_undirected_graph(12, e)
+    ])
+    return SimpleGraph(e)
 end
 
 
 function KrackhardtKiteGraph()
-    e = [
+    e = SimpleEdge.([
     (1, 2), (1, 3), (1, 4), (1, 6),
     (2, 4), (2, 5), (2, 7),
     (3, 4), (3, 6),
@@ -259,13 +240,13 @@ function KrackhardtKiteGraph()
     (7, 8),
     (8, 9),
     (9, 10)
-    ]
-    return _make_simple_undirected_graph(10, e)
+    ])
+    return SimpleGraph(e)
 end
 
 
 function MoebiusKantorGraph()
-    e = [
+    e = SimpleEdge.([
     (1, 2), (1, 6), (1, 16),
     (2, 3), (2, 13),
     (3, 4), (3, 8),
@@ -281,25 +262,25 @@ function MoebiusKantorGraph()
     (13, 14),
     (14, 15),
     (15, 16)
-    ]
-    return _make_simple_undirected_graph(16, e)
+    ])
+    return SimpleGraph(e)
 end
 
 
 function OctahedralGraph()
-    e = [
+    e = SimpleEdge.([
     (1, 2), (1, 3), (1, 4), (1, 5),
     (2, 3), (2, 4), (2, 6),
     (3, 5), (3, 6),
     (4, 5), (4, 6),
     (5, 6)
-    ]
-    return _make_simple_undirected_graph(6, e)
+    ])
+    return SimpleGraph(e)
 end
 
 
 function PappusGraph()
-    e = [
+    e = SimpleEdge.([
     (1, 2), (1, 6), (1, 18),
     (2, 3), (2, 9),
     (3, 4), (3, 14),
@@ -317,13 +298,13 @@ function PappusGraph()
     (15, 16),
     (16, 17),
     (17, 18)
-    ]
-    return _make_simple_undirected_graph(18, e)
+    ])
+    return SimpleGraph(e)
 end
 
 
 function PetersenGraph()
-    e = [
+    e = SimpleEdge.([
     (1, 2), (1, 5), (1, 6),
     (2, 3), (2, 7),
     (3, 4), (3, 8),
@@ -332,29 +313,29 @@ function PetersenGraph()
     (6, 8), (6, 9),
     (7, 9), (7, 10),
     (8, 10)
-    ]
-    return _make_simple_undirected_graph(10, e)
+    ])
+    return SimpleGraph(e)
 end
 
 function SedgewickMazeGraph()
-    e = [
+    e = SimpleEdge.([
     (1, 3),
     (1, 6), (1, 8),
     (2, 8),
     (3, 7),
     (4, 5), (4, 6),
     (5, 6), (5, 7), (5, 8)
-    ]
-    return _make_simple_undirected_graph(8, e)
+    ])
+    return SimpleGraph(e)
 end
 
 
 TetrahedralGraph() =
-_make_simple_undirected_graph(4, [(1, 2), (1, 3), (1, 4), (2, 3), (2, 4), (3, 4)])
+SimpleGraph(SimpleEdge.([(1, 2), (1, 3), (1, 4), (2, 3), (2, 4), (3, 4)]))
 
 
 function TruncatedCubeGraph()
-    e = [
+    e = SimpleEdge.([
     (1, 2), (1, 3), (1, 5),
     (2, 12), (2, 15),
     (3, 4), (3, 5),
@@ -377,13 +358,13 @@ function TruncatedCubeGraph()
     (21, 22),
     (22, 23),
     (23, 24)
-    ]
-    return _make_simple_undirected_graph(24, e)
+    ])
+    return SimpleGraph(e)
 end
 
 
 function TruncatedTetrahedronGraph()
-    e = [
+    e = SimpleEdge.([
     (1, 2), (1, 3), (1, 10),
     (2, 3), (2, 7),
     (3, 4),
@@ -395,13 +376,13 @@ function TruncatedTetrahedronGraph()
     (9, 10), (9, 11),
     (10, 11),
     (11, 12)
-    ]
-    return _make_simple_undirected_graph(12, e)
+    ])
+    return SimpleGraph(e)
 end
 
 
 function TruncatedTetrahedronDiGraph()
-    e = [
+    e = SimpleEdge.([
     (1, 2), (1, 3), (1, 10),
     (2, 3), (2, 7),
     (3, 4),
@@ -413,13 +394,13 @@ function TruncatedTetrahedronDiGraph()
     (9, 10), (9, 11),
     (10, 11),
     (11, 12)
-    ]
-    return _make_simple_directed_graph(12, e)
+    ])
+    return SimpleDiGraph(e)
 end
 
 
 function TutteGraph()
-    e = [
+    e = SimpleEdge.([
     (1, 2), (1, 3), (1, 4),
     (2, 5), (2, 27),
     (3, 11), (3, 12),
@@ -460,6 +441,6 @@ function TutteGraph()
     (42, 43),
     (43, 44), (43, 46),
     (44, 45)
-    ]
-    return _make_simple_undirected_graph(46, e)
+    ])
+    return SimpleGraph(e)
 end

--- a/src/SimpleGraphs/generators/staticgraphs.jl
+++ b/src/SimpleGraphs/generators/staticgraphs.jl
@@ -7,14 +7,18 @@
 Create an undirected [complete graph](https://en.wikipedia.org/wiki/Complete_graph)
 with `n` vertices.
 """
-function CompleteGraph(n::Integer)
-    g = SimpleGraph(n)
-    for i = 1:n, j = 1:n
-        if i < j
-            add_edge!(g, SimpleEdge(i, j))
-        end
+function CompleteGraph(n::T) where {T <: Integer}
+    n <= 0 && return SimpleGraph{T}(0)
+    ne = Int(n * (n - 1) ÷ 2)
+
+    fadjlist = Vector{Vector{T}}(undef, n)
+    @inbounds @simd for u = 1:n
+        listu = Vector{T}(undef, n-1)
+        listu[1:(u-1)] = UnitRange{T}(1, u - 1)
+        listu[u:(n-1)] = UnitRange{T}(u + 1, n)
+        fadjlist[u] = listu
     end
-    return g
+    return SimpleGraph(ne, fadjlist)
 end
 
 
@@ -24,13 +28,26 @@ end
 Create an undirected [complete bipartite graph](https://en.wikipedia.org/wiki/Complete_bipartite_graph)
 with `n1 + n2` vertices.
 """
-function CompleteBipartiteGraph(n1::Integer, n2::Integer)
-    g = SimpleGraph(n1 + n2)
-    for i = 1:n1, j = (n1 + 1):(n1 + n2)
-        add_edge!(g, SimpleEdge(i, j))
+function CompleteBipartiteGraph(n1::T, n2::T) where {T <: Integer}
+    (n1 < 0 || n2 < 0) && return SimpleGraph{T}(0)
+    Tw = widen(T)
+    nw = Tw(n1) + Tw(n2)
+    n = T(n1 + n2)  # checks if T is large enough for n1 + n2
+
+    ne = Int(n1) * Int(n2)
+
+    fadjlist = Vector{Vector{T}}(undef, n)
+    range1 = UnitRange{T}(1, n1)
+    range2 = UnitRange{T}(n1 + 1, n)
+    @inbounds @simd for u in range1
+        fadjlist[u] = Vector{T}(range2)
     end
-    return g
+    @inbounds @simd for u in range2
+        fadjlist[u] = Vector{T}(range1)
+    end
+    return SimpleGraph(ne, fadjlist)
 end
+
 
 """
     CompleteDiGraph(n)
@@ -38,14 +55,20 @@ end
 Create a directed [complete graph](https://en.wikipedia.org/wiki/Complete_graph)
 with `n` vertices.
 """
-function CompleteDiGraph(n::Integer)
-    g = SimpleDiGraph(n)
-    for i = 1:n, j = 1:n
-        if i != j
-            add_edge!(g, SimpleEdge(i, j))
-        end
+function CompleteDiGraph(n::T) where {T <: Integer}
+    n <= 0 && return SimpleDiGraph{T}(0)
+
+    ne = Int(n * (n - 1))
+    fadjlist = Vector{Vector{T}}(undef, n)
+    badjlist = Vector{Vector{T}}(undef, n)
+    @inbounds @simd for u = one(T):n
+        listu = Vector{T}(undef, n-1)
+        listu[1:(u-1)] = UnitRange{T}(1, u - 1)
+        listu[u:(n-1)] = UnitRange{T}(u + 1, n)
+        fadjlist[u] = listu
+        badjlist[u] = deepcopy(listu)
     end
-    return g
+    return SimpleDiGraph(ne, fadjlist, badjlist)
 end
 
 """
@@ -54,12 +77,16 @@ end
 Create an undirected [star graph](https://en.wikipedia.org/wiki/Star_(graph_theory))
 with `n` vertices.
 """
-function StarGraph(n::Integer)
-    g = SimpleGraph(n)
-    for i = 2:n
-        add_edge!(g, SimpleEdge(1, i))
+function StarGraph(n::T) where {T <: Integer}
+    n <= 0 && return SimpleGraph{T}(0)
+
+    ne = Int(n - 1)
+    fadjlist = Vector{Vector{T}}(undef, n)
+    @inbounds fadjlist[1] = Vector{T}(2:n)
+    @inbounds @simd for u = 2:n
+        fadjlist[u] = T[1]
     end
-    return g
+    return SimpleGraph(ne, fadjlist)
 end
 
 """
@@ -68,12 +95,19 @@ end
 Create a directed [star graph](https://en.wikipedia.org/wiki/Star_(graph_theory))
 with `n` vertices.
 """
-function StarDiGraph(n::Integer)
-    g = SimpleDiGraph(n)
-    for i = 2:n
-        add_edge!(g, SimpleEdge(1, i))
+function StarDiGraph(n::T) where {T <: Integer}
+    n <= 0 && return SimpleDiGraph{T}(0)
+
+    ne = Int(n - 1)
+    fadjlist = Vector{Vector{T}}(undef, n)
+    badjlist = Vector{Vector{T}}(undef, n)
+    @inbounds fadjlist[1] = Vector{T}(2:n)
+    @inbounds badjlist[1] = T[]
+    @inbounds @simd for u = 2:n
+        fadjlist[u] = T[]
+        badjlist[u] = T[1]
     end
-    return g
+    return SimpleDiGraph(ne, fadjlist, badjlist)
 end
 
 """
@@ -82,12 +116,18 @@ end
 Create an undirected [path graph](https://en.wikipedia.org/wiki/Path_graph)
 with `n` vertices.
 """
-function PathGraph(n::Integer)
-    g = SimpleGraph(n)
-    for i = 2:n
-        add_edge!(g, SimpleEdge(i - 1, i))
+function PathGraph(n::T) where {T <: Integer}
+    n <= 1 && return SimpleGraph(n)
+
+    ne = Int(n - 1)
+    fadjlist = Vector{Vector{T}}(undef, n)
+    @inbounds fadjlist[1] = T[2]
+    @inbounds fadjlist[n] = T[n - 1]
+
+    @inbounds @simd for u = 2:(n-1)
+        fadjlist[u] = T[u - 1, u + 1]
     end
-    return g
+    return SimpleGraph(ne, fadjlist)
 end
 
 """
@@ -96,12 +136,23 @@ end
 Creates a directed [path graph](https://en.wikipedia.org/wiki/Path_graph)
 with `n` vertices.
 """
-function PathDiGraph(n::Integer)
-    g = SimpleDiGraph(n)
-    for i = 2:n
-        add_edge!(g, SimpleEdge(i - 1, i))
+function PathDiGraph(n::T) where {T <: Integer}
+    n <= 1 && return SimpleDiGraph(n)
+
+    ne = Int(n - 1)
+    fadjlist = Vector{Vector{T}}(undef, n)
+    badjlist = Vector{Vector{T}}(undef, n)
+
+    @inbounds fadjlist[1] = T[2]
+    @inbounds badjlist[1] = T[]
+    @inbounds fadjlist[n] = T[]
+    @inbounds badjlist[n] = T[n - 1]
+
+    @inbounds @simd for u = 2:(n-1)
+        fadjlist[u] = T[u + 1]
+        badjlist[u] = T[u - 1]
     end
-    return g
+    return SimpleDiGraph(ne, fadjlist, badjlist)
 end
 
 """
@@ -125,13 +176,23 @@ end
 Create a directed [cycle graph](https://en.wikipedia.org/wiki/Cycle_graph)
 with `n` vertices.
 """
-function CycleDiGraph(n::Integer)
-    g = SimpleDiGraph(n)
-    for i = 1:(n - 1)
-        add_edge!(g, SimpleEdge(i, i + 1))
+function CycleDiGraph(n::T) where {T <: Integer}
+    n <= 0 && return SimpleDiGraph(n)  # check if correct
+    n == 1 && return SimpleDiGraph(Edge{T}.([(1, 2)]))
+
+    ne = Int(n)
+    fadjlist = Vector{Vector{T}}(undef, n)
+    badjlist = Vector{Vector{T}}(undef, n)
+    @inbounds fadjlist[1] = T[2]
+    @inbounds badjlist[1] = T[n]
+    @inbounds fadjlist[n] = T[1]
+    @inbounds badjlist[n] = T[n-1]
+
+    @inbounds @simd for u = 2:(n-1)
+        fadjlist[u] = T[u + 1]
+        badjlist[u] = T[u + -1]
     end
-    add_edge!(g, SimpleEdge(n, 1))
-    return g
+    return SimpleDiGraph(ne, fadjlist, badjlist)
 end
 
 
@@ -141,15 +202,20 @@ end
 Create an undirected [wheel graph](https://en.wikipedia.org/wiki/Wheel_graph)
 with `n` vertices.
 """
-function WheelGraph(n::Integer)
-    g = StarGraph(n)
-    for i = 3:n
-        add_edge!(g, SimpleEdge(i - 1, i))
+function WheelGraph(n::T) where {T <: Integer}
+    n <= 1 && return SimpleGraph(n)
+    n <= 3 && return CycleGraph(n)
+ 
+    ne = Int(2 * (n - 1))
+    fadjlist = Vector{Vector{T}}(undef, n)
+    @inbounds fadjlist[1] = Vector{T}(2:n)
+    @inbounds fadjlist[2] = T[1, 3, n]
+    @inbounds fadjlist[n] = T[1, 2, n - 1]
+
+    @inbounds @simd for u = 3:(n-1)
+        fadjlist[u] = T[1, u - 1, u + 1]
     end
-    if n != 2
-        add_edge!(g, SimpleEdge(n, 2))
-    end
-    return g
+    return SimpleGraph(ne, fadjlist)
 end
 
 """
@@ -158,15 +224,25 @@ end
 Create a directed [wheel graph](https://en.wikipedia.org/wiki/Wheel_graph)
 with `n` vertices.
 """
-function WheelDiGraph(n::Integer)
-    g = StarDiGraph(n)
-    for i = 3:n
-        add_edge!(g, SimpleEdge(i - 1, i))
+function WheelDiGraph(n::T) where {T <: Integer}
+    n <= 2 && return PathDiGraph(n)
+    n == 3 && return SimpleDiGraph(Edge{T}.([(1,2),(1,3),(2,3),(3,2)]))
+ 
+    ne = Int(2 * (n - 1))
+    fadjlist = Vector{Vector{T}}(undef, n)
+    badjlist = Vector{Vector{T}}(undef, n)
+    @inbounds fadjlist[1] = Vector{T}(2:n)
+    @inbounds badjlist[1] = T[]
+    @inbounds fadjlist[2] = T[3]
+    @inbounds badjlist[2] = T[1, n]
+    @inbounds fadjlist[n] = T[2]
+    @inbounds badjlist[n] = T[1, n - 1]
+
+    @inbounds @simd for u = 3:(n-1)
+        fadjlist[u] = T[u + 1]
+        badjlist[u] = T[1, u - 1]
     end
-    if n != 2
-        add_edge!(g, SimpleEdge(n, 2))
-    end
-    return g
+    return SimpleDiGraph(ne, fadjlist, badjlist)
 end
 
 """
@@ -179,7 +255,16 @@ in dimension `i`.
 - `periodic=false`: If true, the resulting lattice will have periodic boundary
 condition in each dimension.
 """
-function Grid(dims::AbstractVector; periodic=false)
+function Grid(dims::AbstractVector{T}; periodic=false) where {T <: Integer}
+    # checks if T is large enough for product(dims)
+    Tw = widen(T)
+    n = one(T)
+    for d in dims
+        d <= 0 && return SimpleGraph{T}(0)
+        nw = Tw(n) * Tw(d)
+        n = T(nw)
+    end
+
     if periodic
         g = CycleGraph(dims[1])
         for d in dims[2:end]
@@ -200,15 +285,25 @@ end
 Create a [binary tree](https://en.wikipedia.org/wiki/Binary_tree)
 of depth `k`.
 """
-function BinaryTree(k::Integer)
-    g = SimpleGraph(Int(2^k - 1))
-    for i in 0:(k - 2)
-        for j in (2^i):(2^(i + 1) - 1)
-            add_edge!(g, j, 2j)
-            add_edge!(g, j, 2j + 1)
+function BinaryTree(k::T) where {T <: Integer}
+    k <= 0 && return SimpleGraph(0)
+    k == 1 && return SimpleGraph(1)
+    Tw = widen(T)
+    n = T(Tw(2)^Tw(k) - Tw(1))  # checks if T is large enough for 2^k
+
+    ne = Int(n - 1)
+    fadjlist = Vector{Vector{T}}(undef, n)
+    @inbounds fadjlist[1] = T[2, 3]
+    @inbounds for i in 1:(k - 2)
+        @simd for j in (2^i):(2^(i + 1) - 1)
+            fadjlist[j] = T[j ÷ 2, 2j, 2j + 1]
         end
     end
-    return g
+    i = k - 1
+    @inbounds @simd for j in (2^i):(2^(i + 1) - 1)
+        fadjlist[j] = T[j ÷ 2]
+    end
+    return SimpleGraph(ne, fadjlist)
 end
 
 """
@@ -253,8 +348,12 @@ end
 
 Create a graph consisting of `n` connected `k`-cliques.
 """
-function CliqueGraph(k::Integer, n::Integer)
-    g = SimpleGraph(k * n)
+function CliqueGraph(k::T, n::T) where {T <: Integer}
+    Tw = widen(T)
+    knw = Tw(k) * Tw(n)
+    kn = T(knw)  # checks if T is large enough for k * n
+
+    g = SimpleGraph(kn)
     for c = 1:n
         for i = ((c - 1) * k + 1):(c * k - 1), j = (i + 1):(c * k)
             add_edge!(g, i, j)

--- a/src/SimpleGraphs/simpledigraph.jl
+++ b/src/SimpleGraphs/simpledigraph.jl
@@ -217,11 +217,10 @@ function SimpleDiGraphFromIterator(iter)::SimpleDiGraph
     if Base.IteratorEltype(iter) == Base.EltypeUnknown()
         return _SimpleDiGraphFromIterator(iter)
     end
-    # if the eltype of iter is known but is a proper supertype of SimpleDiGraphEdge
-    if !(eltype(iter) <: SimpleDiGraphEdge) && SimpleDiGraphEdge <: eltype(iter)
-        return _SimpleDiGraphFromIterator(iter)
+    if eltype(iter) <: SimpleGraphEdge && isconcretetype(eltype(iter))
+        return _SimpleDiGraphFromIterator(iter, eltype(iter))
     end
-    return _SimpleDiGraphFromIterator(iter, eltype(iter))
+    return _SimpleDiGraphFromIterator(iter)
 end
 
 

--- a/src/SimpleGraphs/simplegraph.jl
+++ b/src/SimpleGraphs/simplegraph.jl
@@ -204,11 +204,10 @@ function SimpleGraphFromIterator(iter)::SimpleGraph
     if Base.IteratorEltype(iter) == Base.EltypeUnknown()
         return _SimpleGraphFromIterator(iter)
     end
-    # if the eltype of iter is know but is a proper supertype of SimpleDiEdge
-    if !(eltype(iter) <: SimpleGraphEdge) && SimpleGraphEdge <: eltype(iter)
-        return _SimpleGraphFromIterator(iter)
+    if eltype(iter) <: SimpleGraphEdge && isconcretetype(eltype(iter))
+        return _SimpleGraphFromIterator(iter, eltype(iter))
     end
-    return _SimpleGraphFromIterator(iter, eltype(iter))
+    return _SimpleGraphFromIterator(iter)
 end
 
 

--- a/test/simplegraphs/generators/euclideangraphs.jl
+++ b/test/simplegraphs/generators/euclideangraphs.jl
@@ -17,6 +17,6 @@
     @test minimum(points) >= 0.
 
 
-    @test_throws ArgumentError euclidean_graph(points, L=0.01,  bc=:periodic)
+    @test_throws DomainError euclidean_graph(points, L=0.01,  bc=:periodic)
     @test_throws ArgumentError euclidean_graph(points, bc=:badbc)
 end

--- a/test/simplegraphs/generators/staticgraphs.jl
+++ b/test/simplegraphs/generators/staticgraphs.jl
@@ -1,50 +1,65 @@
 @testset "Static graphs" begin
     g = @inferred(CompleteDiGraph(5))
     @test nv(g) == 5 && ne(g) == 20
+    @test isvalid_simplegraph(g)
     g = @inferred(CompleteGraph(5))
     @test nv(g) == 5 && ne(g) == 10
+    @test isvalid_simplegraph(g)
 
     g = @inferred(CompleteBipartiteGraph(5, 8))
     @test nv(g) == 13 && ne(g) == 40
+    @test isvalid_simplegraph(g)
 
     g = @inferred(StarDiGraph(5))
     @test nv(g) == 5 && ne(g) == 4
+    @test isvalid_simplegraph(g)
     g = @inferred(StarGraph(5))
     @test nv(g) == 5 && ne(g) == 4
+    @test isvalid_simplegraph(g)
     g = @inferred(StarGraph(1))
     @test nv(g) == 1 && ne(g) == 0
+    @test isvalid_simplegraph(g)
 
     g = @inferred(PathDiGraph(5))
     @test nv(g) == 5 && ne(g) == 4
+    @test isvalid_simplegraph(g)
     g = @inferred(PathGraph(5))
     @test nv(g) == 5 && ne(g) == 4
+    @test isvalid_simplegraph(g)
 
     g = @inferred(CycleDiGraph(5))
     @test nv(g) == 5 && ne(g) == 5
+    @test isvalid_simplegraph(g)
     g = @inferred(CycleGraph(5))
     @test nv(g) == 5 && ne(g) == 5
+    @test isvalid_simplegraph(g)
 
     g = @inferred(WheelDiGraph(5))
     @test nv(g) == 5 && ne(g) == 8
+    @test isvalid_simplegraph(g)
     g = @inferred(WheelGraph(5))
     @test nv(g) == 5 && ne(g) == 8
+    @test isvalid_simplegraph(g)
 
     g = @inferred(Grid([3, 3, 4]))
     @test nv(g) == 3 * 3 * 4
     @test ne(g) == 75
     @test Δ(g) == 6
     @test δ(g) == 3
+    @test isvalid_simplegraph(g)
 
     g = @inferred(Grid([3, 3, 4], periodic=true))
     @test nv(g) == 3 * 3 * 4
     @test ne(g) == 108
     @test Δ(g) == 6
     @test δ(g) == 6
+    @test isvalid_simplegraph(g)
 
 
     g = @inferred(CliqueGraph(3, 5))
     @test nv(g) == 15 && ne(g) == 20
     @test g[1:3] == CompleteGraph(3)
+    @test isvalid_simplegraph(g)
 
     g = @inferred(crosspath(3, BinaryTree(2)))
     # f = Vector{Vector{Int}}[[2 3 4];
@@ -62,6 +77,7 @@
     V = ones(Int, length(I))
     Adj = sparse(I, J, V)
     @test Adj == sparse(g)
+    @test isvalid_simplegraph(g)
 
     g = @inferred(DoubleBinaryTree(3))
     # [[3, 2, 8]
@@ -83,6 +99,7 @@
     V = ones(Int, length(I))
     Adj = sparse(I, J, V)
     @test Adj == sparse(g)
+    @test isvalid_simplegraph(g)
 
     rg3 = @inferred(RoachGraph(3))
     # [3]
@@ -102,4 +119,5 @@
     V = ones(Int, length(I))
     Adj = sparse(I, J, V)
     @test Adj == sparse(rg3)
+    @test isvalid_simplegraph(g)
 end

--- a/test/simplegraphs/runtests.jl
+++ b/test/simplegraphs/runtests.jl
@@ -5,6 +5,74 @@ import LightGraphs.SimpleGraphs: fadj, badj, adj
 
 struct DummySimpleGraph <: AbstractSimpleGraph{Int} end
 
+# function to check if the invariants for SimpleGraph and SimpleDiGraph holds
+function isvalid_simplegraph(g::SimpleGraph{T}) where {T <: Integer}
+    nf = length(g.fadjlist)
+    n = T(nf)
+    # checks it the adjacency lists are sorted, free of duplicates and in the correct range
+    for u in one(T):n
+        listu = g.fadjlist[u]
+        isempty(listu) && continue
+        issorted(listu) || return false
+        allunique(listu) || return false
+        issubset(extrema(listu), one(T):n) || return false
+    end
+    # checks if the edge count is correct
+    edge_count = 0
+    for u in one(T):n
+        listu = g.fadjlist[u]
+        for v in listu
+            v > u && break
+            edge_count += 1
+        end
+    end
+    g.ne == edge_count || return false
+    #  checks for backwards edge
+    for u in one(T):n
+        listu = g.fadjlist[u]
+        for v in listu
+            LightGraphs.insorted(u, g.fadjlist[v]) || return false
+        end
+    end
+    return true
+end
+
+function isvalid_simplegraph(g::SimpleDiGraph{T}) where {T <: Integer}
+    nf = length(g.fadjlist)
+    nb = length(g.badjlist)
+    nf == nb || return false
+    n = T(nf)
+
+    for u in one(T):n
+        for listu in (g.fadjlist[u], g.badjlist[u])
+            listu = g.fadjlist[u]
+            isempty(listu) && continue
+            issorted(listu) || return false
+            allunique(listu) || return false
+            issubset(extrema(listu), one(T):n) || return false
+        end
+    end
+    # checks if the edge count is correct
+    edge_count = 0
+    for u in one(T):n
+        edge_count += length(g.fadjlist[u])
+    end
+    g.ne == edge_count || return false
+    edge_count = 0
+    for u in one(T):n
+        edge_count += length(g.badjlist[u])
+    end
+    g.ne == edge_count || return false
+    #  checks for backwards edge
+    for u in one(T):n
+        listu = g.fadjlist[u]
+        for v in listu
+            LightGraphs.insorted(u, g.badjlist[v]) || return false
+        end
+    end
+    return true
+end
+
 const simplegraphtestdir = dirname(@__FILE__)
 
 tests = [


### PR DESCRIPTION
See #903 

So I did some changes and while there is always more to do I thought it is better to a pr now to get some feedback before I have to change too much back. (And also to get some info on code coverage).

I did some small changes to smallgraphs.jl, this does not really change anything about performance. One thing I saw was that the graphs there are all of type SimpleGraph{Int}. This could be changed to SimpleGraph{Int8}.

Then I replaced several functions in staticgraphs.jl. I'm writing directly to the adjacency list in many of these functions now. To ensure that these graphs are actually correct I wrote a function `isvalid_simplegraph` and put it in simplegraphs/runtest.jl. Not sure if this is the correct location for it though.
I also put in some checks to ensure that the eltype of a graph is large enough to store all vertices. If that it not the case it will throw an `InexactError` at the moment which might not be the right choice.

Here are some benchmarks for dense and sparse graphs:
```
@benchmark CompleteGraph(10000)

# old

BenchmarkTools.Trial: 
  memory estimate:  2.45 GiB
  allocs estimate:  140003
  --------------
  minimum time:     10.039 s (2.37% GC)
  median time:      10.039 s (2.37% GC)
  mean time:        10.039 s (2.37% GC)
  maximum time:     10.039 s (2.37% GC)
  --------------
  samples:          1
  evals/sample:     1

# new

BenchmarkTools.Trial: 
  memory estimate:  763.78 MiB
  allocs estimate:  20003
  --------------
  minimum time:     75.050 ms (0.00% GC)
  median time:      260.585 ms (69.06% GC)
  mean time:        230.154 ms (62.08% GC)
  maximum time:     357.283 ms (75.80% GC)
  --------------
  samples:          23
  evals/sample:     1
```

```
@benchmark CycleGraph(100000)
# old

BenchmarkTools.Trial: 
  memory estimate:  12.97 MiB
  allocs estimate:  200003
  --------------
  minimum time:     5.682 ms (0.00% GC)
  median time:      7.287 ms (16.07% GC)
  mean time:        7.640 ms (21.00% GC)
  maximum time:     66.630 ms (87.64% GC)
  --------------
  samples:          655
  evals/sample:     1


# new 

BenchmarkTools.Trial: 
  memory estimate:  9.92 MiB
  allocs estimate:  100003
  --------------
  minimum time:     2.316 ms (0.00% GC)
  median time:      2.556 ms (0.00% GC)
  mean time:        3.135 ms (22.99% GC)
  maximum time:     61.516 ms (90.73% GC)
  --------------
  samples:          1592
  evals/sample:     1

```
I also made some small changes to eudlideangrapjs.jl and randgraphs.jl. This leads to some performance improvements but this is mainly because I replaced `Set{SimpleEdge}` with `Set{SimpleEdge{T}}` in several places, as collections of concrete types are much faster.
Benchmark:

```
@benchmark euclidean_graph(1000, 2)

# old

BenchmarkTools.Trial: 
  memory estimate:  235.36 MiB
  allocs estimate:  3176748
  --------------
  minimum time:     630.260 ms (40.15% GC)
  median time:      680.507 ms (41.12% GC)
  mean time:        705.465 ms (45.13% GC)
  maximum time:     796.383 ms (51.64% GC)
  --------------
  samples:          8
  evals/sample:     1

# new

BenchmarkTools.Trial: 
  memory estimate:  232.15 MiB
  allocs estimate:  2590544
  --------------
  minimum time:     274.175 ms (21.92% GC)
  median time:      277.335 ms (21.88% GC)
  mean time:        284.337 ms (22.58% GC)
  maximum time:     331.183 ms (32.25% GC)
  --------------
  samples:          18
  evals/sample:     1
```





