### PR TITLE
Dijkstra performance docs

### DIFF
--- a/src/shortestpaths/dijkstra.jl
+++ b/src/shortestpaths/dijkstra.jl
@@ -21,6 +21,12 @@ Return a [`LightGraphs.DijkstraState`](@ref) that contains various traversal inf
 ### Optional Arguments
 - `allpaths=false`: If true, returns a [`LightGraphs.DijkstraState`](@ref) that keeps track of all
 predecessors of a given vertex.
+
+### Performance
+Use a [row-major matrix](https://en.wikipedia.org/wiki/Row-_and_column-major_order) type for 
+`distmx` for better run-time.
+Eg. Set the type of `distmx` to `Transpose{Int64, SparseMatrixCSC{Int64,Int64}}` 
+instead of `SparseMatrixCSC{Int64,Int64}`.
 """
 function dijkstra_shortest_paths(g::AbstractGraph,
     srcs::Vector{U},

--- a/src/shortestpaths/dijkstra.jl
+++ b/src/shortestpaths/dijkstra.jl
@@ -23,8 +23,8 @@ Return a [`LightGraphs.DijkstraState`](@ref) that contains various traversal inf
 predecessors of a given vertex.
 
 ### Performance
-Use a [row-major matrix](https://en.wikipedia.org/wiki/Row-_and_column-major_order) type for 
-`distmx` for better run-time.
+Use a matrix type for `distmx` that is implemented in [row-major matrix format](https://en.wikipedia.org/wiki/Row-_and_column-major_order) 
+for better run-time.
 Eg. Set the type of `distmx` to `Transpose{Int64, SparseMatrixCSC{Int64,Int64}}` 
 instead of `SparseMatrixCSC{Int64,Int64}`.
 """


### PR DESCRIPTION
Added suggestion in docs to use row-major matrix for Dijkstra.

Benchmarks taken on Undirected Ego Twitter graph.

`distmx` is of type `SparseArrays.SparseMatrixCSC{Float64,Int64}}`
527.681 ms (292673 allocations: 32.86 MiB)

`distmx` is of type `Transpose{Float64,SparseArrays.SparseMatrixCSC{Float64,Int64}}`
259.203 ms (292673 allocations: 32.86 MiB)