### PR TITLE
Prim using priority queue instead of heap

### DIFF
--- a/test/spanningtrees/prim.jl
+++ b/test/spanningtrees/prim.jl
@@ -27,7 +27,7 @@
         0.16    0.19    0.34    0       0.37    0.28    0       0
     ]
 
-    vec2 = Vector{Edge}([Edge(1, 8), Edge(2, 8), Edge(1, 3), Edge(3, 4), Edge(6, 8), Edge(5, 6), Edge(3, 7)])
+    vec2 = Vector{Edge}([Edge(8, 2), Edge(1, 3), Edge(3, 4), Edge(6, 5), Edge(8, 6), Edge(3, 7), Edge(1, 8)])
     gx = SimpleGraph(distmx_sec)
     for g in testgraphs(gx)
         mst2 = @inferred(prim_mst(g, distmx_sec))


### PR DESCRIPTION
Prim's MST using priority queue instead of heap.

Benchmarks
```
G  ::   |V| = 81306        |E| = 1342310   (Twitter Ego Graph)
--------------------PRIM--------------------------
  1.743 s (5274021 allocations: 132.38 MiB)
--------------------PRIM 2------------------------------
  228.200 ms (802705 allocations: 20.28 MiB)
------------------------DONE--------------------------------
```

*cc* @somil55 