### PR TITLE
Fix kruskal_mst function for working with abstract graphs

### DIFF
--- a/src/spanningtrees/kruskal.jl
+++ b/src/spanningtrees/kruskal.jl
@@ -10,7 +10,7 @@ function kruskal_mst end
 
     connected_vs = IntDisjointSets(nv(g))
 
-    mst = Vector{AbstractEdge}()
+    mst = Vector{edgetype(g}}()
     sizehint!(mst, nv(g) - 1)
 
     weights = Vector{T}()

--- a/src/spanningtrees/kruskal.jl
+++ b/src/spanningtrees/kruskal.jl
@@ -10,7 +10,7 @@ function kruskal_mst end
 
     connected_vs = IntDisjointSets(nv(g))
 
-    mst = Vector{Edge}()
+    mst = Vector{AbstractEdge}()
     sizehint!(mst, nv(g) - 1)
 
     weights = Vector{T}()
@@ -21,8 +21,8 @@ function kruskal_mst end
     end
 
     for e in edge_list[sortperm(weights)]
-        if !in_same_set(connected_vs, e.src, e.dst)
-            union!(connected_vs, e.src, e.dst)
+        if !in_same_set(connected_vs, src(e), dst(e))
+            union!(connected_vs, src(e), dst(e))
             push!(mst, e)
             (length(mst) >= nv(g) - 1) && break
         end

--- a/src/spanningtrees/kruskal.jl
+++ b/src/spanningtrees/kruskal.jl
@@ -10,7 +10,7 @@ function kruskal_mst end
 
     connected_vs = IntDisjointSets(nv(g))
 
-    mst = Vector{edgetype(g}}()
+    mst = Vector{edgetype(g)}()
     sizehint!(mst, nv(g) - 1)
 
     weights = Vector{T}()


### PR DESCRIPTION
Currently `kruskal_mst` function creates array of `SimpleEdge` inside, which prevents it from working with other types of graphs:
```julia
using LightGraphs, SimpleWeightedGraphs
kruskal_mst(SimpleWeightedGraph([0 2; 2 0]))
```

> MethodError: Cannot `convert` an object of type SimpleWeightedEdge{Int64,Int64} to an object of type LightGraphs.SimpleGraphs.SimpleEdge
> Closest candidates are:
>   convert(::Type{S}, !Matched::T<:(Union{CategoricalString{R}, CategoricalValue{T,R} where T} where R)) where {S, T<:(Union{CategoricalString{R}, CategoricalValue{T,R} where T} where R)} at /home/vp/.julia/packages/CategoricalArrays/04bks/src/value.jl:66
>   convert(::Type{T}, !Matched::RCall.RObject{S<:RCall.Sxp}) where {T, S<:Sxp} at /home/vp/.julia/packages/RCall/fD0FD/src/convert/base.jl:1
>   convert(::Type{T}, !Matched::T) where T at essentials.jl:154
> 
> Stacktrace:
>  [1] push!(::Array{LightGraphs.SimpleGraphs.SimpleEdge,1}, ::SimpleWeightedEdge{Int64,Int64}) at ./array.jl:855
>  [2] kruskal_mst(::Type{SimpleTraits.Not{IsDirected{SimpleWeightedGraph{Int64,Int64}}}}, ::SimpleWeightedGraph{Int64,Int64}, ::SparseArrays.SparseMatrixCSC{Int64,Int64}) at /home/vp/.julia/packages/LightGraphs/jWbFf/src/spanningtrees/kruskal.jl:26
>  [3] kruskal_mst at /home/vp/.julia/packages/SimpleTraits/CZOA2/src/SimpleTraits.jl:350 [inlined] (repeats 2 times)
>  [4] top-level scope at none:0

Now such behaviour is fixed:
```julia
kruskal_mst(SimpleWeightedGraph([0 2; 2 0]))
```
> 1-element Array{AbstractEdge,1}:
> Edge 1 => 2 with weight 2