### PR TITLE
Add comparison operators < and isless for AbstractSimpleEdge

### DIFF
--- a/src/SimpleGraphs/SimpleGraphs.jl
+++ b/src/SimpleGraphs/SimpleGraphs.jl
@@ -5,7 +5,7 @@ using LinearAlgebra
 using LightGraphs
 
 import Base:
-    eltype, show, ==, Pair, Tuple, copy, length, issubset, zero, in, iterate
+    eltype, show, ==, <, isless, Pair, Tuple, copy, length, issubset, zero, in, iterate
 
 import LightGraphs:
     _NI, AbstractGraph, AbstractEdge, AbstractEdgeIter,

--- a/src/SimpleGraphs/simpleedge.jl
+++ b/src/SimpleGraphs/simpleedge.jl
@@ -31,3 +31,6 @@ SimpleEdge{T}(e::AbstractSimpleEdge) where T <: Integer = SimpleEdge{T}(T(e.src)
 # Convenience functions
 reverse(e::T) where T<:AbstractSimpleEdge = T(dst(e), src(e))
 ==(e1::AbstractSimpleEdge, e2::AbstractSimpleEdge) = (src(e1) == src(e2) && dst(e1) == dst(e2))
+<(e1::AbstractSimpleEdge, e2::AbstractSimpleEdge) = src(e1) < src(e2) ||
+                                                    (src(e1) == src(e2) && dst(e1) < dst(e2))
+isless(e1::AbstractSimpleEdge, e2::AbstractSimpleEdge) = (e1 < e2)

--- a/test/simplegraphs/simpleedge.jl
+++ b/test/simplegraphs/simpleedge.jl
@@ -24,6 +24,47 @@
         @test SimpleEdge(t1) == SimpleEdge{UInt8}(t1) == SimpleEdge{Int16}(t1)
         @test SimpleEdge{Int64}(ep1) == e
 
+        # test for <, isless relation
+        @test SimpleEdge{T}(1, 1) < SimpleEdge{T}(2, 2)
+        @test SimpleEdge(1, 1) < SimpleEdge{T}(2, 2)
+        @test SimpleEdge{T}(1, 1) < SimpleEdge(2, 2)
+
+        @test SimpleEdge{T}(1, 1) < SimpleEdge{T}(2, 1)
+        @test SimpleEdge(1, 1) < SimpleEdge{T}(2, 1)
+        @test SimpleEdge{T}(1, 1) < SimpleEdge(2, 1)
+
+        @test SimpleEdge{T}(1, 2) < SimpleEdge{T}(2, 1)
+        @test SimpleEdge(1, 2) < SimpleEdge{T}(2, 1)
+        @test SimpleEdge{T}(1, 2) < SimpleEdge(2, 1)
+
+        @test SimpleEdge{T}(1, 1) < SimpleEdge{T}(1, 2)
+        @test SimpleEdge(1, 1) < SimpleEdge{T}(1, 2)
+        @test SimpleEdge{T}(1, 1) < SimpleEdge(1, 2)
+
+        @test !(SimpleEdge{T}(1, 1) < SimpleEdge{T}(1, 1))
+        @test !(SimpleEdge(1, 1) < SimpleEdge{T}(1, 1))
+        @test !(SimpleEdge{T}(1, 1) < SimpleEdge(1, 1))
+
+        @test !(SimpleEdge{T}(1, 2) < SimpleEdge{T}(1, 1))
+        @test !(SimpleEdge(1, 2) < SimpleEdge{T}(1, 1))
+        @test !(SimpleEdge{T}(1, 2) < SimpleEdge(1, 1))
+
+        @test !(SimpleEdge{T}(2, 1) < SimpleEdge{T}(1, 2))
+        @test !(SimpleEdge(2, 1) < SimpleEdge{T}(1, 2))
+        @test !(SimpleEdge{T}(2, 1) < SimpleEdge(1, 2))
+
+        @test !(SimpleEdge{T}(2, 1) < SimpleEdge{T}(1, 1))
+        @test !(SimpleEdge(2, 1) < SimpleEdge{T}(1, 1))
+        @test !(SimpleEdge{T}(2, 1) < SimpleEdge(1, 1))
+
+        @test !(SimpleEdge{T}(2, 2) < SimpleEdge{T}(1, 1))
+        @test !(SimpleEdge(2, 2) < SimpleEdge{T}(1, 1))
+        @test !(SimpleEdge{T}(2, 2) < SimpleEdge(1, 1))
+
+        # sort uses isless
+        @test sort(SimpleEdge{T}.([(2,1), (1, 1), (1, 2), (2, 2), (1, 1)])) ==
+                   SimpleEdge{T}.([(1,1), (1, 1), (1, 2), (2, 1), (2, 2)])
+
         @test Pair(e) == p
         @test Tuple(e) == t1
         @test reverse(ep1) == re


### PR DESCRIPTION
Hope it is ok that I did not open an issue for such a minor thing. 
I added the operators `<` and `isless` for  `AbstractSimpleEdge`  (using lexical ordering). The main idea is, that now `sort` and `sort!` can be used on lists of edges.