### PR TITLE
[WIP] 32-bit compatibility

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,42 @@
+environment:
+  matrix:
+  - julia_version: 1
+  # - julia_version: nightly
+
+platform:
+  - x86 # 32-bit
+  - x64 # 64-bit
+
+# # Uncomment the following lines to allow failures on nightly julia
+# # (tests will run but not make your overall status red)
+# matrix:
+#   allow_failures:
+#   - julia_version: nightly
+
+branches:
+  only:
+    - master
+    - /release-.*/
+
+notifications:
+  - provider: Email
+    on_build_success: false
+    on_build_failure: false
+    on_build_status_changed: false
+
+install:
+  - ps: iex ((new-object net.webclient).DownloadString("https://raw.githubusercontent.com/JuliaCI/Appveyor.jl/version-1/bin/install.ps1"))
+
+build_script:
+  - echo "%JL_BUILD_SCRIPT%"
+  - C:\julia\bin\julia -e "%JL_BUILD_SCRIPT%"
+
+test_script:
+  - echo "%JL_TEST_SCRIPT%"
+  - C:\julia\bin\julia -e "%JL_TEST_SCRIPT%"
+
+# # Uncomment to support code coverage upload. Should only be enabled for packages
+# # which would have coverage gaps without running on Windows
+# on_success:
+#   - echo "%JL_CODECOV_SCRIPT%"
+#   - C:\julia\bin\julia -e "%JL_CODECOV_SCRIPT%"

--- a/src/core.jl
+++ b/src/core.jl
@@ -201,7 +201,7 @@ can accommodate all vertices.
 """
 function squash(g::AbstractGraph)
     gtype = is_directed(g) ? DiGraph : Graph
-    validtypes = [UInt8, UInt16, UInt32, UInt64, Int]
+    validtypes = [UInt8, UInt16, UInt32, UInt64, Int32, Int64]
     nvg = nv(g)
     for T in validtypes
         nvg < typemax(T) && return gtype{T}(g)

--- a/src/linalg/graphmatrices.jl
+++ b/src/linalg/graphmatrices.jl
@@ -1,4 +1,4 @@
-const SparseMatrix{T} = SparseMatrixCSC{T,Int64}
+const SparseMatrix{T} = SparseMatrixCSC{T,Int}
 
 """
     GraphMatrix{T}

--- a/src/persistence/lg.jl
+++ b/src/persistence/lg.jl
@@ -20,7 +20,7 @@ struct LGHeader
     ne::Int
     is_directed::Bool
     name::String
-    ver::Int
+    ver::Int64
     dtype::DataType
     code::String
 end
@@ -29,7 +29,7 @@ function show(io::IO, h::LGHeader)
     print(io, "$(h.nv),$(h.ne),$isdir,$(h.name),$(h.ver),$(h.dtype),$(h.code)")
 end
 
-LGHeader(nv::Int, ne::Int, is_directed::Bool, name::AbstractString) = 
+LGHeader(nv::Int, ne::Int, is_directed::Bool, name::AbstractString) =
     LGHeader(nv, ne, is_directed, name, 1, Int64, "simplegraph")
 
 function _lg_read_one_graph(f::IO, header::LGHeader)
@@ -83,7 +83,7 @@ end
 
 
 
-    
+
 """
     loadlg_mult(io)
 


### PR DESCRIPTION
This is an attempt to fix #985. Since I don't have a good VM right now I put together an AppVeyor script using AppVeyor.jl so that CI can be enabled on Windows 32-bit and 64-bit. Note that AppVeyor cannot run on org accounts so it must go to a user account. My AppVeyor is overfilled (sometimes it can take a day or so to run a PR :-/) so another LightGraphs dev might want to set it up to run on their account.