### PR TITLE
Fix misspelling of Hawick

### DIFF
--- a/docs/src/pathing.md
+++ b/docs/src/pathing.md
@@ -85,7 +85,7 @@ is_cyclic
 maxsimplecycles
 simplecycles
 simplecycles_iter
-simplecycles_hadwick_james
+simplecycles_hawick_james
 simplecyclescount
 simplecycleslength
 karp_minimum_cycle_mean

--- a/src/LightGraphs.jl
+++ b/src/LightGraphs.jl
@@ -87,7 +87,7 @@ condensation, attracting_components, neighborhood, neighborhood_dists,
 isgraphical,
 
 # cycles
-simplecycles_hadwick_james, maxsimplecycles, simplecycles, simplecycles_iter,
+simplecycles_hawick_james, maxsimplecycles, simplecycles, simplecycles_iter,
 simplecyclescount, simplecycleslength, karp_minimum_cycle_mean, cycle_basis,
 
 # maximum_adjacency_visit
@@ -196,7 +196,7 @@ const Edge = LightGraphs.SimpleGraphs.SimpleEdge
 include("degeneracy.jl")
 include("digraph/transitivity.jl")
 include("cycles/johnson.jl")
-include("cycles/hadwick-james.jl")
+include("cycles/hawick-james.jl")
 include("cycles/karp.jl")
 include("cycles/basis.jl")
 include("traversals/bfs.jl")

--- a/src/cycles/hawick-james.jl
+++ b/src/cycles/hawick-james.jl
@@ -1,15 +1,15 @@
 """
-    simplecycles_hadwick_james(g)
+    simplecycles_hawick_james(g)
 
 Find circuits (including self-loops) in `g` using the algorithm
-of Hadwick & James.
+of Hawick & James.
 
 ### References
-- Hadwick & James, "Enumerating Circuits and Loops in Graphs with Self-Arcs and Multiple-Arcs", 2008
+- Hawick & James, "Enumerating Circuits and Loops in Graphs with Self-Arcs and Multiple-Arcs", 2008
 """
-function simplecycles_hadwick_james end
+function simplecycles_hawick_james end
 # see https://github.com/mauro3/SimpleTraits.jl/issues/47#issuecomment-327880153 for syntax
-@traitfn function simplecycles_hadwick_james(g::AG::IsDirected) where {T, AG<:AbstractGraph{T}}
+@traitfn function simplecycles_hawick_james(g::AG::IsDirected) where {T, AG<:AbstractGraph{T}}
     nvg = nv(g)
     B = Vector{T}[Vector{T}() for i in vertices(g)]
     blocked = zeros(Bool, nvg)

--- a/src/deprecations.jl
+++ b/src/deprecations.jl
@@ -1,2 +1,5 @@
 # deprecations should also include a comment stating the version
 # for which the deprecation should be removed.
+
+# Deprecated to fix spelling. Can be removed for version 2.0.
+@deprecate simplecycles_hadwick_james simplecycles_hawick_james

--- a/test/cycles/hawick-james.jl
+++ b/test/cycles/hawick-james.jl
@@ -1,4 +1,4 @@
-@testset "Hadwick-James Cycles" begin
+@testset "Hawick-James Cycles" begin
 
     # Simple graph gives expected circuits
     ex1 = SimpleDiGraph(5)
@@ -14,7 +14,7 @@
         [2, 3, 5]
     ]
     for g in testdigraphs(ex1)
-        ex1_circuits = simplecycles_hadwick_james(g)
+        ex1_circuits = simplecycles_hawick_james(g)
 
         @test issubset(expected_circuits, ex1_circuits)
         @test issubset(ex1_circuits, expected_circuits)
@@ -23,7 +23,7 @@
         add_edge!(g, 1, 1)
         add_edge!(g, 3, 3)
 
-        ex1_circuits_self = simplecycles_hadwick_james(g)
+        ex1_circuits_self = simplecycles_hawick_james(g)
 
         @test issubset(expected_circuits, ex1_circuits_self)
         @test [1] ∈ ex1_circuits_self && [3] ∈ ex1_circuits_self
@@ -33,14 +33,14 @@
     ex2_size = 10
     ex2 = testdigraphs(PathDiGraph(ex2_size))
     for g in ex2
-        @test isempty(simplecycles_hadwick_james(g))
+        @test isempty(simplecycles_hawick_james(g))
     end
 
     # Complete DiGraph
     ex3_size = 5
     ex3 = testdigraphs(CompleteDiGraph(ex3_size))
     for g in ex3
-        ex3_circuits = simplecycles_hadwick_james(g)
+        ex3_circuits = simplecycles_hawick_james(g)
         @test length(ex3_circuits) == length(unique(ex3_circuits))
     end
 
@@ -52,7 +52,7 @@
         add_edge!(ex4, dest, src)
     end
     for g in testdigraphs(ex4)
-        ex4_output = simplecycles_hadwick_james(g)
+        ex4_output = simplecycles_hawick_james(g)
         @test [1, 2] ∈ ex4_output && [8, 9] ∈ ex4_output
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -29,7 +29,7 @@ tests = [
     "degeneracy",
     "distance",
     "digraph/transitivity",
-    "cycles/hadwick-james",
+    "cycles/hawick-james",
     "cycles/johnson",
     "cycles/karp",
     "cycles/basis",


### PR DESCRIPTION
Hawick & James algorithm was misspelled Ha**d**wick & James.
