### PR TITLE
Add function to find short cycles

### DIFF
--- a/docs/src/pathing.md
+++ b/docs/src/pathing.md
@@ -88,6 +88,7 @@ simplecycles_iter
 simplecycles_hawick_james
 simplecyclescount
 simplecycleslength
+simplecycles_limited_length
 karp_minimum_cycle_mean
 ```
 

--- a/src/LightGraphs.jl
+++ b/src/LightGraphs.jl
@@ -89,6 +89,7 @@ isgraphical,
 # cycles
 simplecycles_hawick_james, maxsimplecycles, simplecycles, simplecycles_iter,
 simplecyclescount, simplecycleslength, karp_minimum_cycle_mean, cycle_basis,
+simplecycles_limited_length,
 
 # maximum_adjacency_visit
 MaximumAdjacency, AbstractMASVisitor, mincut, maximum_adjacency_visit,
@@ -199,6 +200,7 @@ include("cycles/johnson.jl")
 include("cycles/hawick-james.jl")
 include("cycles/karp.jl")
 include("cycles/basis.jl")
+include("cycles/limited_length.jl")
 include("traversals/bfs.jl")
 include("traversals/bipartition.jl")
 include("traversals/greedy_color.jl")

--- a/src/cycles/johnson.jl
+++ b/src/cycles/johnson.jl
@@ -160,9 +160,10 @@ Compute and return all cycles of the given directed graph using Johnson's algori
 
 ### Performance
 The number of cycles grows more than exponentially with the number of vertices,
-you might want to use the algorithm with a ceiling -- `getcycles` -- on large directed graphs
+you might want to use the algorithm with a ceiling -- `simplecycles_iter` -- on large directed graphs
 (slightly slower). If you want to have an idea of the possible number of cycles,
-look at function `maxsimplecycles(dg::DiGraph, byscc::Bool = true)`.
+look at function `maxsimplecycles(dg::DiGraph, byscc::Bool = true)`. If you only need
+short cycles of a limited length, `simplecycles_limited_length` can be more efficient.
 
 ### References
 - [Johnson](http://epubs.siam.org/doi/abs/10.1137/0204007)

--- a/src/cycles/limited_length.jl
+++ b/src/cycles/limited_length.jl
@@ -1,0 +1,53 @@
+"""
+    simplecycles_limited_length(g, n, ceiling=10^6)
+
+Compute and return at most `ceiling` cycles of length at most `n` of
+the given graph. Both directed and undirected graphs are supported.
+
+### Performance
+The number of cycles grows very fast with the number of vertices and
+the allowed length of the cycles. This function is intended for
+finding short cycles. If you want to find cycles of any length in a
+directed graph, `simplecycles` or `simplecycles_iter` may be more
+efficient.
+"""
+function simplecycles_limited_length(graph::AbstractGraph, n::Integer,
+                                     ceiling = 10^6)
+    cycles = Vector{Int}[]
+    n < 1 && return cycles
+    cycle = Int[]
+    for v = 1:nv(graph)
+        push!(cycle, v)
+        simplecycles_limited_length!(graph, n, ceiling, cycles, cycle)
+        pop!(cycle)
+        length(cycles) >= ceiling && break
+    end
+    return cycles
+end
+
+function simplecycles_limited_length!(graph, n, ceiling, cycles, cycle)
+    length(cycles) >= ceiling && return
+    for v in outneighbors(graph, cycle[end])
+        if v == cycle[1]
+            push!(cycles, copy(cycle))
+        elseif (length(cycle) < n
+                && v > cycle[1]
+                && !repeated_vertex(v, cycle, 2, length(cycle)))
+            push!(cycle, v)
+            simplecycles_limited_length!(graph, n, ceiling, cycles, cycle)
+            pop!(cycle)
+        end
+    end
+end
+
+# Note: Doing the same thing as `@views v in cycle[n1:n2]`, but until
+# views are completely allocation free this can be expected to be
+# faster.
+function repeated_vertex(v, cycle, n1, n2)
+    for k = n1:n2
+        if cycle[k] == v
+            return true
+        end
+    end
+    return false
+end

--- a/test/cycles/limited_length.jl
+++ b/test/cycles/limited_length.jl
@@ -1,0 +1,45 @@
+@testset "Limited Length Cycles" begin
+    completedg = CompleteDiGraph(4)
+    pathdg = PathDiGraph(5)
+    cycledg = CycleDiGraph(5)
+
+    @test length(simplecycles_limited_length(completedg, 0)) == 0
+    @test length(simplecycles_limited_length(completedg, 1)) == 0
+    @test length(simplecycles_limited_length(completedg, 2)) == 6
+    @test length(simplecycles_limited_length(completedg, 3)) == 14
+    @test length(simplecycles_limited_length(completedg, 4)) == 20
+    @test length(simplecycles_limited_length(completedg, 4, 10)) == 10
+    @test length(simplecycles_limited_length(completedg, 4, typemax(Int))) == 20
+
+    @test length(simplecycles_limited_length(pathdg, 1)) == 0
+    @test length(simplecycles_limited_length(pathdg, 2)) == 0
+    @test length(simplecycles_limited_length(pathdg, 3)) == 0
+    @test length(simplecycles_limited_length(pathdg, 4)) == 0
+    @test length(simplecycles_limited_length(pathdg, 5)) == 0
+
+    @test length(simplecycles_limited_length(cycledg, 1)) == 0
+    @test length(simplecycles_limited_length(cycledg, 2)) == 0
+    @test length(simplecycles_limited_length(cycledg, 3)) == 0
+    @test length(simplecycles_limited_length(cycledg, 4)) == 0
+    @test length(simplecycles_limited_length(cycledg, 5)) == 1
+
+    selfloopg = DiGraph([
+        0 1 0 0;
+        0 0 1 0;
+        1 0 1 0;
+        0 0 0 1;
+    ])
+    cycles = simplecycles_limited_length(selfloopg, nv(selfloopg))
+    @test [3] in cycles
+    @test [4] in cycles
+    @test [1, 2, 3] in cycles || [2, 3, 1] in cycles || [3, 1, 2] in cycles
+    @test length(cycles) == 3
+
+    octag = smallgraph(:octahedral)
+    octadg = DiGraph(octag)
+    octalengths, _ = simplecycleslength(octadg)
+    for k = 1:6
+        @test sum(octalengths[1:k]) == length(simplecycles_limited_length(octag, k))
+        @test sum(octalengths[1:k]) == length(simplecycles_limited_length(octadg, k))
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -33,6 +33,7 @@ tests = [
     "cycles/johnson",
     "cycles/karp",
     "cycles/basis",
+    "cycles/limited_length",
     "edit_distance",
     "connectivity",
     "persistence/persistence",


### PR DESCRIPTION
This PR adds a new function to find cycles of limited length in directed or undirected graphs. The algorithm is kind of naive, just a recursive depth first search from each vertex, but limited to vertices with higher number than the starting vertex. Still seems to be competitive with Johnson (`simplecycles`) for finding all cycles in small graphs, and of course much more efficient at finding only the short cycles in larger graphs.

Feel free to bikeshed the naming.
