### PR TITLE
Add cross-ref from edges to neighbors in docstrings

### DIFF
--- a/src/interface.jl
+++ b/src/interface.jl
@@ -191,6 +191,10 @@ julia> collect(edges(g))
  Edge 1 => 2
  Edge 2 => 3
 ```
+
+### See also
+[`inneighbors`](@ref) and [`outneighbors`](@ref) for how to find vertices
+connected to a given vertex by and edge.
 """
 edges(g) = _NI("edges")
 


### PR DESCRIPTION
I kind of exprected `edges(graph, vertex_id)` to return a list of all connected edges.
When it didn't, I therefore looked at the docstring.

Adding about neighbors in that docstring gives a pointer to anyone else making the same mistake I did