### PR TITLE
Add ladder graphs

### DIFF
--- a/src/LightGraphs.jl
+++ b/src/LightGraphs.jl
@@ -128,6 +128,7 @@ label_propagation, maximal_cliques, clique_percolation,
 CompleteGraph, StarGraph, PathGraph, WheelGraph, CycleGraph,
 CompleteBipartiteGraph, CompleteDiGraph, StarDiGraph, PathDiGraph, Grid,
 WheelDiGraph, CycleDiGraph, BinaryTree, DoubleBinaryTree, RoachGraph, CliqueGraph,
+LadderGraph, CircularLadderGraph
 
 #smallgraphs
 smallgraph,

--- a/src/LightGraphs.jl
+++ b/src/LightGraphs.jl
@@ -128,7 +128,7 @@ label_propagation, maximal_cliques, clique_percolation,
 CompleteGraph, StarGraph, PathGraph, WheelGraph, CycleGraph,
 CompleteBipartiteGraph, CompleteDiGraph, StarDiGraph, PathDiGraph, Grid,
 WheelDiGraph, CycleDiGraph, BinaryTree, DoubleBinaryTree, RoachGraph, CliqueGraph,
-LadderGraph, CircularLadderGraph
+LadderGraph, CircularLadderGraph,
 
 #smallgraphs
 smallgraph,

--- a/src/SimpleGraphs/SimpleGraphs.jl
+++ b/src/SimpleGraphs/SimpleGraphs.jl
@@ -28,7 +28,7 @@ export AbstractSimpleGraph, AbstractSimpleEdge,
     CompleteGraph, StarGraph, PathGraph, WheelGraph, CycleGraph,
     CompleteBipartiteGraph, CompleteDiGraph, StarDiGraph, PathDiGraph, Grid,
     WheelDiGraph, CycleDiGraph, BinaryTree, DoubleBinaryTree, RoachGraph, CliqueGraph,
-    LadderGraph, CircularLadderGraph
+    LadderGraph, CircularLadderGraph,
     #smallgraphs
     smallgraph,
     # Euclidean graphs

--- a/src/SimpleGraphs/SimpleGraphs.jl
+++ b/src/SimpleGraphs/SimpleGraphs.jl
@@ -28,6 +28,7 @@ export AbstractSimpleGraph, AbstractSimpleEdge,
     CompleteGraph, StarGraph, PathGraph, WheelGraph, CycleGraph,
     CompleteBipartiteGraph, CompleteDiGraph, StarDiGraph, PathDiGraph, Grid,
     WheelDiGraph, CycleDiGraph, BinaryTree, DoubleBinaryTree, RoachGraph, CliqueGraph,
+    LadderGraph, CircularLadderGraph
     #smallgraphs
     smallgraph,
     # Euclidean graphs

--- a/src/SimpleGraphs/generators/staticgraphs.jl
+++ b/src/SimpleGraphs/generators/staticgraphs.jl
@@ -440,9 +440,6 @@ Create a [ladder graph](https://en.wikipedia.org/wiki/Ladder_graph) consisting o
 ### Implementation Notes
 Preserves the eltype of `n`. Will error if the required number of vertices
 exceeds the eltype.
-
-### References
-- https://en.wikipedia.org/wiki/Ladder_graph
 """
 function LadderGraph(n::T) where {T <: Integer}
     n <= 0 && return SimpleGraph{T}(0)
@@ -466,17 +463,13 @@ end
 """
     CircularLadderGraph(n)
 
-Create a circular [ladder graph](https://en.wikipedia.org/wiki/Ladder_graph) consisting of `2n` nodes and `3n` edges.
+Create a [circular ladder graph](https://en.wikipedia.org/wiki/Ladder_graph#Circular_ladder_graph) consisting of `2n` nodes and `3n` edges.
 This is also known as the [prism graph](https://en.wikipedia.org/wiki/Prism_graph).
 
 ### Implementation Notes
 Preserves the eltype of the partitions vector. Will error if the required number of vertices
 exceeds the eltype. 
 `n` must be at least 3 to avoid self-loops and multi-edges.
-
-### References
-- https://en.wikipedia.org/wiki/Ladder_graph#Circular_ladder_graph
-- http://mathworld.wolfram.com/PrismGraph.html
 """
 function CircularLadderGraph(n::T) where {T <: Integer}
     n < 3 && throw(DomainError("n=$n must be at least 3"))

--- a/src/SimpleGraphs/generators/staticgraphs.jl
+++ b/src/SimpleGraphs/generators/staticgraphs.jl
@@ -372,3 +372,27 @@ function CliqueGraph(k::T, n::T) where {T <: Integer}
     add_edge!(g, 1, (n - 1) * k + 1)
     return g
 end
+
+function LadderGraph(n::T) where {T <: Integer}
+    n == 0 && SimpleGraph{T}(0)
+    n == 1 && PathGraph(T(2))
+    Tw = widen(T)
+    temp = T(Tw(n)+Tw(n)) # test to check if T is large enough
+    g = SimpleGraph(2*n)
+    for i in 1:(n-1)
+        add_edge!(g, i, i+1)
+        add_edge!(g, n+i, n+i+1)
+        add_edge!(g, i, n+i)
+    end
+    add_edge!(g, n, 2*n)
+    return g
+end
+
+function CircularLadderGraph(n::T) where {T <: Integer}
+    n == 0 && SimpleGraph{T}(0)
+    n == 1 && PathGraph(T(2))
+    g = LadderGraph(n)
+    add_edge!(g, 1, n)
+    add_edge!(g, n+1, 2*n)
+    return g
+end

--- a/src/SimpleGraphs/generators/staticgraphs.jl
+++ b/src/SimpleGraphs/generators/staticgraphs.jl
@@ -373,12 +373,20 @@ function CliqueGraph(k::T, n::T) where {T <: Integer}
     return g
 end
 
+"""
+    LadderGraph(n)
+
+Create a graph consisting of `2n` nodes and `3n-2` edges.
+
+### Implementation Notes
+Preserves the eltype of `n`. Will error if the required number of vertices
+exceeds the eltype.
+"""
 function LadderGraph(n::T) where {T <: Integer}
-    n == 0 && SimpleGraph{T}(0)
+    n <= 0 && SimpleGraph{T}(0)
     n == 1 && PathGraph(T(2))
-    Tw = widen(T)
-    temp = T(Tw(n)+Tw(n)) # test to check if T is large enough
-    g = SimpleGraph(2*n)
+
+    g = SimpleGraph{T}(2*n)
     for i in 1:(n-1)
         add_edge!(g, i, i+1)
         add_edge!(g, n+i, n+i+1)
@@ -388,9 +396,18 @@ function LadderGraph(n::T) where {T <: Integer}
     return g
 end
 
+"""
+    CircularLadderGraph(n)
+
+Create a graph consisting of `2n` nodes and `3n` edges.
+
+### Implementation Notes
+Preserves the eltype of the partitions vector. Will error if the required number of vertices
+exceeds the eltype. 
+`n` must be at least 3 to avoid self-loops and multi-edges.
+"""
 function CircularLadderGraph(n::T) where {T <: Integer}
-    n == 0 && SimpleGraph{T}(0)
-    n == 1 && PathGraph(T(2))
+    n < 3 && throw(DomainError("n=$n must be at least 3"))
     g = LadderGraph(n)
     add_edge!(g, 1, n)
     add_edge!(g, n+1, 2*n)

--- a/src/SimpleGraphs/generators/staticgraphs.jl
+++ b/src/SimpleGraphs/generators/staticgraphs.jl
@@ -376,7 +376,7 @@ end
 """
     LadderGraph(n)
 
-Create a graph consisting of `2n` nodes and `3n-2` edges.
+Create a [ladder graph](https://en.wikipedia.org/wiki/Ladder_graph) consisting of `2n` nodes and `3n-2` edges.
 
 ### Implementation Notes
 Preserves the eltype of `n`. Will error if the required number of vertices
@@ -407,7 +407,8 @@ end
 """
     CircularLadderGraph(n)
 
-Create a graph consisting of `2n` nodes and `3n` edges. This is also known as the Prism Graph.
+Create a circular [ladder graph](https://en.wikipedia.org/wiki/Ladder_graph) consisting of `2n` nodes and `3n` edges.
+This is also known as the [prism graph](https://en.wikipedia.org/wiki/Prism_graph).
 
 ### Implementation Notes
 Preserves the eltype of the partitions vector. Will error if the required number of vertices

--- a/test/simplegraphs/generators/staticgraphs.jl
+++ b/test/simplegraphs/generators/staticgraphs.jl
@@ -243,4 +243,36 @@
     Adj = sparse(I, J, V)
     @test Adj == sparse(rg3)
     @test isvalid_simplegraph(g)
+
+    g = @inferred(LadderGraph(5))
+    @test nv(g) == 10 && ne(g) == 13
+    @test isvalid_simplegraph(g)
+    # tests for extreme values
+    g = LadderGraph(0)
+    @test nv(g) == 0 && ne(g) == 0
+    g = LadderGraph(1)
+    @test nv(g) == 2 && ne(g) == 1
+    g = @inferred LadderGraph(-1)
+    @test nv(g) == 0 && ne(g) == 0
+    g = LadderGraph(Int8(63))
+    @test nv(g) == 126 && ne(g) == 187
+    @test eltype(g) == Int8
+    # tests for errors
+    @test_throws InexactError LadderGraph(Int8(64))
+
+    g = @inferred(CircularLadderGraph(5))
+    @test nv(g) == 10 && ne(g) == 15
+    @test isvalid_simplegraph(g)
+    # tests for extreme values
+    g = CircularLadderGraph(3)
+    @test nv(g) == 6 && ne(g) == 9
+    g = CircularLadderGraph(Int8(63))
+    @test nv(g) == 126 && ne(g) == 189
+    @test eltype(g) == Int8
+    # tests for errors
+    @test_throws InexactError CircularLadderGraph(Int8(64))
+    @test_throws DomainError CircularLadderGraph(-1)
+    @test_throws DomainError CircularLadderGraph(0)
+    @test_throws DomainError CircularLadderGraph(1)
+    @test_throws DomainError CircularLadderGraph(2)
 end

--- a/test/simplegraphs/generators/staticgraphs.jl
+++ b/test/simplegraphs/generators/staticgraphs.jl
@@ -244,9 +244,23 @@
     @test Adj == sparse(rg3)
     @test isvalid_simplegraph(g)
 
+    function isladdergraph(g)
+      n = nv(g)÷2
+      !(degree(g, 1) == degree(g, n) == degree(g, n+1) == degree(g, 2*n) == 2) && return false
+      !(has_edge(g, 1, n+1) && has_edge(g, n, 2*n)) && return false
+      !(has_edge(g, 1, 2) && has_edge(g, n, n-1) && has_edge(g, n+1, n+2) && has_edge(g, 2*n, 2*n-1) ) && return false
+      for i in 2:(n-1)
+        !(degree(g, i) == 3 && degree(g, n+i) == 3) && return false
+        !(has_edge(g, i, i%n +1) && has_edge(g, i, i+n)) && return false
+        !(has_edge(g, n+i,n+(i%n +1)) && has_edge(g, n+i, i)) && return false
+      end
+      return true
+    end
+
     g = @inferred(LadderGraph(5))
     @test nv(g) == 10 && ne(g) == 13
     @test isvalid_simplegraph(g)
+    @test isladdergraph(g)
     # tests for extreme values
     g = LadderGraph(0)
     @test nv(g) == 0 && ne(g) == 0
@@ -257,18 +271,32 @@
     g = LadderGraph(Int8(63))
     @test nv(g) == 126 && ne(g) == 187
     @test eltype(g) == Int8
+    @test isladdergraph(g)
     # tests for errors
     @test_throws InexactError LadderGraph(Int8(64))
+
+    function iscircularladdergraph(g)
+      n = nv(g)÷2
+      for i in 1:n
+        !(degree(g, i) == 3 && degree(g, n+i) == 3) && return false
+        !(has_edge(g, i, i%n +1) && has_edge(g, i, i+n)) && return false
+        !(has_edge(g, n+i,n+(i%n +1)) && has_edge(g, n+i, i)) && return false
+      end
+      return true
+    end
 
     g = @inferred(CircularLadderGraph(5))
     @test nv(g) == 10 && ne(g) == 15
     @test isvalid_simplegraph(g)
+    @test iscircularladdergraph(g)
     # tests for extreme values
     g = CircularLadderGraph(3)
     @test nv(g) == 6 && ne(g) == 9
+    @test iscircularladdergraph(g)
     g = CircularLadderGraph(Int8(63))
     @test nv(g) == 126 && ne(g) == 189
     @test eltype(g) == Int8
+    @test iscircularladdergraph(g)
     # tests for errors
     @test_throws InexactError CircularLadderGraph(Int8(64))
     @test_throws DomainError CircularLadderGraph(-1)


### PR DESCRIPTION
This adds LadderGraph and CircularLadderGraph. See #1030.

I benchmarked a few ways to generate ladder graphs and this was the most efficient (in both time and space).

```
julia> using BenchmarkTools, Base, Test, Statistics, LightGraphs

julia> function LadderGraph2(n::T) where {T <: Integer}
           n == 0 && SimpleGraph{T}(0)
           n == 1 && PathGraph(T(2))
           Tw = widen(T)
           temp = T(Tw(n)+Tw(n)) # test to check if T is large enough

           fadjlist = Vector{Vector{T}}(undef, 2*n)
           @inbounds @simd for i in 2:(n-1)
               fadjlist[i]   = Vector{T}([i-1, i+1, i+n])
               fadjlist[n+i] = Vector{T}([i, n+i-1, n+i+1])
           end
           fadjlist[1]   = Vector{T}([2, n+1])
           fadjlist[n+1] = Vector{T}([1, n+2])
           fadjlist[n]   = Vector{T}([n-1, 2*n])
           fadjlist[2*n] = Vector{T}([n, 2*n-1])

           return SimpleGraph(3*n-2, fadjlist)
       end
LadderGraph2 (generic function with 1 method)

julia> function LadderGraph3(n)
           Grid([n, 2])
       end
LadderGraph3 (generic function with 1 method)

julia> function LadderGraph4(n)
           cartesian_product(CycleGraph(n), PathGraph(2))
       end
LadderGraph4 (generic function with 1 method)

julia> N = 50
50

julia> @btime LadderGraph(N)
  6.715 μs (202 allocations: 13.41 KiB)
{100, 148} undirected simple Int64 graph

julia> @btime LadderGraph2(N)
  6.168 μs (202 allocations: 22.66 KiB)
{100, 148} undirected simple Int64 graph

julia> @btime LadderGraph3(N)
  9.518 μs (260 allocations: 19.16 KiB)
{100, 148} undirected simple Int64 graph

julia> @btime LadderGraph4(N)
  9.815 μs (258 allocations: 18.97 KiB)
{100, 150} undirected simple Int64 graph

julia> N = 500
500

julia> @btime LadderGraph(N)
  68.568 μs (2002 allocations: 132.97 KiB)
{1000, 1498} undirected simple Int64 graph

julia> @btime LadderGraph2(N)
  64.885 μs (3468 allocations: 249.50 KiB)
{1000, 1498} undirected simple Int64 graph

julia> @btime LadderGraph3(N)
  98.533 μs (2510 allocations: 184.44 KiB)
{1000, 1498} undirected simple Int64 graph

julia> @btime LadderGraph4(N)
  98.865 μs (2508 allocations: 184.25 KiB)
{1000, 1500} undirected simple Int64 graph

julia> N = 50000
50000

julia> @btime LadderGraph(N)
  6.980 ms (200003 allocations: 12.97 MiB)
{100000, 149998} undirected simple Int64 graph

julia> @btime LadderGraph2(N)
  14.748 ms (498467 allocations: 26.68 MiB)
{100000, 149998} undirected simple Int64 graph

julia> @btime LadderGraph3(N)
  9.912 ms (250013 allocations: 17.93 MiB)
{100000, 149998} undirected simple Int64 graph

julia> @btime LadderGraph4(N)
  10.237 ms (250010 allocations: 17.93 MiB)
{100000, 150000} undirected simple Int64 graph
```