### PR TITLE
Fix jldoctest formatting for all_neighbors

### DIFF
--- a/src/core.jl
+++ b/src/core.jl
@@ -265,6 +265,7 @@ julia> all_neighbors(g, 3)
 2-element Array{Int64,1}:
  1
  2
+ ```
 """
 function all_neighbors end
 @traitfn all_neighbors(g::::IsDirected, v::Integer) =


### PR DESCRIPTION
Just a tiny formatting error I spotted in the wild.