### PR TITLE
Fix infinite cycle traversal in floyd-warshall path enumeration

### DIFF
--- a/src/shortestpaths/floyd-warshall.jl
+++ b/src/shortestpaths/floyd-warshall.jl
@@ -80,7 +80,11 @@ function enumerate_paths(s::FloydWarshallState{T,U}, v::Integer) where T where U
             currpathindex = i
             while currpathindex != 0
                 push!(path, currpathindex)
-                currpathindex = pathinfo[currpathindex]
+                if pathinfo[currpathindex] == currpathindex
+                    currpathindex = 0
+                else
+                    currpathindex = pathinfo[currpathindex]
+                end
             end
             push!(paths, reverse(path))
         end

--- a/test/shortestpaths/floyd-warshall.jl
+++ b/test/shortestpaths/floyd-warshall.jl
@@ -24,4 +24,20 @@
         z = @inferred(floyd_warshall_shortest_paths(g, d))
         @test z.dists == [0 1 -3 2 -4; 3 0 -4 1 -1; 7 4 0 5 3; 2 -1 -5 0 -2; 8 5 1 6 0]
     end 
+
+    @testset "enumerate_paths infinite loop bug" begin
+        g = SimpleGraph(2)
+        add_edge!(g, 1, 2)
+        add_edge!(g, 2, 2)
+        @test enumerate_paths(floyd_warshall_shortest_paths(g)) ==
+            Vector{Vector{Int}}[[[], [1, 2]], [[2, 1], []]]
+
+        g = SimpleDiGraph(2)
+        add_edge!(g, 1, 1)
+        add_edge!(g, 1, 2)
+        add_edge!(g, 2, 1)
+        add_edge!(g, 2, 2)
+        @test enumerate_paths(floyd_warshall_shortest_paths(g)) ==
+            Vector{Vector{Int}}[[[], [1, 2]], [[2, 1], []]]
+    end
 end


### PR DESCRIPTION
Thanks for making this great package available.

The included tests are examples of cases that result in infinite loops with the current floyd-warshall path enumeration function, and that I think are correctly handled by the updated function.

With the current enumerate_paths code, the first test example would take the path from 1 -> 2 and then loop in the 2 -> 2 cycle forever. The second example does the same but with a directed graph.

This is with the current master of LightGraphs and Julia 1.0.2