### PR TITLE
transitive closure speed improved

### DIFF
--- a/src/digraph/transitivity.jl
+++ b/src/digraph/transitivity.jl
@@ -12,7 +12,7 @@ This version of the function modifies the original graph.
 """
 function transitiveclosure! end
 @traitfn function transitiveclosure!(g::::IsDirected, selflooped=false)
-    cg = copy(g)
+    cg = SimpleDiGraph{eltype(g)}(nv(g))
     visited = Vector{Bool}(undef,nv(g))
     stack = Vector{eltype(g)}(undef,nv(g))
     for i in vertices(g)

--- a/src/digraph/transitivity.jl
+++ b/src/digraph/transitivity.jl
@@ -12,6 +12,7 @@ This version of the function modifies the original graph.
 """
 function transitiveclosure! end
 @traitfn function transitiveclosure!(g::::IsDirected, selflooped=false)
+    cg = copy(g)
     visited = Vector{Bool}(undef,nv(g))
     stack = Vector{eltype(g)}(undef,nv(g))
     for i in vertices(g)
@@ -23,7 +24,7 @@ function transitiveclosure! end
             w = stack[stacksize]
             stacksize -= 1
             if i != w || selflooped
-                add_edge!(g,i,w)
+                add_edge!(cg,i,w)
             end
             visited[w] = true
             for j in outneighbors(g,w)
@@ -33,6 +34,9 @@ function transitiveclosure! end
                 end
             end
         end
+    end
+    for e in edges(cg)
+        add_edge!(g,e)
     end
     return g
 end


### PR DESCRIPTION
#1035 
```julia
g = SimpleDiGraph(100,200)
@benchmark transitiveclosure(g)
```
Benchmarks using Floyd Warshall Algorithm
```julia
  BenchmarkTools.Trial: 
  memory estimate:  401.77 KiB
  allocs estimate:  1195
  --------------
  minimum time:     3.634 ms (0.00% GC)
  median time:      3.715 ms (0.00% GC)
  mean time:        3.859 ms (2.09% GC)
  maximum time:     64.727 ms (94.07% GC)
  --------------
  samples:          1294
  evals/sample:     1
```
Benchmarks using DFS
```julia
  BenchmarkTools.Trial: 
  memory estimate:  700.92 KiB
  allocs estimate:  2188
  --------------
  minimum time:     1.989 ms (0.00% GC)
  median time:      2.028 ms (0.00% GC)
  mean time:        2.119 ms (3.14% GC)
  maximum time:     63.122 ms (96.40% GC)
  --------------
  samples:          2352
  evals/sample:     1
```