### PR TITLE
Minor cleanup of CircularLadderGraph signature

### DIFF
--- a/src/SimpleGraphs/generators/staticgraphs.jl
+++ b/src/SimpleGraphs/generators/staticgraphs.jl
@@ -471,7 +471,7 @@ Preserves the eltype of the partitions vector. Will error if the required number
 exceeds the eltype. 
 `n` must be at least 3 to avoid self-loops and multi-edges.
 """
-function CircularLadderGraph(n::T) where {T <: Integer}
+function CircularLadderGraph(n::Integer)
     n < 3 && throw(DomainError("n=$n must be at least 3"))
     g = LadderGraph(n)
     add_edge!(g, 1, n)


### PR DESCRIPTION
Just a small aesthetic change. `T` is not used in the function body. 