### PR TITLE
RFC: Add option for is_cyclic to return the found cycle.

### DIFF
--- a/src/traversals/dfs.jl
+++ b/src/traversals/dfs.jl
@@ -6,23 +6,35 @@
 
 Return `true` if graph `g` contains a cycle.
 
+    is_cyclic(g, cycle)
+
+Return `true` if directed graph `g` contains a cycle. Also fill in
+`cycle` with the first found cycle. `cycle` must be a vector of the
+element type of the graph and will be overwritten with the new cycle.
+If no cycle is found, `cycle` will become empty.
+
 ### Implementation Notes
 Uses DFS.
 """
 function is_cyclic end
 @traitfn is_cyclic(g::::(!IsDirected)) = ne(g) > 0
 # see https://github.com/mauro3/SimpleTraits.jl/issues/47#issuecomment-327880153 for syntax
-@traitfn function is_cyclic(g::AG::IsDirected) where {T, AG<:AbstractGraph{T}}
+@traitfn function is_cyclic(g::AG::IsDirected,
+                            cycle::Vector{T}=Vector{T}()) where {T, AG<:AbstractGraph{T}}
     vcolor = zeros(UInt8, nv(g))
+    empty!(cycle)
     for v in vertices(g)
         vcolor[v] != 0 && continue
-        S = Vector{T}([v])
+        push!(cycle, v)
         vcolor[v] = 1
-        while !isempty(S)
-            u = S[end]
+        while !isempty(cycle)
+            u = cycle[end]
             w = 0
             for n in outneighbors(g, u)
                 if vcolor[n] == 1
+                    while cycle[1] != n
+                        popfirst!(cycle)
+                    end
                     return true
                 elseif vcolor[n] == 0
                     w = n
@@ -31,10 +43,10 @@ function is_cyclic end
             end
             if w != 0
                 vcolor[w] = 1
-                push!(S, w)
+                push!(cycle, w)
             else
                 vcolor[u] = 2
-                pop!(S)
+                pop!(cycle)
             end
         end
     end

--- a/test/traversals/dfs.jl
+++ b/test/traversals/dfs.jl
@@ -2,18 +2,38 @@
     g5 = SimpleDiGraph(4)
     add_edge!(g5, 1, 2); add_edge!(g5, 2, 3); add_edge!(g5, 1, 3); add_edge!(g5, 3, 4)
     for g in testdigraphs(g5)
-      z = @inferred(dfs_tree(g, 1))
-      @test ne(z) == 3 && nv(z) == 4
-      @test !has_edge(z, 1, 3)
+        z = @inferred(dfs_tree(g, 1))
+        @test ne(z) == 3 && nv(z) == 4
+        @test !has_edge(z, 1, 3)
 
-      @test @inferred(topological_sort_by_dfs(g)) == [1, 2, 3, 4]
-      @test !is_cyclic(g)
+        @test @inferred(topological_sort_by_dfs(g)) == [1, 2, 3, 4]
+        @test !is_cyclic(g)
+        cycle = Vector{eltype(g)}(undef, 2)
+        @test !is_cyclic(g, cycle)
+        @test isempty(cycle)
     end
 
     gx = CycleDiGraph(3)
     for g in testdigraphs(gx)
-      @test @inferred(is_cyclic(g))
-      @test_throws ErrorException topological_sort_by_dfs(g)
+        @test @inferred(is_cyclic(g))
+        cycle = Vector{eltype(g)}()
+        @test @inferred(is_cyclic(g, cycle))
+        @test length(cycle) > 0
+        for i = 1:length(cycle)
+            @test cycle[mod1(i + 1, length(cycle))] in outneighbors(g, cycle[i])
+        end
+        @test_throws ErrorException topological_sort_by_dfs(g)
+    end
+
+    g6 = PathDiGraph(5)
+    add_edge!(g6, 5, 3)
+    for g in testdigraphs(g6)
+        cycle = Vector{eltype(g)}()
+        @test @inferred(is_cyclic(g, cycle))
+        @test length(cycle) > 0
+        for i = 1:length(cycle)
+            @test cycle[mod1(i + 1, length(cycle))] in outneighbors(g, cycle[i])
+        end
     end
 
     for g in testgraphs(PathGraph(2))


### PR DESCRIPTION
`is_cyclic` for directed graphs constructively finds a cycle when determining whether the graph is cyclic. This PR adds the option to have it returned by providing an optional second argument, which is a vector that gets overwritten with the found cycle.

Marking this as RFC for primarily two reasons:
* Something about the workings of the `@traitfn` macro causes this to break `is_cyclic` for undirected graphs.
* More generally this is maybe not at all the desired interface. A reasonable alternative would be to have separate functions to query the existence of a cycle and obtaining a cycle, with a common backend function doing the work.
