### PR TITLE
has_path(g, v, v) now false

### DIFF
--- a/src/traversals/bfs.jl
+++ b/src/traversals/bfs.jl
@@ -146,6 +146,11 @@ gdistances(g::AbstractGraph{T}, source; sort_alg = Base.Sort.QuickSort) where T 
 Return `true` if there is a path from `u` to `v` in `g` (while avoiding vertices in
 `exclude_vertices`) or `u == v`. Return false if there is no such path or if `u` or `v`
 is in `excluded_vertices`. 
+
+### Implementation Notes
+`has_path(g, v, v)` will return `false` unless there is an explicit
+self-loop defined on vertex `v`. This is a change from previous
+versions.
 """
 function has_path(g::AbstractGraph{T}, u::Integer, v::Integer; 
         exclude_vertices::AbstractVector = Vector{T}()) where T
@@ -154,7 +159,7 @@ function has_path(g::AbstractGraph{T}, u::Integer, v::Integer;
         seen[ve] = true
     end
     (seen[u] || seen[v]) && return false
-    u == v && return true # cannot be separated
+    u == v  && return has_edge(g, u, v) # cannot be separated
     next = Vector{T}()
     push!(next, u)
     seen[u] = true

--- a/test/traversals/bfs.jl
+++ b/test/traversals/bfs.jl
@@ -76,8 +76,11 @@ import LightGraphs: tree
         # Edge cases
         @test !has_path(g, 1, 6)
         @test !has_path(g, 6, 1)  
-        @test has_path(g, 1, 1) # inseparable 
+        @test !has_path(g, 1, 1) # inseparable 
         @test !has_path(g, 1, 2; exclude_vertices=[2])
         @test !has_path(g, 1, 2; exclude_vertices=[1])
+
+	add_edge!(g, 1, 1)
+	@test has_path(g, 1, 1)
     end
 end


### PR DESCRIPTION
...unless explicit self-loop exists.