### PR TITLE
Added a internal function deepcopy_adjlist

### DIFF
--- a/src/SimpleGraphs/SimpleGraphs.jl
+++ b/src/SimpleGraphs/SimpleGraphs.jl
@@ -10,7 +10,7 @@ import Base:
 import LightGraphs:
     _NI, AbstractGraph, AbstractEdge, AbstractEdgeIter,
     src, dst, edgetype, nv, ne, vertices, edges, is_directed,
-    has_vertex, has_edge, inneighbors, outneighbors,
+    has_vertex, has_edge, inneighbors, outneighbors, deepcopy_adjlist,
 
     indegree, outdegree, degree, has_self_loops, num_self_loops, insorted
 

--- a/src/SimpleGraphs/simpledigraph.jl
+++ b/src/SimpleGraphs/simpledigraph.jl
@@ -146,8 +146,8 @@ julia> SimpleDiGraph(g)
 function SimpleDiGraph(g::AbstractSimpleGraph)
     h = SimpleDiGraph(nv(g))
     h.ne = ne(g) * 2 - num_self_loops(g)
-    h.fadjlist = deepcopy(fadj(g))
-    h.badjlist = deepcopy(badj(g))
+    h.fadjlist = deepcopy_adjlist(fadj(g))
+    h.badjlist = deepcopy_adjlist(badj(g))
     return h
 end
 
@@ -342,7 +342,7 @@ badj(g::SimpleDiGraph, v::Integer) = badj(g)[v]
 
 
 copy(g::SimpleDiGraph{T}) where T <: Integer =
-SimpleDiGraph{T}(g.ne, deepcopy(g.fadjlist), deepcopy(g.badjlist))
+SimpleDiGraph{T}(g.ne, deepcopy_adjlist(g.fadjlist), deepcopy_adjlist(g.badjlist))
 
 
 ==(g::SimpleDiGraph, h::SimpleDiGraph) =

--- a/src/SimpleGraphs/simplegraph.jl
+++ b/src/SimpleGraphs/simplegraph.jl
@@ -127,7 +127,7 @@ julia> SimpleGraph(g)
 function SimpleGraph(g::SimpleDiGraph)
     gnv = nv(g)
     edgect = 0
-    newfadj = deepcopy(g.fadjlist)
+    newfadj = deepcopy_adjlist(g.fadjlist)
     @inbounds for i in vertices(g)
         for j in badj(g, i)
             index = searchsortedfirst(newfadj[i], j)
@@ -351,7 +351,7 @@ Returns a reference, not a copy. Do not modify result.
 adj(g::SimpleGraph) = fadj(g)
 adj(g::SimpleGraph, v::Integer) = fadj(g, v)
 
-copy(g::SimpleGraph) =  SimpleGraph(g.ne, deepcopy(g.fadjlist))
+copy(g::SimpleGraph) =  SimpleGraph(g.ne, deepcopy_adjlist(g.fadjlist))
 
 ==(g::SimpleGraph, h::SimpleGraph) =
 vertices(g) == vertices(h) &&

--- a/src/operators.jl
+++ b/src/operators.jl
@@ -79,8 +79,8 @@ function reverse end
     gnv = nv(g)
     gne = ne(g)
     h = SimpleDiGraph(gnv)
-    h.fadjlist = deepcopy(g.badjlist)
-    h.badjlist = deepcopy(g.fadjlist)
+    h.fadjlist = deepcopy_adjlist(g.badjlist)
+    h.badjlist = deepcopy_adjlist(g.fadjlist)
     h.ne = gne
     return h
 end
@@ -287,7 +287,7 @@ julia> collect(edges(f))
  Edge 4 => 5
 ```
 """
-function union(g::T, h::T) where T <: AbstractGraph
+function union(g::T, h::T) where T <: AbstractSimpleGraph
     gnv = nv(g)
     hnv = nv(h)
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -261,7 +261,6 @@ function deepcopy_adjlist(adjlist::Vector{Vector{T}}) where {T}
 
     result = Vector{Vector{T}}(undef, length(adjlist))
     @inbounds for (i, list) in enumerate(adjlist)
-        length_list = length(list)
         result_list = Vector{T}(undef, length(list))
         for (j, item) in enumerate(list)
             result_list[j] = item

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -244,3 +244,30 @@ Returns true if `typemax(T)` of a type `T <: Integer` exists.
 isbounded(::Type{T}) where {T <: Integer} = isconcretetype(T)
 isbounded(::Type{BigInt}) = false
 
+"""
+    deepcopy_adjlist(adjlist::Vector{Vector{T}})
+
+Internal utility function for copying adjacency lists.
+On adjacency lists this function is more efficient than `deepcopy` for two reasons:
+-  As of Julia v1.0.2, `deepcopy` is not typestable.
+- `deepcopy` needs to track all references when traversing a recursive data structure
+    in order to ensure that references to the same location do need get assigned to
+    different locations in the copy. Because we can assume that all lists in our
+    adjacency list are different, we don't need to keep track of them.
+If `T` is not a bitstype (e.g. `BigInt`), we use the standard `deepcopy`.
+"""
+function deepcopy_adjlist(adjlist::Vector{Vector{T}}) where {T}
+    isbitstype(T) || return deepcopy(adjlist)
+
+    result = Vector{Vector{T}}(undef, length(adjlist))
+    @inbounds for (i, list) in enumerate(adjlist)
+        length_list = length(list)
+        result_list = Vector{T}(undef, length(list))
+        for (j, item) in enumerate(list)
+            result_list[j] = item
+        end
+        result[i] = result_list
+    end
+
+    return result
+end


### PR DESCRIPTION
In several places (mainly constructors) we use the function `deepcopy` for copying adjacency lists. This is not very efficient. Therefore I have implemented a function `deepcopy_adjlist`. Here are some benchmarks:
```
julia> g = erdos_renyi(100000, 0.001);

# old

julia> @btime SimpleDiGraph(g);
  196.273 ms (400042 allocations: 206.27 MiB) 

# new

julia> @btime SimpleDiGraph(g);
  113.588 ms (400010 allocations: 195.60 MiB)
```
On dense graphs the effect is less notable.