### PR TITLE
Update URL to the stable version of Julia manual

### DIFF
--- a/docs/src/developing.md
+++ b/docs/src/developing.md
@@ -7,7 +7,7 @@ All LightGraphs functions rely on a standard API to function. As long as your gr
 within the LightGraphs package should just work:
 
 - [`edges`](@ref)
-- [Base.eltype](https://docs.julialang.org/en/stable/stdlib/collections/#Base.eltype)
+- [Base.eltype](https://docs.julialang.org/en/v1/stdlib/collections/#Base.eltype)
 - [`has_edge`](@ref)
 - [`has_vertex`](@ref)
 - [`inneighbors`](@ref)


### PR DESCRIPTION
The URL to the stable version of Julia manual website, https://docs.julialang.org/en/stable/manual/, is not generated any more. Instead, use the new URL, https://docs.julialang.org/en/v1/manual/.

Discussed at JuliaLang/julia#30524