### PR TITLE
Fixes egonet

### DIFF
--- a/src/operators.jl
+++ b/src/operators.jl
@@ -701,7 +701,7 @@ This is equivalent to [`induced_subgraph`](@ref)`(g, neighborhood(g, v, d, dir=d
 with respect to `v` (i.e. `:in` or `:out`).
 """
 egonet(g::AbstractGraph{T}, v::Integer, d::Integer, distmx::AbstractMatrix{U}=weights(g); dir=:out) where T <: Integer where U <: Real =
-    g[neighborhood(g, v, d, distmx, dir=dir)]
+    g[unique!(neighborhood(g, v, d, distmx, dir=dir))]
 
 
 

--- a/test/operators.jl
+++ b/test/operators.jl
@@ -294,4 +294,12 @@
         @test @inferred(egonet(g, 1, 1)) == g
         @test @inferred(ndims(g)) == 2
     end
+    
+    let gegonet = SimpleDiGraph([0 1 1 0; 0 0 0 1; 0 0 0 1; 0 0 0 0])
+        @test egonet(gegonet,1,3,dir=:out)==gegonet
+        @test egonet(gegonet,4,3,dir=:in)==reverse(gegonet)
+        gegonetlarge = copy(gegonet)
+        add_vertex!(gegonetlarge); add_edge!(gegonetlarge,5,1)
+        @test egonet(gegonetlarge,1,3,dir=:out)==gegonet
+    end
 end


### PR DESCRIPTION
`egonet` requires a vector of unique indicies. Added tests related to issue.