### PR TITLE
corrected transitive closure

### DIFF
--- a/src/digraph/transitivity.jl
+++ b/src/digraph/transitivity.jl
@@ -15,7 +15,7 @@ function transitiveclosure! end
     scc = strongly_connected_components(g)
     cg = condensation(g, scc)
     tp = reverse(topological_sort_by_dfs(cg))
-    sr = [Vector{eltype(cg)}() for _ in vertices(g)]
+    sr = [Vector{eltype(cg)}() for _ in vertices(cg)]
 
     x = selflooped ? 0 : 1
     for comp in scc

--- a/src/digraph/transitivity.jl
+++ b/src/digraph/transitivity.jl
@@ -15,32 +15,27 @@ function transitiveclosure! end
     scc = strongly_connected_components(g)
     cg = condensation(g, scc)
     tp = reverse(topological_sort_by_dfs(cg))
-    sr = Array{Array{eltype(cg),1},1}(undef,nv(cg))
-    for i in vertices(cg)
-        sr[i] = [0]
-    end
+    sr = [Vector{eltype(cg)}() for _ in vertices(g)]
+
     x = selflooped ? 0 : 1
     for comp in scc
         for j in 1:(length(comp)-x)
             for k in (j+x):length(comp)
-                add_edge!(g,comp[j],comp[k])
-                add_edge!(g,comp[k],comp[j])
+                add_edge!(g, comp[j], comp[k])
+                add_edge!(g, comp[k], comp[j])
             end
         end
     end
     for u in tp
-        for v in outneighbors(cg,u)
-            union!(sr[u],sr[v],[v])
+        for v in outneighbors(cg, u)
+            union!(sr[u], sr[v], [v])
         end
     end
     for i in vertices(cg)
         for u in scc[i]
             for j in sr[i]
-                if j == 0
-                    continue
-                end
                 for v in scc[j]
-                    add_edge!(g,u,v)
+                    add_edge!(g, u, v)
                 end
             end
         end


### PR DESCRIPTION
In #1078 I made the mistake of initializing an array of vectors with ```[0]``` and checking for zero later because I did not know we could create an empty array, I was a bit confused by ```undef``` at the time (I should've verified before merging). Just wanted to correct that and some code style changes.It should not affect the benchmarks though.