### PR TITLE
Doc fix: random_orientation_dag takes a graph

### DIFF
--- a/src/SimpleGraphs/generators/randgraphs.jl
+++ b/src/SimpleGraphs/generators/randgraphs.jl
@@ -1047,7 +1047,7 @@ function dorogovtsev_mendes(n::Integer; seed::Int=-1)
 end
 
 """
-    random_orientation_dag(n)
+    random_orientation_dag(g)
 
 Generate a random oriented acyclical digraph. The function takes in a simple
 graph and a random number generator as an argument. The probability of each


### PR DESCRIPTION
Very minor documentation fix - `n` sounded like it should be a number, so I made it be `g` instead.