### PR TITLE
Sbromberger/fix 1116

### DIFF
--- a/src/connectivity.jl
+++ b/src/connectivity.jl
@@ -507,6 +507,7 @@ neighborhood_dists(g::AbstractGraph{T}, v::Integer, d, distmx::AbstractMatrix{U}
 function _neighborhood(g::AbstractGraph{T}, v::Integer, d::Real, distmx::AbstractMatrix{U}, neighborfn::Function) where T <: Integer where U <: Real
     d < 0 && return Vector{Tuple{T,U}}()
     neighs = Vector{T}()
+    neighset = Set{T}()
     push!(neighs, v)
     Q = Vector{T}()
     push!(Q, v)
@@ -521,10 +522,11 @@ function _neighborhood(g::AbstractGraph{T}, v::Integer, d::Real, distmx::Abstrac
         vertexneighbors = neighborfn(g, src)
         @inbounds for vertex in vertexneighbors
             if !seen[vertex] 
-                vdist = currdist + distmx[src, vertex]
-                if vdist <= d
+                vdist = currdist == typemax(U) ? typemax(U) : currdist + distmx[src, vertex]
+                if vdist <= d && vertex ∉ neighset
                     push!(Q, vertex)
                     push!(neighs, vertex)
+                    push!(neighset, vertex)
                     dists[vertex] = vdist
                 end
             end

--- a/src/connectivity.jl
+++ b/src/connectivity.jl
@@ -460,7 +460,7 @@ neighborhood(g::AbstractGraph{T}, v::Integer, d, distmx::AbstractMatrix{U}=weigh
 """
     neighborhood_dists(g, v, d, distmx=weights(g))
 
-Return a tuple of each vertex at a geodesic distance less than or equal to `d`, along with 
+Return a a vector of tuples representing each vertex which is at a geodesic distance less than or equal to `d`, along with 
 its distance from `v`. Non-negative distances may be specified by `distmx`.
 
 ### Optional Arguments
@@ -521,16 +521,16 @@ function _neighborhood(g::AbstractGraph{T}, v::Integer, d::Real, distmx::Abstrac
         push!(neighs, src)
         vertexneighbors = neighborfn(g, src)
         @inbounds for vertex in vertexneighbors
-            if !seen[vertex] 
-                vdist = currdist == typemax(U) ? typemax(U) : currdist + distmx[src, vertex]
-                if vdist <= ud && vdist < dists[vertex]
+            if !seen[vertex]  && currdist < typemax(U)
+                vdist = currdist + distmx[src, vertex]
+                if vdist <= ud  && vdist < dists[vertex]
                     push!(Q, vertex)
                     dists[vertex] = vdist
                 end
             end
         end
     end
-    # working around closure bug - should be fixed in Julia 1.2
+    # working around closure bug https://github.com/JuliaLang/julia/issues/15276 - should be fixed in Julia 1.2
     return let dists=dists; [(x::T, dists[x]::U) for x in neighs]; end
 end
 

--- a/src/connectivity.jl
+++ b/src/connectivity.jl
@@ -505,11 +505,13 @@ neighborhood_dists(g::AbstractGraph{T}, v::Integer, d, distmx::AbstractMatrix{U}
 
 
 function _neighborhood(g::AbstractGraph{T}, v::Integer, d::Real, distmx::AbstractMatrix{U}, neighborfn::Function) where T <: Integer where U <: Real
-    d < 0 && return Vector{Tuple{T,U}}()
+    ud = U(d)
+    if ud < 0
+        return Vector{Tuple{T, U}}()
+    end
+
+    #= ud < zero(U) && return Vector{Tuple{T,U}}() =#
     neighs = Vector{T}()
-    neighset = Set{T}()
-    push!(neighs, v)
-    push!(neighset, v)
     Q = Vector{T}()
     push!(Q, v)
     seen = falses(nv(g))
@@ -520,14 +522,13 @@ function _neighborhood(g::AbstractGraph{T}, v::Integer, d::Real, distmx::Abstrac
         seen[src] && continue
         seen[src] = true
         currdist = dists[src]
+        push!(neighs, src)
         vertexneighbors = neighborfn(g, src)
         @inbounds for vertex in vertexneighbors
             if !seen[vertex] 
                 vdist = currdist == typemax(U) ? typemax(U) : currdist + distmx[src, vertex]
-                if vdist <= d && vertex ∉ neighset
+                if vdist <= ud
                     push!(Q, vertex)
-                    push!(neighs, vertex)
-                    push!(neighset, vertex)
                     dists[vertex] = vdist
                 end
             end

--- a/src/connectivity.jl
+++ b/src/connectivity.jl
@@ -506,11 +506,7 @@ neighborhood_dists(g::AbstractGraph{T}, v::Integer, d, distmx::AbstractMatrix{U}
 
 function _neighborhood(g::AbstractGraph{T}, v::Integer, d::Real, distmx::AbstractMatrix{U}, neighborfn::Function) where T <: Integer where U <: Real
     ud = U(d)
-    if ud < 0
-        return Vector{Tuple{T, U}}()
-    end
-
-    #= ud < zero(U) && return Vector{Tuple{T,U}}() =#
+    ud < zero(U) && return Vector{Tuple{T,U}}()
     neighs = Vector{T}()
     Q = Vector{T}()
     push!(Q, v)
@@ -527,14 +523,15 @@ function _neighborhood(g::AbstractGraph{T}, v::Integer, d::Real, distmx::Abstrac
         @inbounds for vertex in vertexneighbors
             if !seen[vertex] 
                 vdist = currdist == typemax(U) ? typemax(U) : currdist + distmx[src, vertex]
-                if vdist <= ud
+                if vdist <= ud && vdist < dists[vertex]
                     push!(Q, vertex)
                     dists[vertex] = vdist
                 end
             end
         end
     end
-    return [(x::T, dists[x]::U) for x in neighs]
+    # working around closure bug - should be fixed in Julia 1.2
+    return let dists=dists; [(x::T, dists[x]::U) for x in neighs]; end
 end
 
 """

--- a/src/connectivity.jl
+++ b/src/connectivity.jl
@@ -460,8 +460,8 @@ neighborhood(g::AbstractGraph{T}, v::Integer, d, distmx::AbstractMatrix{U}=weigh
 """
     neighborhood_dists(g, v, d, distmx=weights(g))
 
-Return a tuple of each vertex at a geodesic distance less than or equal to `d`, where distances
-may be specified by `distmx`, along with its distance from `v`.
+Return a tuple of each vertex at a geodesic distance less than or equal to `d`, along with 
+its distance from `v`. Non-negative distances may be specified by `distmx`.
 
 ### Optional Arguments
 - `dir=:out`: If `g` is directed, this argument specifies the edge direction

--- a/src/connectivity.jl
+++ b/src/connectivity.jl
@@ -509,6 +509,7 @@ function _neighborhood(g::AbstractGraph{T}, v::Integer, d::Real, distmx::Abstrac
     neighs = Vector{T}()
     neighset = Set{T}()
     push!(neighs, v)
+    push!(neighset, v)
     Q = Vector{T}()
     push!(Q, v)
     seen = falses(nv(g))

--- a/test/connectivity.jl
+++ b/test/connectivity.jl
@@ -193,4 +193,18 @@
     @test @inferred(!isgraphical([1, 1, 1]))
     @test @inferred(isgraphical([2, 2, 2]))
     @test @inferred(isgraphical(fill(3, 10)))
+    # 1116
+    gc = CycleGraph(4)
+    for g in testgraphs(gc)
+        z = @inferred(neighborhood(g, 3, 3))
+        @test (z == [3, 2, 4, 1] || z == [3, 4, 2, 1])
+    end
+
+    gd = SimpleDiGraph([0 1 1 0; 0 0 0 1; 0 0 0 1; 0 0 0 0])
+    add_edge!(gd, 1, 4)
+    for g in testdigraphs(gd)
+        z = @inferred(neighborhood_dists(g, 1, 4))
+        @test (4, 1) ∈ z
+        @test (4, 2) ∉ z
+    end
 end


### PR DESCRIPTION
This has a bad effect on (worst-case) performance:

```
julia> g = CompleteGraph(5000)
{5000, 12497500} undirected simple Int64 graph
```
OLD:
```
julia> @benchmark neighborhood_dists(g, 1, 4)
BenchmarkTools.Trial: 
  memory estimate:  1.96 MiB
  allocs estimate:  40440
  --------------
  minimum time:     579.565 ms (0.00% GC)
  median time:      589.257 ms (0.00% GC)
  mean time:        592.398 ms (0.00% GC)
  maximum time:     617.377 ms (0.00% GC)
  --------------
  samples:          9
  evals/sample:     1
```

NEW:
```
julia> @benchmark neighborhood_dists(g, 1, 4)
BenchmarkTools.Trial: 
  memory estimate:  779.59 KiB
  allocs estimate:  13524
  --------------
  minimum time:     1.142 s (0.00% GC)
  median time:      1.155 s (0.00% GC)
  mean time:        1.162 s (0.00% GC)
  maximum time:     1.189 s (0.00% GC)
  --------------
  samples:          5
  evals/sample:     1
```
