### PR TITLE
Simplify neighborhood_dists

### DIFF
--- a/src/connectivity.jl
+++ b/src/connectivity.jl
@@ -505,12 +505,10 @@ neighborhood_dists(g::AbstractGraph{T}, v::Integer, d, distmx::AbstractMatrix{U}
 
 
 function _neighborhood(g::AbstractGraph{T}, v::Integer, d::Real, distmx::AbstractMatrix{U}, neighborfn::Function) where T <: Integer where U <: Real
-    Q = [ (T(v),zero(U),) ]
-    if d < zero(U)
-        pop!(Q)
-        return Q
-    end
-    seen = [i==v for i in 1:nv(g)]
+    Q = Vector{Tuple{T,U}}()
+    d < zero(U) && return Q
+    push!(Q, (v,zero(U),) )
+    seen = fill(false,nv(g)); seen[v] = true #Bool Vector benchmarks faster than BitArray
     for (src,currdist) in Q
         currdist >= d && continue
         for dst in neighborfn(g,src)

--- a/src/connectivity.jl
+++ b/src/connectivity.jl
@@ -420,9 +420,9 @@ end
 
 """
     neighborhood(g, v, d, distmx=weights(g))
-    
+
 Return a vector of each vertex in `g` at a geodesic distance less than or equal to `d`, where distances
-may be specified by `distmx`. 
+may be specified by `distmx`.
 
 ### Optional Arguments
 - `dir=:out`: If `g` is directed, this argument specifies the edge direction
@@ -460,7 +460,7 @@ neighborhood(g::AbstractGraph{T}, v::Integer, d, distmx::AbstractMatrix{U}=weigh
 """
     neighborhood_dists(g, v, d, distmx=weights(g))
 
-Return a a vector of tuples representing each vertex which is at a geodesic distance less than or equal to `d`, along with 
+Return a a vector of tuples representing each vertex which is at a geodesic distance less than or equal to `d`, along with
 its distance from `v`. Non-negative distances may be specified by `distmx`.
 
 ### Optional Arguments
@@ -505,33 +505,24 @@ neighborhood_dists(g::AbstractGraph{T}, v::Integer, d, distmx::AbstractMatrix{U}
 
 
 function _neighborhood(g::AbstractGraph{T}, v::Integer, d::Real, distmx::AbstractMatrix{U}, neighborfn::Function) where T <: Integer where U <: Real
-    ud = U(d)
-    ud < zero(U) && return Vector{Tuple{T,U}}()
-    neighs = Vector{T}()
-    Q = Vector{T}()
-    push!(Q, v)
-    seen = falses(nv(g))
-    dists = fill(typemax(U), nv(g))
-    dists[v] = zero(U)
-    while !isempty(Q)
-        src = popfirst!(Q)
-        seen[src] && continue
-        seen[src] = true
-        currdist = dists[src]
-        push!(neighs, src)
-        vertexneighbors = neighborfn(g, src)
-        @inbounds for vertex in vertexneighbors
-            if !seen[vertex]  && currdist < typemax(U)
-                vdist = currdist + distmx[src, vertex]
-                if vdist <= ud  && vdist < dists[vertex]
-                    push!(Q, vertex)
-                    dists[vertex] = vdist
+    Q = [ (T(v),zero(U),) ]
+    if d < zero(U)
+        pop!(Q)
+        return Q
+    end
+    seen = [i==v for i in 1:nv(g)]
+    for (src,currdist) in Q
+        currdist >= d && continue
+        for dst in neighborfn(g,src)
+            if !seen[dst]
+                seen[dst]=true
+                if currdist+distmx[src,dst] <= d
+                    push!(Q, (dst , currdist+distmx[src,dst],))
                 end
             end
         end
     end
-    # working around closure bug https://github.com/JuliaLang/julia/issues/15276 - should be fixed in Julia 1.2
-    return let dists=dists; [(x::T, dists[x]::U) for x in neighs]; end
+    return Q
 end
 
 """


### PR DESCRIPTION
This is an alternative to neighborhood_dists with improved performance.

```
g=CompleteGraph(5000)
w=collect(weights(g))
```

The benchmark of the new implementation.
```
@benchmark neighborhood_dists($g,1,4)
BenchmarkTools.Trial: 
  memory estimate:  261.66 KiB
  allocs estimate:  14
  --------------
  minimum time:     22.693 ms (0.00% GC)
  median time:      24.123 ms (0.00% GC)
  mean time:        24.487 ms (0.09% GC)
  maximum time:     40.420 ms (0.00% GC)
  --------------
  samples:          205
  evals/sample:     1
```

Using a weights matrix does not adversely affect performance.
```
@benchmark neighborhood_dists($g,1,4,$w)
BenchmarkTools.Trial: 
  memory estimate:  261.66 KiB
  allocs estimate:  14
  --------------
  minimum time:     22.679 ms (0.00% GC)
  median time:      24.400 ms (0.00% GC)
  mean time:        24.821 ms (0.09% GC)
  maximum time:     36.978 ms (0.00% GC)
  --------------
  samples:          202
  evals/sample:     1
```

Comparing to the current implementation:

Comparing to the current implementation for the case without weights, ~40% improvement is due to a switch to `Vector{Bool}`
```
@benchmark neighborhood_dists($g,1,4)
BenchmarkTools.Trial: 
  memory estimate:  375.30 KiB
  allocs estimate:  34
  --------------
  minimum time:     35.491 ms (0.00% GC)
  median time:      40.724 ms (0.00% GC)
  mean time:        41.104 ms (0.11% GC)
  maximum time:     53.128 ms (0.00% GC)
  --------------
  samples:          122
  evals/sample:     1
```

Compared to the current implementation, when a weighted matrix is included, the performance improvement is significant.
```
@benchmark neighborhood_dists($g,1,4,$w)
BenchmarkTools.Trial: 
  memory estimate:  375.30 KiB
  allocs estimate:  34
  --------------
  minimum time:     112.708 ms (0.00% GC)
  median time:      117.853 ms (0.00% GC)
  mean time:        119.334 ms (0.00% GC)
  maximum time:     139.108 ms (0.00% GC)
  --------------
  samples:          42
  evals/sample:     1
```