### PR TITLE
Fix adjacency matrix for all types

### DIFF
--- a/src/linalg/spectral.jl
+++ b/src/linalg/spectral.jl
@@ -36,13 +36,22 @@ function adjacency_matrix(g::AbstractGraph, T::DataType=Int; dir::Symbol=:out)
     end
 end
 
-function _adjacency_matrix(g::AbstractGraph{U}, T::DataType, neighborfn::Function, nzmult::Int=1) where U
+@generated function _find_correct_type(g::AbstractGraph{T}) where T
+    TT = widen(T)
+    if typemax(TT) >= typemax(Int64)
+        TT = Int64
+    end
+    return :($TT)
+ end
+
+function _adjacency_matrix(g::AbstractGraph, T::DataType, neighborfn::Function, nzmult::Int=1)
     n_v = nv(g)
     nz = ne(g) * (is_directed(g) ? 1 : 2) * nzmult
-    colpt = ones(U, n_v + 1)
+    TT = _find_correct_type(g)
+    colpt = ones(TT, n_v + 1)
 
-    rowval = sizehint!(Vector{U}(), nz)
-    selfloops = Vector{U}()
+    rowval = sizehint!(Vector{TT}(), nz)
+    selfloops = Vector{TT}()
     for j in 1:n_v  # this is by column, not by row.
         if has_edge(g, j, j)
             push!(selfloops, j)

--- a/test/linalg/spectral.jl
+++ b/test/linalg/spectral.jl
@@ -97,8 +97,6 @@ Matrix(nbt::Nonbacktracking) = Matrix(sparse(nbt))
             T = eltype(g)
             amat = adjacency_matrix(g, Float64; dir=dir)
             lmat = laplacian_matrix(g, Float64; dir=dir)
-            @test isa(amat, SparseMatrixCSC{Float64,T})
-            @test isa(lmat, SparseMatrixCSC{Float64,T})
             evals = eigvals(Matrix(lmat))
             @test all(evals .>= -1e-15) # positive semidefinite
             @test (minimum(evals)) ≈ 0 atol = 1e-13


### PR DESCRIPTION
#1130
As suggested by @sbromberger , using ```Int``` as colptr for all graph types. Modified some existing tests to reflect this. I am not sure though, if it is worth sacrificing low memory usage for type stability ?