### PR TITLE
Add Kosaraju's Algorithm for finding Strongly Connected Components in a directed graph.

### DIFF
--- a/docs/src/pathing.md
+++ b/docs/src/pathing.md
@@ -61,6 +61,7 @@ is_strongly_connected
 is_weakly_connected
 connected_components
 strongly_connected_components
+strongly_connected_components_kosaraju
 weakly_connected_components
 has_self_loops
 attracting_components

--- a/src/LightGraphs.jl
+++ b/src/LightGraphs.jl
@@ -76,7 +76,7 @@ diffusion, diffusion_rate,
 greedy_color,
 
 # connectivity
-connected_components, strongly_connected_components, weakly_connected_components,
+connected_components, strongly_connected_components, strongly_connected_components_kosaraju, weakly_connected_components,
 is_connected, is_strongly_connected, is_weakly_connected, period,
 condensation, attracting_components, neighborhood, neighborhood_dists,
 isgraphical,

--- a/src/connectivity.jl
+++ b/src/connectivity.jl
@@ -364,7 +364,7 @@ function strongly_connected_components_kosaraju end
    dfs_stack = T[]   # Stack used for dfs
     
    # dfs1
-   for v in vertices(g)
+   @inbounds for v in vertices(g)
        
        color[v] != 0  && continue  
        color[v] = 1
@@ -395,13 +395,13 @@ function strongly_connected_components_kosaraju end
    end
     
     
-   for i = 1:nvg
+   @inbounds for i = 1:nvg
         color[i] = 0    # Marking all the vertices from 1 to n as unvisited for dfs2
    end
    
     
    # dfs2
-   for i in 1:nvg
+   @inbounds for i in 1:nvg
     
        v = order[end-i+1]   # Reading the order vector in the decreasing order of finish time
        color[v] != 0  && continue  

--- a/src/connectivity.jl
+++ b/src/connectivity.jl
@@ -283,6 +283,7 @@ function strongly_connected_components end
     return components
 end
 
+
 """
     strongly_connected_components_kosaraju(g)
 
@@ -292,17 +293,11 @@ Compute the strongly connected components of a directed graph `g` using Kosaraju
 Return an array of arrays, each of which is the entire connected component.
 
 ### Performance
-Time Complexity : O(|E|+|V|) 
+Time Complexity : O(|E|+|V|)
+Space Complexity : O(|V|) {Excluding the memory required for storing graph}
+
 |V| = Number of vertices
 |E| = Number of edges
-This algorithm requires 2 depth first search passes. Also the algorithm reverses the graph once after one dfs.
-At the end, the graph is reversed again to restore the original graph.
-Also, an iterative version of dfs is written so that this graph doesn't show "stackoverflow" when run on large 
-graphs.
-
-Space Complexity : O(|V|) 
-This memory is used for vectors named color, original, component and components. This space complexity 
-excludes the space required to store the graph.
 
 ### Examples
 ```jldoctest
@@ -310,14 +305,9 @@ excludes the space required to store the graph.
 julia> g=SimpleDiGraph(3)
 {3, 0} directed simple Int64 graph
 
-julia> edge_list=[(1,2),(2,3)]
-2-element Array{Tuple{Int64,Int64},1}:
- (1, 2)
- (2, 3)
+julia> g = SimpleDiGraph([0 1 0 ; 0 0 1; 0 0 0])
+{3, 2} directed simple Int64 graph
 
-julia> for e in edge_list
-           add_edge!(g, e[1], e[2])
-       end
 
 julia> strongly_connected_components_kosaraju(g)
 3-element Array{Array{Int64,1},1}:
@@ -325,37 +315,6 @@ julia> strongly_connected_components_kosaraju(g)
  [2]
  [3]
 
-
-julia> g=SimpleDiGraph(3)
-{3, 0} directed simple Int64 graph
-
-julia> edge_list=[(1,2),(2,3),(3,1)]
-3-element Array{Tuple{Int64,Int64},1}:
- (1, 2)
- (2, 3)
- (3, 1)
-
-julia> for e in edge_list
-           add_edge!(g, e[1], e[2])
-       end
-
-julia> strongly_connected_components_kosaraju(g)
-1-element Array{Array{Int64,1},1}:
- [2, 3, 1]
-
-
-julia> g=SimpleDiGraph(3)
-{3, 0} directed simple Int64 graph
-
-julia> edge_list=[(1,2),(2,3),(3,2)]
-3-element Array{Tuple{Int64,Int64},1}:
- (1, 2)
- (2, 3)
- (3, 2)
-
-julia> for e in edge_list
-           add_edge!(g, e[1], e[2])
-       end
 
 
 julia> g=SimpleDiGraph(11)
@@ -377,9 +336,8 @@ julia> edge_list=[(1,2),(2,3),(3,4),(4,1),(3,5),(5,6),(6,7),(7,5),(5,8),(8,9),(9
  (10, 11)
  (11, 10)
 
-julia> for e in edge_list
-           add_edge!(g, e[1], e[2])
-       end
+julia> g = SimpleDiGraph(Edge.(edge_list))
+{11, 13} directed simple Int64 graph
 
 julia> strongly_connected_components_kosaraju(g)
 4-element Array{Array{Int64,1},1}:

--- a/src/connectivity.jl
+++ b/src/connectivity.jl
@@ -392,12 +392,12 @@ function strongly_connected_components_kosaraju end
        end
    end
     
-   reverse!(g)   # Reverse the graph (Transpose of the graph) 
     
    for i = 1:nvg
         color[i] = 0    # Marking all the vertices from 1 to n as unvisited for dfs2
    end
    
+    
    # dfs2
    for i in 1:nvg
     
@@ -414,7 +414,7 @@ function strongly_connected_components_kosaraju end
            u = dfs_stack[end]
            w = zero(T)
        
-           for u_neighbor in outneighbors(g, u)
+           for u_neighbor in inneighbors(g, u)
                if  color[u_neighbor] == 0
                    w = u_neighbor
                    break
@@ -434,8 +434,7 @@ function strongly_connected_components_kosaraju end
        push!(components,component)
    end
  
-   reverse!(g)   # Restore the original graph (Transpose of the graph again) 
-
+    
    return components
 end
 

--- a/src/connectivity.jl
+++ b/src/connectivity.jl
@@ -350,12 +350,11 @@ julia> strongly_connected_components_kosaraju(g)
 """
 
 function strongly_connected_components_kosaraju end
-@traitfn function strongly_connected_components_kosaraju(g::AG::IsDirected) where {T, AG <: AbstractGraph{T}}
+@traitfn function strongly_connected_components_kosaraju(g::AG::IsDirected) where {T<:Integer, AG <: AbstractGraph{T}}
        
    nvg = nv(g)    
 
    components = Vector{Vector{T}}()    # Maintains a list of strongly connected components
-   sizehint!(components, nvg)
    
    order = Vector{T}()         # Vector which will store the order in which vertices are visited
    sizehint!(order, nvg)
@@ -369,15 +368,15 @@ function strongly_connected_components_kosaraju end
        color[v] = 1
        
        # Start dfs from v
-       dfs_stack = Vector{T}([v])   # Stack used for dfs. Also push v to the stack
+       dfs_stack = T[v]   # Stack used for dfs. Also push v to the stack
        
        while !isempty(dfs_stack)
            u = dfs_stack[end]
-           w = 0
+           w = zero(T)
        
-           for n in outneighbors(g, u)
-               if  color[n] == 0
-                   w = n
+           for u_neighbor in outneighbors(g, u)
+               if  color[u_neighbor] == 0
+                   w = u_neighbor
                    break
                end
            end
@@ -401,23 +400,23 @@ function strongly_connected_components_kosaraju end
    
    # dfs2
    for i in 1:nvg
-       
-       v = order[nvg-i+1]   # Reading the order vector in the decreasing order of finish time
+    
+       v = order[end-i+1]   # Reading the order vector in the decreasing order of finish time
        color[v] != 0  && continue  
        color[v] = 1
        
        component=Vector{T}()   # Vector used to store the vertices of one component temporarily
        
        # Start dfs from v
-       dfs_stack = Vector{T}([v])   # Stack used for dfs. Also push v to the stack
+       dfs_stack = T[v]   # Stack used for dfs. Also push v to the stack
        
        while !isempty(dfs_stack)
            u = dfs_stack[end]
-           w = 0
+           w = zero(T)
        
-           for n in outneighbors(g, u)
-               if  color[n] == 0
-                   w = n
+           for u_neighbor in outneighbors(g, u)
+               if  color[u_neighbor] == 0
+                   w = u_neighbor
                    break
                end
            end
@@ -439,6 +438,8 @@ function strongly_connected_components_kosaraju end
 
    return components
 end
+
+
 
 """
     is_strongly_connected(g)

--- a/src/connectivity.jl
+++ b/src/connectivity.jl
@@ -315,7 +315,6 @@ julia> strongly_connected_components_kosaraju(g)
  [3]
 
 
-
 julia> g=SimpleDiGraph(11)
 {11, 0} directed simple Int64 graph
 
@@ -430,7 +429,7 @@ function strongly_connected_components_kosaraju end
            end
        end
        
-       push!(components,component)
+       push!(components, component)
    end
  
    return components

--- a/src/connectivity.jl
+++ b/src/connectivity.jl
@@ -361,6 +361,8 @@ function strongly_connected_components_kosaraju end
    
    color = zeros(UInt8, nvg)       # Vector used as for marking the colors during dfs
    
+   dfs_stack = T[]   # Stack used for dfs
+    
    # dfs1
    for v in vertices(g)
        
@@ -368,7 +370,7 @@ function strongly_connected_components_kosaraju end
        color[v] = 1
        
        # Start dfs from v
-       dfs_stack = T[v]   # Stack used for dfs. Also push v to the stack
+       push!(dfs_stack,v)   # Push v to the stack
        
        while !isempty(dfs_stack)
            u = dfs_stack[end]
@@ -408,8 +410,8 @@ function strongly_connected_components_kosaraju end
        component=Vector{T}()   # Vector used to store the vertices of one component temporarily
        
        # Start dfs from v
-       dfs_stack = T[v]   # Stack used for dfs. Also push v to the stack
-       
+       push!(dfs_stack,v)   # Push v to the stack
+      
        while !isempty(dfs_stack)
            u = dfs_stack[end]
            w = zero(T)

--- a/src/connectivity.jl
+++ b/src/connectivity.jl
@@ -437,7 +437,6 @@ function strongly_connected_components_kosaraju end
 end
 
 
-
 """
     is_strongly_connected(g)
 

--- a/src/connectivity.jl
+++ b/src/connectivity.jl
@@ -308,7 +308,6 @@ julia> g=SimpleDiGraph(3)
 julia> g = SimpleDiGraph([0 1 0 ; 0 0 1; 0 0 0])
 {3, 2} directed simple Int64 graph
 
-
 julia> strongly_connected_components_kosaraju(g)
 3-element Array{Array{Int64,1},1}:
  [1]
@@ -357,11 +356,11 @@ function strongly_connected_components_kosaraju end
    components = Vector{Vector{T}}()    # Maintains a list of strongly connected components
    
    order = Vector{T}()         # Vector which will store the order in which vertices are visited
-   sizehint!(order, nvg)
+   sizehint!(order, nvg)    
    
    color = zeros(UInt8, nvg)       # Vector used as for marking the colors during dfs
    
-   dfs_stack = T[]   # Stack used for dfs
+   dfs_stack = Vector{T}()   # Stack used for dfs
     
    # dfs1
    @inbounds for v in vertices(g)
@@ -370,7 +369,7 @@ function strongly_connected_components_kosaraju end
        color[v] = 1
        
        # Start dfs from v
-       push!(dfs_stack,v)   # Push v to the stack
+       push!(dfs_stack, v)   # Push v to the stack
        
        while !isempty(dfs_stack)
            u = dfs_stack[end]
@@ -394,12 +393,10 @@ function strongly_connected_components_kosaraju end
        end
    end
     
-    
-   @inbounds for i = 1:nvg
+   @inbounds for i in vertices(g)
         color[i] = 0    # Marking all the vertices from 1 to n as unvisited for dfs2
    end
    
-    
    # dfs2
    @inbounds for i in 1:nvg
     
@@ -410,7 +407,7 @@ function strongly_connected_components_kosaraju end
        component=Vector{T}()   # Vector used to store the vertices of one component temporarily
        
        # Start dfs from v
-       push!(dfs_stack,v)   # Push v to the stack
+       push!(dfs_stack, v)   # Push v to the stack
       
        while !isempty(dfs_stack)
            u = dfs_stack[end]
@@ -428,7 +425,7 @@ function strongly_connected_components_kosaraju end
                color[w] = 1
            else
                color[u] = 2
-               push!(component,u)   # Push u to the vector component
+               push!(component, u)   # Push u to the vector component
                pop!(dfs_stack)    
            end
        end
@@ -436,7 +433,6 @@ function strongly_connected_components_kosaraju end
        push!(components,component)
    end
  
-    
    return components
 end
 

--- a/test/connectivity.jl
+++ b/test/connectivity.jl
@@ -62,9 +62,11 @@
     for g in testdigraphs(h)
         @test @inferred(is_weakly_connected(g))
         scc = @inferred(strongly_connected_components(g))
+        scc_k = @inferred(strongly_connected_components_kosaraju(g))
         wcc = @inferred(weakly_connected_components(g))
 
         @test length(scc) == 3 && sort(scc[3]) == [1, 2, 5]
+        @test length(scc_k) == 3 && sort(scc_k[1]) == [1, 2, 5]
         @test length(wcc) == 1 && length(wcc[1]) == nv(g)
     end
 
@@ -75,16 +77,26 @@
       scc_as_subgraphs = map(i -> graph[i], scc)
       return all(is_strongly_connected, scc_as_subgraphs)
     end
+    
+    function scc_k_ok(graph)
+      """Check that all SCC really are strongly connected"""
+      scc_k = @inferred(strongly_connected_components_kosaraju(graph))
+      scc_k_as_subgraphs = map(i -> graph[i], scc_k)
+      return all(is_strongly_connected, scc_k_as_subgraphs)
+    end
 
     # the two graphs below are isomorphic (exchange 2 <--> 4)
     h = SimpleDiGraph(4);  add_edge!(h, 1, 4); add_edge!(h, 4, 2); add_edge!(h, 2, 3); add_edge!(h, 1, 3);
     for g in testdigraphs(h)
       @test scc_ok(g)
+      @test scc_k_ok(g)
+        
     end
 
     h2 = SimpleDiGraph(4); add_edge!(h2, 1, 2); add_edge!(h2, 2, 4); add_edge!(h2, 4, 3); add_edge!(h2, 1, 3);
     for g in testdigraphs(h2)
       @test scc_ok(g)
+      @test scc_k_ok(g)
     end
 
     h = SimpleDiGraph(6)
@@ -92,14 +104,18 @@
     add_edge!(h, 3, 5); add_edge!(h, 5, 6); add_edge!(h, 6, 4)
     for g in testdigraphs(h)
       scc = @inferred(strongly_connected_components(g))
+      scc_k = @inferred(strongly_connected_components_kosaraju(g))
       @test length(scc) == 1 && sort(scc[1]) == [1:6;]
+      @test length(scc_k) == 1 && sort(scc_k[1]) == [1:6;]
     end
     # tests from Graphs.jl
     h = SimpleDiGraph(4)
     add_edge!(h, 1, 2); add_edge!(h, 2, 3); add_edge!(h, 3, 1); add_edge!(h, 4, 1)
     for g in testdigraphs(h)
       scc = @inferred(strongly_connected_components(g))
+      scc_k = @inferred(strongly_connected_components_kosaraju(g))
       @test length(scc) == 2 && sort(scc[1]) == [1:3;] && sort(scc[2]) == [4]
+      @test length(scc_k) == 2 && sort(scc_k[2]) == [1:3;] && sort(scc[1]) == [4]
     end
 
     h = SimpleDiGraph(12)
@@ -111,12 +127,20 @@
 
     for g in testdigraphs(h)
       scc = @inferred(strongly_connected_components(g))
+      scc_k = @inferred(strongly_connected_components_kosaraju(g))
       @test length(scc) == 4
       @test sort(scc[1]) == [7, 8, 9, 10, 11, 12]
       @test sort(scc[2]) == [3, 6]
       @test sort(scc[3]) == [2, 4, 5]
       @test scc[4] == [1]
+        
+      @test length(scc_k) == 4
+      @test sort(scc_k[1]) ==  [1] 
+      @test sort(scc_k[2]) ==  [4, 5, 2] 
+      @test sort(scc_k[3]) ==  [6, 3]  
+      @test scc_k[4] ==  [11, 12, 10, 9, 7, 8]
     end
+
     # Test examples with self-loops from
     # Graph-Theoretic Analysis of Finite Markov Chains by J.P. Jarvis & D. R. Shier
 

--- a/test/connectivity.jl
+++ b/test/connectivity.jl
@@ -138,7 +138,7 @@
       @test sort(scc_k[1]) ==  [1] 
       @test sort(scc_k[2]) ==  [2, 4 ,5] 
       @test sort(scc_k[3]) ==  [3, 6]  
-      @test scc_k[4] ==  [11, 12, 10, 9, 7, 8]
+      @test sort(scc_k[4]) ==  [7, 8, 9, 10, 11, 12]
     end
 
     # Test examples with self-loops from

--- a/test/connectivity.jl
+++ b/test/connectivity.jl
@@ -115,7 +115,7 @@
       scc = @inferred(strongly_connected_components(g))
       scc_k = @inferred(strongly_connected_components_kosaraju(g))
       @test length(scc) == 2 && sort(scc[1]) == [1:3;] && sort(scc[2]) == [4]
-      @test length(scc_k) == 2 && sort(scc_k[2]) == [1:3;] && sort(scc_[1]) == [4]
+      @test length(scc_k) == 2 && sort(scc_k[2]) == [1:3;] && sort(scc_k[1]) == [4]
     end
 
     h = SimpleDiGraph(12)

--- a/test/connectivity.jl
+++ b/test/connectivity.jl
@@ -115,7 +115,7 @@
       scc = @inferred(strongly_connected_components(g))
       scc_k = @inferred(strongly_connected_components_kosaraju(g))
       @test length(scc) == 2 && sort(scc[1]) == [1:3;] && sort(scc[2]) == [4]
-      @test length(scc_k) == 2 && sort(scc_k[2]) == [1:3;] && sort(scc[1]) == [4]
+      @test length(scc_k) == 2 && sort(scc_k[2]) == [1:3;] && sort(scc_[1]) == [4]
     end
 
     h = SimpleDiGraph(12)
@@ -136,8 +136,8 @@
         
       @test length(scc_k) == 4
       @test sort(scc_k[1]) ==  [1] 
-      @test sort(scc_k[2]) ==  [4, 5, 2] 
-      @test sort(scc_k[3]) ==  [6, 3]  
+      @test sort(scc_k[2]) ==  [2, 4 ,5] 
+      @test sort(scc_k[3]) ==  [3, 6]  
       @test scc_k[4] ==  [11, 12, 10, 9, 7, 8]
     end
 

--- a/test/connectivity.jl
+++ b/test/connectivity.jl
@@ -99,6 +99,45 @@
       @test scc_k_ok(g)
     end
 
+    
+    #Test case for empty graph
+    h = SimpleDiGraph(0)
+    for g in testdigraphs(h)
+      scc = @inferred(strongly_connected_components(g))
+      scc_k = @inferred(strongly_connected_components_kosaraju(g))
+      @test length(scc) == 0
+      @test length(scc_k) == 0 
+    end    
+
+
+    #Test case for graph with one vertex
+    h = SimpleDiGraph(1)
+    for g in testdigraphs(h)
+      scc = @inferred(strongly_connected_components(g))
+      scc_k = @inferred(strongly_connected_components_kosaraju(g))
+      @test length(scc) == 1 && scc[1] == [1]
+      @test length(scc_k) == 1 && scc[1] == [1]
+    end    
+ 
+
+    #Test case for graph with self loops
+    h = SimpleDiGraph(3);
+    add_edge!(h, 1, 1); add_edge!(h, 2, 2); add_edge!(h, 3, 3); 
+    add_edge!(h, 1, 2); add_edge!(h, 2, 3); add_edge!(h, 2, 1);
+
+    for g in testdigraphs(h)
+      scc = @inferred(strongly_connected_components(g))
+      scc_k = @inferred(strongly_connected_components_kosaraju(g))
+      @test length(scc) == 2 
+      @test sort(scc[1]) == [3]
+      @test sort(scc[2]) == [1,2]
+    
+      @test length(scc_k) == 2 
+      @test sort(scc_k[1]) == [1,2]
+      @test sort(scc_k[2]) == [3]
+    end
+    
+    
     h = SimpleDiGraph(6)
     add_edge!(h, 1, 3); add_edge!(h, 3, 4); add_edge!(h, 4, 2); add_edge!(h, 2, 1)
     add_edge!(h, 3, 5); add_edge!(h, 5, 6); add_edge!(h, 6, 4)

--- a/test/connectivity.jl
+++ b/test/connectivity.jl
@@ -72,14 +72,14 @@
 
 
     function scc_ok(graph)
-      """Check that all SCC really are strongly connected"""
+      #Check that all SCC really are strongly connected
       scc = @inferred(strongly_connected_components(graph))
       scc_as_subgraphs = map(i -> graph[i], scc)
       return all(is_strongly_connected, scc_as_subgraphs)
     end
     
     function scc_k_ok(graph)
-      """Check that all SCC really are strongly connected"""
+      #Check that all SCC really are strongly connected
       scc_k = @inferred(strongly_connected_components_kosaraju(graph))
       scc_k_as_subgraphs = map(i -> graph[i], scc_k)
       return all(is_strongly_connected, scc_k_as_subgraphs)


### PR DESCRIPTION
This implementation runs faster as compared to the current implementation in src/connectivity.jl.
Some benchmarks on SNAPDatasets :
```
julia> eg = SimpleDiGraph{Int32}(loadsnap(:ego_twitter_d));

julia> @benchmark strongly_connected_components_kosaraju(eg)
BenchmarkTools.Trial: 
  memory estimate:  6.08 MiB
  allocs estimate:  49450
  --------------
  minimum time:     35.088 ms (0.00% GC)
  median time:      37.437 ms (0.00% GC)
  mean time:        37.453 ms (1.64% GC)
  maximum time:     41.985 ms (4.95% GC)
  --------------
  samples:          134
  evals/sample:     1

julia> @benchmark strongly_connected_components(eg)
BenchmarkTools.Trial: 
  memory estimate:  2.30 GiB
  allocs estimate:  36776
  --------------
  minimum time:     92.271 ms (57.10% GC)
  median time:      98.682 ms (58.91% GC)
  mean time:        106.764 ms (61.84% GC)
  maximum time:     196.805 ms (78.53% GC)
  --------------
  samples:          48
  evals/sample:     1
```
```
julia> ss = SimpleDiGraph{Int32}(loadsnap(:soc_slashdot0902_d));

julia> @benchmark strongly_connected_components(ss)
BenchmarkTools.Trial: 
  memory estimate:  1.70 GiB
  allocs estimate:  31705
  --------------
  minimum time:     86.266 ms (44.07% GC)
  median time:      90.336 ms (46.22% GC)
  mean time:        98.146 ms (49.64% GC)
  maximum time:     181.922 ms (73.07% GC)
  --------------
  samples:          51
  evals/sample:     1

julia> @benchmark strongly_connected_components_kosaraju(ss)
BenchmarkTools.Trial: 
  memory estimate:  5.34 MiB
  allocs estimate:  42541
  --------------
  minimum time:     42.838 ms (0.00% GC)
  median time:      44.965 ms (0.00% GC)
  mean time:        45.110 ms (1.03% GC)
  maximum time:     49.870 ms (3.12% GC)
  --------------
  samples:          111
  evals/sample:     1
```