### PR TITLE
Time and memory efficient Tarjan's algorithm for strongly connected components in a directed graph 

### DIFF
--- a/src/connectivity.jl
+++ b/src/connectivity.jl
@@ -247,8 +247,7 @@ function strongly_connected_components end
     lowlink = zeros(T, nvg)       # lowest index vertex that it can reach through back edge (index array not vertex id number)
     parents = zeros(T, nvg)       # parent of every vertex in dfs
     components = Vector{Vector{T}}()    # maintains a list of scc (order is not guaranteed in API)
-    #sizehint!(stack, nvg)
-    #sizehint!(components, nvg)
+
 
     dfs_stack = T[]
     
@@ -288,7 +287,7 @@ function strongly_connected_components end
                     if index[v] == lowlink[v]
                         # found a cycle in a completed dfs tree.
                         component = Vector{T}()
-                        #sizehint!(component, length(stack))
+                        
                         while !isempty(stack) #break when popped == v
                             # drain stack until we see v.
                             # everything on the stack until we see v is in the SCC rooted at v.
@@ -320,9 +319,6 @@ function strongly_connected_components end
 
     return components
 end
-
-
-
 
 
 

--- a/src/connectivity.jl
+++ b/src/connectivity.jl
@@ -223,7 +223,7 @@ julia> edge_list=[(1,2),(2,3),(3,4),(4,1),(3,5),(5,6),(6,7),(7,5),(5,8),(8,9),(9
 julia> g = SimpleDiGraph(Edge.(edge_list))
 {11, 13} directed simple Int64 graph
 
-julia> strongly_connected_components_kosaraju(g)
+julia> strongly_connected_components(g)
 4-element Array{Array{Int64,1},1}:
  [8, 9]      
  [5, 6, 7]   
@@ -232,7 +232,6 @@ julia> strongly_connected_components_kosaraju(g)
 
 ```
 """
-
 function strongly_connected_components end
 # see https://github.com/mauro3/SimpleTraits.jl/issues/47#issuecomment-327880153 for syntax
 @traitfn function strongly_connected_components(g::AG::IsDirected) where {T<:Integer, AG <: AbstractGraph{T}}

--- a/src/connectivity.jl
+++ b/src/connectivity.jl
@@ -225,6 +225,7 @@ function strongly_connected_components end
     nvg = nv(g)
     count = one_t
     
+    
     index = zeros(T, nvg)         # first time in which vertex is discovered
     stack = Vector{T}()           # stores vertices which have been discovered and not yet assigned to any component
     onstack = zeros(Bool, nvg)    # false if a vertex is waiting in the stack to receive a component assignment
@@ -232,7 +233,7 @@ function strongly_connected_components end
     parents = zeros(T, nvg)       # parent of every vertex in dfs
     components = Vector{Vector{T}}()    # maintains a list of scc (order is not guaranteed in API)
 
-
+    
     dfs_stack = Vector{T}()
     
     @inbounds for s in vertices(g)
@@ -245,7 +246,8 @@ function strongly_connected_components end
             count = count + one_t
 
             # start dfs from 's'
-            push!(dfs_stack,s) 
+            push!(dfs_stack, s) 
+            
             while !isempty(dfs_stack)
                 v = dfs_stack[end] #end is the most recently added item
                 u = zero_t
@@ -268,6 +270,7 @@ function strongly_connected_components end
                     # time to start popping.
                     popped = pop!(dfs_stack)
                     lowlink[parents[popped]] = min(lowlink[parents[popped]], lowlink[popped])
+                    
                     if index[v] == lowlink[v]
                         # found a cycle in a completed dfs tree.
                         component = Vector{T}()
@@ -284,9 +287,11 @@ function strongly_connected_components end
                                 break
                             end
                         end
+                        
                         reverse!(component)
                         push!(components, component)
                     end
+                    
                 else #LABEL A
                     # add unvisited neighbor to dfs
                     index[u] = count
@@ -294,6 +299,7 @@ function strongly_connected_components end
                     onstack[u] = true
                     parents[u] = v
                     count = count + one_t
+                    
                     push!(stack, u)
                     push!(dfs_stack, u)
                     # next iteration of while loop will expand the DFS tree from u.

--- a/src/connectivity.jl
+++ b/src/connectivity.jl
@@ -199,9 +199,39 @@ julia> strongly_connected_components(g)
 2-element Array{Array{Int64,1},1}:
  [3]
  [1, 2]
+
+
+julia> g=SimpleDiGraph(11)
+{11, 0} directed simple Int64 graph
+
+julia> edge_list=[(1,2),(2,3),(3,4),(4,1),(3,5),(5,6),(6,7),(7,5),(5,8),(8,9),(9,8),(10,11),(11,10)]
+13-element Array{Tuple{Int64,Int64},1}:
+ (1, 2)  
+ (2, 3)  
+ (3, 4)  
+ (4, 1)  
+ (3, 5)  
+ (5, 6)  
+ (6, 7)  
+ (7, 5)  
+ (5, 8)  
+ (8, 9)  
+ (9, 8)  
+ (10, 11)
+ (11, 10)
+
+julia> g = SimpleDiGraph(Edge.(edge_list))
+{11, 13} directed simple Int64 graph
+
+julia> strongly_connected_components_kosaraju(g)
+4-element Array{Array{Int64,1},1}:
+ [8, 9]      
+ [5, 6, 7]   
+ [1, 2, 3, 4]
+ [10, 11]    
+
 ```
 """
-
 
 function strongly_connected_components end
 # see https://github.com/mauro3/SimpleTraits.jl/issues/47#issuecomment-327880153 for syntax

--- a/src/connectivity.jl
+++ b/src/connectivity.jl
@@ -204,21 +204,7 @@ julia> strongly_connected_components(g)
 julia> g=SimpleDiGraph(11)
 {11, 0} directed simple Int64 graph
 
-julia> edge_list=[(1,2),(2,3),(3,4),(4,1),(3,5),(5,6),(6,7),(7,5),(5,8),(8,9),(9,8),(10,11),(11,10)]
-13-element Array{Tuple{Int64,Int64},1}:
- (1, 2)  
- (2, 3)  
- (3, 4)  
- (4, 1)  
- (3, 5)  
- (5, 6)  
- (6, 7)  
- (7, 5)  
- (5, 8)  
- (8, 9)  
- (9, 8)  
- (10, 11)
- (11, 10)
+julia> edge_list=[(1,2),(2,3),(3,4),(4,1),(3,5),(5,6),(6,7),(7,5),(5,8),(8,9),(9,8),(10,11),(11,10)];
 
 julia> g = SimpleDiGraph(Edge.(edge_list))
 {11, 13} directed simple Int64 graph

--- a/src/connectivity.jl
+++ b/src/connectivity.jl
@@ -300,7 +300,7 @@ function strongly_connected_components end
                                 break
                             end
                         end
-                        push!(components, reverse(component))
+                        push!(components, reverse!(component))
                     end
                 else #LABEL A
                     # add unvisited neighbor to dfs

--- a/src/connectivity.jl
+++ b/src/connectivity.jl
@@ -179,8 +179,6 @@ true
 is_weakly_connected(g) = is_connected(g)
 
 
-
-
 """
     strongly_connected_components(g)
 
@@ -218,6 +216,7 @@ julia> strongly_connected_components(g)
 
 ```
 """
+
 function strongly_connected_components end
 # see https://github.com/mauro3/SimpleTraits.jl/issues/47#issuecomment-327880153 for syntax
 @traitfn function strongly_connected_components(g::AG::IsDirected) where {T<:Integer, AG <: AbstractGraph{T}}
@@ -227,7 +226,7 @@ function strongly_connected_components end
     count = one_t
     
     index = zeros(T, nvg)         # first time in which vertex is discovered
-    stack = Vector{T}()                   # stores vertices which have been discovered and not yet assigned to any component
+    stack = Vector{T}()           # stores vertices which have been discovered and not yet assigned to any component
     onstack = zeros(Bool, nvg)    # false if a vertex is waiting in the stack to receive a component assignment
     lowlink = zeros(T, nvg)       # lowest index vertex that it can reach through back edge (index array not vertex id number)
     parents = zeros(T, nvg)       # parent of every vertex in dfs
@@ -285,7 +284,8 @@ function strongly_connected_components end
                                 break
                             end
                         end
-                        push!(components, reverse!(component))
+                        reverse!(component)
+                        push!(components, component)
                     end
                 else #LABEL A
                     # add unvisited neighbor to dfs
@@ -304,7 +304,6 @@ function strongly_connected_components end
 
     return components
 end
-
 
 
 """

--- a/src/connectivity.jl
+++ b/src/connectivity.jl
@@ -242,14 +242,14 @@ function strongly_connected_components end
     count = one_t
     
     index = zeros(T, nvg)         # first time in which vertex is discovered
-    stack = T[]                   # stores vertices which have been discovered and not yet assigned to any component
+    stack = Vector{T}()                   # stores vertices which have been discovered and not yet assigned to any component
     onstack = zeros(Bool, nvg)    # false if a vertex is waiting in the stack to receive a component assignment
     lowlink = zeros(T, nvg)       # lowest index vertex that it can reach through back edge (index array not vertex id number)
     parents = zeros(T, nvg)       # parent of every vertex in dfs
     components = Vector{Vector{T}}()    # maintains a list of scc (order is not guaranteed in API)
 
 
-    dfs_stack = T[]
+    dfs_stack = Vector{T}()
     
     @inbounds for s in vertices(g)
         if index[s] == zero_t


### PR DESCRIPTION
Making some small changes makes the current implementation of strongly_connected_components() 4-5 times faster and requires 500 times lesser memory. 

Acknowledgement : @simonschoelly helped me in figuring out what is wrong with the current implementation.
 
Some benchmarks :
```
julia> eg = SimpleDiGraph{Int32}(loadsnap(:ego_twitter_d));

##Current implementation
julia> @benchmark strongly_connected_components(eg)
BenchmarkTools.Trial: 
  memory estimate:  2.30 GiB
  allocs estimate:  36776
  --------------
  minimum time:     102.059 ms (59.44% GC)
  median time:      115.630 ms (60.22% GC)
  mean time:        123.090 ms (62.91% GC)
  maximum time:     214.746 ms (78.27% GC)
  --------------
  samples:          41
  evals/sample:     1

##Proposed implementation
julia> @benchmark strongly_connected_components(eg)
BenchmarkTools.Trial: 
  memory estimate:  4.82 MiB
  allocs estimate:  24598
  --------------
  minimum time:     26.544 ms (0.00% GC)
  median time:      27.205 ms (0.00% GC)
  mean time:        27.964 ms (1.41% GC)
  maximum time:     36.095 ms (6.22% GC)
  --------------
  samples:          179
  evals/sample:     1

```

```
julia> ss = SimpleDiGraph{Int32}(loadsnap(:soc_slashdot0902_d));

##Current implementation
julia> @benchmark strongly_connected_components(ss)
BenchmarkTools.Trial: 
  memory estimate:  1.70 GiB
  allocs estimate:  31705
  --------------
  minimum time:     116.306 ms (54.33% GC)
  median time:      122.452 ms (54.30% GC)
  mean time:        130.374 ms (56.26% GC)
  maximum time:     214.087 ms (72.84% GC)
  --------------
  samples:          39
  evals/sample:     1


##Proposed implementation
julia> @benchmark strongly_connected_components(ss)
BenchmarkTools.Trial: 
  memory estimate:  4.52 MiB
  allocs estimate:  21190
  --------------
  minimum time:     34.608 ms (0.00% GC)
  median time:      35.258 ms (0.00% GC)
  mean time:        36.028 ms (0.86% GC)
  maximum time:     40.149 ms (4.55% GC)
  --------------
  samples:          139
  evals/sample:     1
```
