### PR TITLE
Floyd Warshall which indicates negative weight cycles on the path between 2 vertices

### DIFF
--- a/src/shortestpaths/floyd-warshall.jl
+++ b/src/shortestpaths/floyd-warshall.jl
@@ -103,6 +103,7 @@ function floyd_warshall_shortest_paths(
     return fws
 end
 
+
 function enumerate_paths(s::FloydWarshallState{T,U}, v::Integer) where T where U<:Integer
     pathinfo = s.parents[v, :]
     paths = Vector{Vector{U}}()
@@ -111,10 +112,14 @@ function enumerate_paths(s::FloydWarshallState{T,U}, v::Integer) where T where U
             push!(paths, Vector{U}())
         else
             path = Vector{U}()
-            currpathindex = i
+            currpathindex = U(i)
             while currpathindex != 0
                 push!(path, currpathindex)
-                currpathindex = pathinfo[currpathindex]
+                if pathinfo[currpathindex] == currpathindex
+                    currpathindex = zero(currpathindex)
+                else
+                    currpathindex = pathinfo[currpathindex]
+                end
             end
             push!(paths, reverse(path))
         end

--- a/src/shortestpaths/floyd-warshall.jl
+++ b/src/shortestpaths/floyd-warshall.jl
@@ -89,14 +89,10 @@ function floyd_warshall_shortest_paths(
     end
 
     #If dists[i,j] is negative, it means that there is a negative cycle in going from i to j
-    @inbounds for i=1:nvg
-        @inbounds for j=1:nvg
-            @inbounds for t = 1:nvg
-                if (dists[i,t] < typemax(T)) && (dists[t,t] < 0) && (dists[t,j] < typemax(T))
-                    dists[i,j] = - typemax(T)
-                end
-            end
-        end
+    @inbounds for i in vertices(g) , j in vertices(g) , k in vertices(g) 
+         if (dists[i,t] < typemax(T)) && (dists[t,t] < 0) && (dists[t,j] < typemax(T))
+               dists[i,j] = - typemax(T)
+         end
     end
 
     fws = FloydWarshallState(dists, parents)

--- a/src/shortestpaths/floyd-warshall.jl
+++ b/src/shortestpaths/floyd-warshall.jl
@@ -119,10 +119,14 @@ function enumerate_paths(s::FloydWarshallState{T,U}, v::Integer) where T where U
             push!(paths, Vector{U}())
         else
             path = Vector{U}()
-            currpathindex = i
+            currpathindex = U(i)
             while currpathindex != 0
                 push!(path, currpathindex)
-                currpathindex = pathinfo[currpathindex]
+                if pathinfo[currpathindex] == currpathindex
+                    currpathindex = zero(currpathindex)
+                else
+                    currpathindex = pathinfo[currpathindex]
+                end
             end
             push!(paths, reverse(path))
         end

--- a/src/shortestpaths/floyd-warshall.jl
+++ b/src/shortestpaths/floyd-warshall.jl
@@ -17,6 +17,31 @@ optional distance matrix `distmx`. Return a [`LightGraphs.FloydWarshallState`](@
 traversal information.
 ### Performance
 Space complexity is on the order of ``\\mathcal{O}(|V|^2)``.
+Example :
+
+julia> g= SimpleWeightedDiGraph(5);
+
+julia> add_edge!(g,1,2,1); add_edge!(g,2,3,-2); add_edge!(g,3,4,-3); add_edge!(g,4,2,-4); add_edge!(g,3,5,5);
+
+julia> a=floyd_warshall_shortest_paths(g);
+
+julia> a.dists
+5×5 Array{Float64,2}:
+   0.0  -Inf  -Inf  -Inf  -Inf
+ Inf    -Inf  -Inf  -Inf  -Inf
+ Inf    -Inf  -Inf  -Inf  -Inf
+ Inf    -Inf  -Inf  -Inf  -Inf
+ Inf     Inf   Inf   Inf    0.0
+
+julia> a.parents
+5×5 Array{Int64,2}:
+ 0  4  2  3  3
+ 0  4  2  3  3
+ 0  4  2  3  3
+ 0  4  2  3  3
+ 0  0  0  0  0
+
+
 """
 function floyd_warshall_shortest_paths(
     g::AbstractGraph{U},
@@ -54,7 +79,7 @@ function floyd_warshall_shortest_paths(
             d == typemax(T) && continue
             p = parents[pivot, v]
             for u in vertices(g)
-                ans = (dists[u, pivot] == typemax(T) ? typemax(T) : dists[u, pivot] + d) 
+                ans = (dists[u, pivot] == typemax(T) ? typemax(T) : dists[u, pivot] + d)
                 if dists[u, v] > ans
                     dists[u, v] = ans
                     parents[u, v] = p

--- a/src/shortestpaths/floyd-warshall.jl
+++ b/src/shortestpaths/floyd-warshall.jl
@@ -2,7 +2,6 @@
 # licensing details.
 """
     struct FloydWarshallState{T, U}
-
 An [`AbstractPathState`](@ref) designed for Floyd-Warshall shortest-paths calculations.
 """
 struct FloydWarshallState{T,U<:Integer} <: AbstractPathState
@@ -12,12 +11,10 @@ end
 
 @doc """
     floyd_warshall_shortest_paths(g, distmx=weights(g))
-
 Use the [Floyd-Warshall algorithm](http://en.wikipedia.org/wiki/Floyd–Warshall_algorithm)
 to compute the shortest paths between all pairs of vertices in graph `g` using an
 optional distance matrix `distmx`. Return a [`LightGraphs.FloydWarshallState`](@ref) with relevant
 traversal information.
-
 ### Performance
 Space complexity is on the order of ``\\mathcal{O}(|V|^2)``.
 """
@@ -65,6 +62,18 @@ function floyd_warshall_shortest_paths(
             end
         end
     end
+
+    #If dists[i,j] is negative, it means that there is a negative cycle in going from i to j
+    @inbounds for i=1:nvg
+        @inbounds for j=1:nvg
+            @inbounds for t = 1:nvg
+                if (dists[i,t] < typemax(T)) && (dists[t,t] < 0) && (dists[t,j] < typemax(T))
+                    dists[i,j] = - typemax(T)
+                end
+            end
+        end
+    end
+
     fws = FloydWarshallState(dists, parents)
     return fws
 end
@@ -77,14 +86,10 @@ function enumerate_paths(s::FloydWarshallState{T,U}, v::Integer) where T where U
             push!(paths, Vector{U}())
         else
             path = Vector{U}()
-            currpathindex = U(i)
+            currpathindex = i
             while currpathindex != 0
                 push!(path, currpathindex)
-                if pathinfo[currpathindex] == currpathindex
-                    currpathindex = zero(currpathindex)
-                else
-                    currpathindex = pathinfo[currpathindex]
-                end
+                currpathindex = pathinfo[currpathindex]
             end
             push!(paths, reverse(path))
         end


### PR DESCRIPTION
In case there is a negative weight cycle on the path from a vertex `i` to vertex `j` , then the shortest distance between them doesn't exist or we can say it is `-Inf` as we can cover negative weight cycle infinitely many times in the path to shorten the path.

The current implementation of Floyd Warshall gives incorrect result in case of negative weight cycles. It gives an arbitrary negative value as the answer which is wrong.

I have added some code which shows the distance between a vertex `i` and vertex `j` to be `-Inf` if there is a negative weight cycle in a path from `i` to `j`. The weight `-Inf` can also be an indicator to identify such pair of vertices between which a path having a negative weight cycle exists.

An illustration : 

Current implementation:
```
julia> g= SimpleWeightedDiGraph(5)
{5, 0} directed simple Int64 graph with Float64 weights

julia> add_edge!(g,1,2,1); add_edge!(g,2,3,-2); add_edge!(g,3,4,-3); add_edge!(g,4,2,-4); add_edge!(g,3,5,5);

julia> a=floyd_warshall_shortest_paths(g)
LightGraphs.FloydWarshallState{Float64,Int64}([0.0 -8.0 … -13.0 -14.0; Inf -9.0 … -14.0 -15.0; … ; Inf -13.0 … -18.0 -19.0; Inf Inf … Inf 0.0], [0 4 … 3 3; 0 4 … 3 3; … ; 0 4 … 3 3; 0 0 … 0 0])

julia> a.dists
5×5 Array{Float64,2}:
   0.0   -8.0  -10.0  -13.0  -14.0
 Inf     -9.0  -11.0  -14.0  -15.0
 Inf     -7.0   -9.0  -12.0  -13.0
 Inf    -13.0  -15.0  -18.0  -19.0
 Inf    Inf    Inf    Inf      0.0

```

Proposed implementation:
```
julia> g= SimpleWeightedDiGraph(5)
{5, 0} directed simple Int64 graph with Float64 weights

julia> add_edge!(g,1,2,1); add_edge!(g,2,3,-2); add_edge!(g,3,4,-3); add_edge!(g,4,2,-4); add_edge!(g,3,5,5);

julia> a=floyd_warshall_shortest_paths(g)
LightGraphs.FloydWarshallState{Float64,Int64}([0.0 -Inf … -Inf -Inf; Inf -Inf … -Inf -Inf; … ; Inf -Inf … -Inf -Inf; Inf Inf … Inf 0.0], [0 4 … 3 3; 0 4 … 3 3; … ; 0 4 … 3 3; 0 0 … 0 0])

julia> a.dists
5×5 Array{Float64,2}:
   0.0  -Inf  -Inf  -Inf  -Inf  
 Inf    -Inf  -Inf  -Inf  -Inf  
 Inf    -Inf  -Inf  -Inf  -Inf  
 Inf    -Inf  -Inf  -Inf  -Inf  
 Inf     Inf   Inf   Inf     0.0

```