### PR TITLE
Add Shortest Path Faster Algorithm for calculating single source shortest path 

### DIFF
--- a/docs/src/pathing.md
+++ b/docs/src/pathing.md
@@ -116,6 +116,7 @@ desopo_pape_shortest_paths
 bellman_ford_shortest_paths
 floyd_warshall_shortest_paths
 yen_k_shortest_paths
+spfa_shortest_paths
 ```
 
 ## Path discovery / enumeration
@@ -134,9 +135,9 @@ LightGraphs.AbstractPathState
 ```
 
 The `dijkstra_shortest_paths`, `floyd_warshall_shortest_paths`,
-`bellman_ford_shortest_paths`, and `yen_shortest_paths` functions 
+`bellman_ford_shortest_paths`, and `yen_shortest_paths` functions
 return states that contain various  information about the graph
-learned during traversal. 
+learned during traversal.
 
 ```@docs
 LightGraphs.DijkstraState

--- a/src/LightGraphs.jl
+++ b/src/LightGraphs.jl
@@ -89,10 +89,10 @@ simplecycles_limited_length,
 # maximum_adjacency_visit
 mincut, maximum_adjacency_visit,
 
-# a-star, dijkstra, bellman-ford, floyd-warshall, desopo-pape
+# a-star, dijkstra, bellman-ford, floyd-warshall, desopo-pape, spfa
 a_star, dijkstra_shortest_paths, bellman_ford_shortest_paths,
-has_negative_edge_cycle, enumerate_paths, johnson_shortest_paths,
-floyd_warshall_shortest_paths, transitiveclosure!, transitiveclosure, transitivereduction, 
+spfa_shortest_paths,has_negative_edge_cycle_spfa,has_negative_edge_cycle, enumerate_paths,
+johnson_shortest_paths, floyd_warshall_shortest_paths, transitiveclosure!, transitiveclosure, transitivereduction,
 yen_k_shortest_paths, desopo_pape_shortest_paths,
 
 # centrality
@@ -227,6 +227,7 @@ include("shortestpaths/johnson.jl")
 include("shortestpaths/desopo-pape.jl")
 include("shortestpaths/floyd-warshall.jl")
 include("shortestpaths/yen.jl")
+include("shortestpaths/spfa.jl")
 include("linalg/LinAlg.jl")
 include("operators.jl")
 include("persistence/common.jl")

--- a/src/shortestpaths/spfa.jl
+++ b/src/shortestpaths/spfa.jl
@@ -16,44 +16,26 @@ Compute shortest paths between a source `s` and all
 other nodes in graph `g` using the [Shortest Path Faster Algorithm]
 (https://en.wikipedia.org/wiki/Shortest_Path_Faster_Algorithm).
 
-# Examples
-```jldoctest
-julia> g = CompleteGraph(3);
 
-julia> d = [1 -3 1; -3 1 1; 1 1 1];
-
-julia> spfa_shortest_paths(g, 1, d)
-ERROR: LightGraphs.NegativeCycleError()
-
-
-julia> g = CompleteGraph(4);
-
-julia> d = [1 1 -1 1; 1 1 -1 1; 1 1 1 1; 1 1 1 1];
-
-julia> spfa_shortest_paths(gx, 1, d)
-4-element Array{Int64,1}:
-  0
-  0
- -1
-  0
-```
 """
+
 function spfa_shortest_paths(
     graph::AbstractGraph{U},
     source::Integer,
     distmx::AbstractMatrix{T}=weights(graph)
     ) where T<:Real where U<:Integer
 
+
     nvg = nv(graph)
 
-    (source in 1:nvg) || throw(DomainError(source, "source should be in between 1 and $nvg"))
-    dists = fill(typemax(T), nvg)
+    (source in vertices(g)) || throw(DomainError(source, "source should be in between 1 and $nvg"))
+    dists = fill(typemax(T),nvg)
     dists[source] = 0
 
     count = zeros(U, nvg)           # Vector to store the count of number of times a vertex goes in the queue.
 
     queue = Vector{U}()             # Vector used to implement queue
-    inqueue = zeros(Bool, nvg)      # Vector to mark which vertices are in queue
+    inqueue = falses(nvg,1)         # BitArray to mark which vertices are in queue
     push!(queue, source)
     inqueue[source] = true
 
@@ -62,18 +44,19 @@ function spfa_shortest_paths(
         inqueue[v] = false
 
         @inbounds for v_neighbor in outneighbors(graph,v)
-            if dists[v] + distmx[v,v_neighbor] < dists[v_neighbor]      # Relaxing edges
-                dists[v_neighbor] = dists[v] + distmx[v,v_neighbor]
+            d = distmx[v,v_neighbor]
+            if dists[v] + d < dists[v_neighbor]      # Relaxing edges
+                dists[v_neighbor] = dists[v] + d
 
                 if !inqueue[v_neighbor]
                     push!(queue,v_neighbor)
-                    inqueue[v_neighbor] = true
+                    inqueue[v_neighbor] = true                   # Mark the vertex as inside queue.
                     count[v_neighbor] = count[v_neighbor]+1      # Increment the number of times a vertex enters a queue.
 
-                    if count[v_neighbor] > nvg      # This step is just to check negative edge cycle. If this step is not there,
-                        throw(NegativeCycleError()) # the algorithm will run infinitely in case of a negative weight cycle.
-                                                    # If count[i]>nvg for any i belonging to [1,nvg], it means a negative edge
-                                                    # cycle is present.
+                    if count[v_neighbor] > nvg          # This step is just to check negative edge cycle. If this step is not there,
+                        throw(NegativeCycleError())     # the algorithm will run infinitely in case of a negative weight cycle.
+                                                        # If count[i]>nvg for any i belonging to [1,nvg], it means a negative edge
+                                                        # cycle is present.
                     end
                 end
             end
@@ -85,36 +68,16 @@ end
 
 has_negative_edge_cycle_spfa(g::AbstractGraph) = false
 
-"""
-Function which returns true if there is any negative weight cycle in the graph.
-
-# Examples
-```jldoctest
-julia> g = CompleteGraph(3);
-
-julia> d = [1 -3 1; -3 1 1; 1 1 1];
-
-julia> has_negative_edge_cycle_spfa(g, d)
-true
-
-
-julia> g = CompleteGraph(4);
-
-julia> d = [1 1 -1 1; 1 1 -1 1; 1 1 1 1; 1 1 1 1];
-
-julia> has_negative_edge_cycle_spfa(g, d);
-false
-```
-"""
-
 function has_negative_edge_cycle_spfa(
     g::AbstractGraph{U},
     distmx::AbstractMatrix{T}
     ) where T<:Real where U<:Integer
+
     try
         spfa_shortest_paths(g, 1, distmx)
     catch e
         isa(e, NegativeCycleError) && return true
     end
+
     return false
 end

--- a/src/shortestpaths/spfa.jl
+++ b/src/shortestpaths/spfa.jl
@@ -38,7 +38,6 @@ julia> spfa_shortest_paths(gx, 1, d)
   0
 
 """
-
 function spfa_shortest_paths(
     graph::AbstractGraph{U},
     source::Integer,

--- a/src/shortestpaths/spfa.jl
+++ b/src/shortestpaths/spfa.jl
@@ -51,7 +51,7 @@ function spfa_shortest_paths(
 
     nvg = nv(graph)
 
-    (source in vertices(g)) || throw(DomainError(source, "source should be in between 1 and $nvg"))
+    (source in 1:nvg) || throw(DomainError(source, "source should be in between 1 and $nvg"))
     dists = fill(typemax(T),nvg)
     dists[source] = 0
 

--- a/src/shortestpaths/spfa.jl
+++ b/src/shortestpaths/spfa.jl
@@ -72,7 +72,7 @@ function has_negative_edge_cycle_spfa(
     distmx::AbstractMatrix{T}
     ) where T<:Real where U<:Integer
     try
-        spfa_shortest_paths(g, vertices(g), distmx)
+        spfa_shortest_paths(g, 1, distmx)
     catch e
         isa(e, NegativeCycleError) && return true
     end

--- a/src/shortestpaths/spfa.jl
+++ b/src/shortestpaths/spfa.jl
@@ -16,6 +16,25 @@ Compute shortest paths between a source `s` and all
 other nodes in graph `g` using the [Shortest Path Faster Algorithm]
 (https://en.wikipedia.org/wiki/Shortest_Path_Faster_Algorithm).
 
+###Examples
+julia> g = CompleteGraph(3);
+
+julia> d = [1 -3 1; -3 1 1; 1 1 1];
+
+julia> spfa_shortest_paths(g, 1, d)
+ERROR: LightGraphs.NegativeCycleError()
+
+
+julia> g = CompleteGraph(4);
+
+julia> d = [1 1 -1 1; 1 1 -1 1; 1 1 1 1; 1 1 1 1];
+
+julia> spfa_shortest_paths(gx, 1, d)
+4-element Array{Int64,1}:
+  0
+  0
+ -1
+  0
 
 """
 
@@ -66,6 +85,27 @@ function spfa_shortest_paths(
 end
 
 has_negative_edge_cycle_spfa(g::AbstractGraph) = false
+
+"""
+Function which returns true if there is any negative weight cycle in the graph.
+
+###Examples
+julia> g = CompleteGraph(3);
+
+julia> d = [1 -3 1; -3 1 1; 1 1 1];
+
+julia> has_negative_edge_cycle_spfa(g, d)
+true
+
+
+julia> g = CompleteGraph(4);
+
+julia> d = [1 1 -1 1; 1 1 -1 1; 1 1 1 1; 1 1 1 1];
+
+julia> has_negative_edge_cycle_spfa(g, d);
+false
+
+"""
 
 function has_negative_edge_cycle_spfa(
     g::AbstractGraph{U},

--- a/src/shortestpaths/spfa.jl
+++ b/src/shortestpaths/spfa.jl
@@ -17,6 +17,7 @@ other nodes in graph `g` using the [Shortest Path Faster Algorithm]
 (https://en.wikipedia.org/wiki/Shortest_Path_Faster_Algorithm).
 
 ###Examples
+```jldoctest
 julia> g = CompleteGraph(3);
 
 julia> d = [1 -3 1; -3 1 1; 1 1 1];

--- a/src/shortestpaths/spfa.jl
+++ b/src/shortestpaths/spfa.jl
@@ -1,0 +1,81 @@
+# The Shortest Path Faster Algorithm for single-source shortest path
+
+###################################################################
+#
+#The type that capsulates the state of Shortest Path Faster Algorithm
+#
+###################################################################
+
+using Base.Threads
+
+struct NegativeCycleError <: Exception end
+
+"""
+    spfa_shortest_paths(g, s, distmx=weights(g))
+
+Compute shortest paths between a source `s` and all
+other nodes in graph `g` using the [Shortest Path Faster Algorithm]
+(https://en.wikipedia.org/wiki/Shortest_Path_Faster_Algorithm).
+
+
+"""
+
+function spfa_shortest_paths(
+    graph::AbstractGraph{U},
+    source::Integer,
+    distmx::AbstractMatrix{T}=weights(graph)
+    ) where T<:Real where U<:Integer
+
+
+    nvg = nv(graph)
+
+    (source in 1:nvg) || throw(DomainError(source, "source should be in between 1 and $nvg"))
+    dists = fill(typemax(T), nvg)
+    dists[source] = 0
+
+    count = zeros(U, nvg)           # Vector to store the count of number of times a vertex goes in the queue.
+
+    queue = Vector{U}()             # Vector used to implement queue
+    inqueue = zeros(Bool, nvg)      # Vector to mark which vertices are in queue
+    push!(queue, source)
+    inqueue[source] = true
+
+    @inbounds while !isempty(queue)
+        v = popfirst!(queue)
+        inqueue[v] = false
+
+        @inbounds for v_neighbor in outneighbors(graph,v)
+            if dists[v] + distmx[v,v_neighbor] < dists[v_neighbor]      # Relaxing edges
+                dists[v_neighbor] = dists[v] + distmx[v,v_neighbor]
+
+                if !inqueue[v_neighbor]
+                    push!(queue,v_neighbor)
+                    inqueue[v_neighbor] = true
+                    count[v_neighbor] = count[v_neighbor]+1      # Increment the number of times a vertex enters a queue.
+
+                    if count[v_neighbor] > nvg      # This step is just to check negative edge cycle. If this step is not there,
+                        throw(NegativeCycleError()) # the algorithm will run infinitely in case of a negative weight cycle.
+                                                    # If count[i]>nvg for any i belonging to [1,nvg], it means a negative edge
+                                                    # cycle is present.
+                    end
+                end
+            end
+        end
+    end
+
+    return dists
+end
+
+has_negative_edge_cycle_spfa(g::AbstractGraph) = false
+
+function has_negative_edge_cycle_spfa(
+    g::AbstractGraph{U},
+    distmx::AbstractMatrix{T}
+    ) where T<:Real where U<:Integer
+    try
+        spfa_shortest_paths(g, vertices(g), distmx)
+    catch e
+        isa(e, NegativeCycleError) && return true
+    end
+    return false
+end

--- a/src/shortestpaths/spfa.jl
+++ b/src/shortestpaths/spfa.jl
@@ -16,7 +16,7 @@ Compute shortest paths between a source `s` and all
 other nodes in graph `g` using the [Shortest Path Faster Algorithm]
 (https://en.wikipedia.org/wiki/Shortest_Path_Faster_Algorithm).
 
-###Examples
+# Examples
 ```jldoctest
 julia> g = CompleteGraph(3);
 

--- a/src/shortestpaths/spfa.jl
+++ b/src/shortestpaths/spfa.jl
@@ -68,6 +68,22 @@ end
 
 has_negative_edge_cycle_spfa(g::AbstractGraph) = false
 
+"""
+Function which returns true if there is any negative weight cycle in the graph.
+# Examples
+
+```jldoctest
+julia> g = CompleteGraph(3);
+julia> d = [1 -3 1; -3 1 1; 1 1 1];
+julia> has_negative_edge_cycle_spfa(g, d)
+true
+
+julia> g = CompleteGraph(4);
+julia> d = [1 1 -1 1; 1 1 -1 1; 1 1 1 1; 1 1 1 1];
+julia> has_negative_edge_cycle_spfa(g, d);
+false
+```
+"""
 function has_negative_edge_cycle_spfa(
     g::AbstractGraph{U},
     distmx::AbstractMatrix{T}

--- a/src/shortestpaths/spfa.jl
+++ b/src/shortestpaths/spfa.jl
@@ -8,7 +8,6 @@
 
 using Base.Threads
 
-struct NegativeCycleError <: Exception end
 
 """
     spfa_shortest_paths(g, s, distmx=weights(g))

--- a/src/shortestpaths/spfa.jl
+++ b/src/shortestpaths/spfa.jl
@@ -36,7 +36,7 @@ julia> spfa_shortest_paths(gx, 1, d)
   0
  -1
   0
-
+```
 """
 function spfa_shortest_paths(
     graph::AbstractGraph{U},
@@ -105,7 +105,7 @@ julia> d = [1 1 -1 1; 1 1 -1 1; 1 1 1 1; 1 1 1 1];
 
 julia> has_negative_edge_cycle_spfa(g, d);
 false
-
+```
 """
 
 function has_negative_edge_cycle_spfa(

--- a/src/shortestpaths/spfa.jl
+++ b/src/shortestpaths/spfa.jl
@@ -16,6 +16,29 @@ Compute shortest paths between a source `s` and all
 other nodes in graph `g` using the [Shortest Path Faster Algorithm]
 (https://en.wikipedia.org/wiki/Shortest_Path_Faster_Algorithm).
 
+# Examples
+
+```jldoctest
+julia> g = CompleteGraph(3);
+
+julia> d = [1 -3 1; -3 1 1; 1 1 1];
+
+julia> spfa_shortest_paths(g, 1, d)
+
+ERROR: LightGraphs.NegativeCycleError()
+
+julia> g = CompleteGraph(4);
+
+julia> d = [1 1 -1 1; 1 1 -1 1; 1 1 1 1; 1 1 1 1];
+
+julia> spfa_shortest_paths(gx, 1, d)
+
+4-element Array{Int64,1}:
+  0
+  0
+ -1
+  0
+```
 
 """
 
@@ -74,15 +97,20 @@ Function which returns true if there is any negative weight cycle in the graph.
 
 ```jldoctest
 julia> g = CompleteGraph(3);
+
 julia> d = [1 -3 1; -3 1 1; 1 1 1];
+
 julia> has_negative_edge_cycle_spfa(g, d)
 true
 
 julia> g = CompleteGraph(4);
+
 julia> d = [1 1 -1 1; 1 1 -1 1; 1 1 1 1; 1 1 1 1];
+
 julia> has_negative_edge_cycle_spfa(g, d);
 false
 ```
+
 """
 function has_negative_edge_cycle_spfa(
     g::AbstractGraph{U},

--- a/src/shortestpaths/spfa.jl
+++ b/src/shortestpaths/spfa.jl
@@ -44,7 +44,6 @@ function spfa_shortest_paths(
     distmx::AbstractMatrix{T}=weights(graph)
     ) where T<:Real where U<:Integer
 
-
     nvg = nv(graph)
 
     (source in 1:nvg) || throw(DomainError(source, "source should be in between 1 and $nvg"))

--- a/src/shortestpaths/spfa.jl
+++ b/src/shortestpaths/spfa.jl
@@ -90,6 +90,7 @@ has_negative_edge_cycle_spfa(g::AbstractGraph) = false
 Function which returns true if there is any negative weight cycle in the graph.
 
 # Examples
+```jldoctest
 julia> g = CompleteGraph(3);
 
 julia> d = [1 -3 1; -3 1 1; 1 1 1];

--- a/src/shortestpaths/spfa.jl
+++ b/src/shortestpaths/spfa.jl
@@ -89,7 +89,7 @@ has_negative_edge_cycle_spfa(g::AbstractGraph) = false
 """
 Function which returns true if there is any negative weight cycle in the graph.
 
-###Examples
+# Examples
 julia> g = CompleteGraph(3);
 
 julia> d = [1 -3 1; -3 1 1; 1 1 1];

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -44,6 +44,7 @@ tests = [
     "shortestpaths/johnson",
     "shortestpaths/floyd-warshall",
     "shortestpaths/yen",
+    "shortestpaths/spfa",
     "traversals/bfs",
     "traversals/bipartition",
     "traversals/greedy_color",

--- a/test/shortestpaths/spfa.jl
+++ b/test/shortestpaths/spfa.jl
@@ -75,8 +75,8 @@
     @testset "Random Graphs" begin
         @testset "Simple graphs" begin
             for i = 1:5
-                nvg = Int(floor(250*rand()))
-                neg = Int(floor((nvg*(nvg-1)/2)*rand()))
+                nvg = Int(ceil(250*rand()))
+                neg = Int(ceil((nvg*(nvg-1)/2)*rand()))
                 seed = Int(floor(100*rand()))
                 g = SimpleGraph(nvg, neg; seed = seed)
                 z = spfa_shortest_paths(g, 1)

--- a/test/shortestpaths/spfa.jl
+++ b/test/shortestpaths/spfa.jl
@@ -1,0 +1,176 @@
+@testset "Shortest_Path_Faster_Algorithm" begin
+    @testset "Generic tests for graphs" begin
+        g4 = PathDiGraph(5)
+        d1 = float([0 1 2 3 4; 5 0 6 7 8; 9 10 0 11 12; 13 14 15 0 16; 17 18 19 20 0])
+
+        for g in testdigraphs(g4)
+            y = @inferred(spfa_shortest_paths(g, 2, d1))
+            @test y == [Inf, 0, 6, 17, 33]
+        end
+
+        @testset "Graph with cycle" begin
+            gx = PathGraph(5)
+            add_edge!(gx, 2, 4)
+            d = ones(Int, 5, 5)
+            d[2, 3] = 100
+            for g in testgraphs(gx)
+                z = @inferred(spfa_shortest_paths(g, 1, d))
+                @test z == [0, 1, 3, 2, 3]
+            end
+        end
+
+        m = [0 2 2 0 0; 2 0 0 0 3; 2 0 0 1 2;0 0 1 0 1;0 3 2 1 0]
+        G = SimpleGraph(5)
+        add_edge!(G, 1, 2)
+        add_edge!(G, 1, 3)
+        add_edge!(G, 2, 5)
+        add_edge!(G, 3, 5)
+        add_edge!(G, 3, 4)
+        add_edge!(G, 4, 5)
+
+        for g in testgraphs(G)
+            y = @inferred(spfa_shortest_paths(g, 1, m))
+            @test y == [0, 2, 2, 3, 4]
+        end
+    end
+
+    @testset "Graph with self loop" begin
+        G = SimpleGraph(5)
+        add_edge!(G, 2, 2)
+        add_edge!(G, 1, 2)
+        add_edge!(G, 1, 3)
+        add_edge!(G, 3, 3)
+        add_edge!(G, 1, 5)
+        add_edge!(G, 2, 4)
+        add_edge!(G, 4, 5)
+        m = [0 10 2 0 15; 10 9 0 1 0; 2 0 1 0 0; 0 1 0 0 2; 15 0 0 2 0]
+        for g in testgraphs(G)
+            z = @inferred(spfa_shortest_paths(g, 1 , m))
+            y = @inferred(dijkstra_shortest_paths(g, 1, m))
+            @test isapprox(z, y.dists)
+        end
+    end
+
+    @testset "Disconnected graph" begin
+        G = SimpleGraph(5)
+        add_edge!(G, 1, 2)
+        add_edge!(G, 1, 3)
+        add_edge!(G, 4, 5)
+        inf = typemax(eltype(G))
+        for g in testgraphs(G)
+            z = @inferred(spfa_shortest_paths(g, 1))
+            @test z == [0, 1, 1, inf, inf]
+        end
+    end
+
+    @testset "Empty graph" begin
+        G = SimpleGraph(3)
+        inf = typemax(eltype(G))
+        for g in testgraphs(G)
+            z = @inferred(spfa_shortest_paths(g, 1))
+            @test z == [0, inf, inf]
+        end
+    end
+
+    @testset "Random Graphs" begin
+        @testset "Simple graphs" begin
+            for i = 1:5
+                nvg = Int(floor(250*rand()))
+                neg = Int(floor((nvg*(nvg-1)/2)*rand()))
+                seed = Int(floor(100*rand()))
+                g = SimpleGraph(nvg, neg; seed = seed)
+                z = spfa_shortest_paths(g, 1)
+                y = dijkstra_shortest_paths(g, 1)
+                @test isapprox(z, y.dists)
+            end
+        end
+
+        @testset "Simple DiGraphs" begin
+            for i = 1:5
+                nvg = 10
+                neg = 45
+                seed = Int(floor(100*rand()))
+                g = SimpleDiGraph(nvg, neg; seed = seed)
+                z = spfa_shortest_paths(g, 1)
+                y = dijkstra_shortest_paths(g, 1)
+                @test isapprox(z, y.dists)
+            end
+        end
+    end
+
+    @testset "Different types of graph" begin
+        G = CompleteGraph(9)
+        z = spfa_shortest_paths(G, 1)
+        y = dijkstra_shortest_paths(G, 1)
+        @test isapprox(z, y.dists)
+
+        G = CompleteDiGraph(9)
+        z = spfa_shortest_paths(G, 1)
+        y = dijkstra_shortest_paths(G, 1)
+        @test isapprox(z, y.dists)
+
+        G = CycleGraph(9)
+        z = spfa_shortest_paths(G, 1)
+        y = dijkstra_shortest_paths(G, 1)
+        @test isapprox(z, y.dists)
+
+        G = CycleDiGraph(9)
+        z = spfa_shortest_paths(G, 1)
+        y = dijkstra_shortest_paths(G, 1)
+        @test isapprox(z, y.dists)
+
+        G = StarGraph(9)
+        z = spfa_shortest_paths(G, 1)
+        y = dijkstra_shortest_paths(G, 1)
+        @test isapprox(z, y.dists)
+
+        G = WheelGraph(9)
+        z = spfa_shortest_paths(G, 1)
+        y = dijkstra_shortest_paths(G, 1)
+        @test isapprox(z, y.dists)
+
+        G = RoachGraph(9)
+        z = spfa_shortest_paths(G, 1)
+        y = dijkstra_shortest_paths(G, 1)
+        @test isapprox(z, y.dists)
+
+        G = CliqueGraph(5, 19)
+        z = spfa_shortest_paths(G, 1)
+        y = dijkstra_shortest_paths(G, 1)
+        @test isapprox(z, y.dists)
+
+        @testset "Small Graphs" begin
+            for s in [:bull, :chvatal, :cubical, :desargues,
+                      :diamond, :dodecahedral, :frucht, :heawood,
+                      :house, :housex, :icosahedral, :krackhardtkite, :moebiuskantor,
+                      :octahedral, :pappus, :petersen, :sedgewickmaze, :tutte,
+                      :tetrahedral, :truncatedcube, :truncatedtetrahedron, :truncatedtetrahedron_dir]
+                G = smallgraph(s)
+                z = spfa_shortest_paths(G, 1)
+                y = dijkstra_shortest_paths(G, 1)
+                @test isapprox(z, y.dists)
+            end
+        end
+    end
+
+    # Negative Cycle
+    gx = CompleteGraph(3)
+    for g in testgraphs(gx)
+        d = [1 -3 1; -3 1 1; 1 1 1]
+        @test_throws LightGraphs.NegativeCycleError spfa_shortest_paths(g, 1, d)
+        @test has_negative_edge_cycle(g, d)
+
+        d = [1 -1 1; -1 1 1; 1 1 1]
+        @test_throws LightGraphs.NegativeCycleError spfa_shortest_paths(g, 1, d)
+        @test has_negative_edge_cycle(g, d)
+    end
+
+    # Negative cycle of length 3 in graph of diameter 4
+    gx = CompleteGraph(4)
+    d = [1 -1 1 1; 1 1 1 -1; 1 1 1 1; 1 1 1 1]
+    for g in testgraphs(gx)
+        @test_throws LightGraphs.NegativeCycleError spfa_shortest_paths(g, 1, d)
+        @test has_negative_edge_cycle(g, d)
+    end
+
+end

--- a/test/shortestpaths/spfa.jl
+++ b/test/shortestpaths/spfa.jl
@@ -76,7 +76,7 @@
         @testset "Simple graphs" begin
             for i = 1:5
                 nvg = Int(ceil(250*rand()))
-                neg = Int(ceil((nvg*(nvg-1)/2)*rand()))
+                neg = Int(floor((nvg*(nvg-1)/2)*rand()))
                 seed = Int(floor(100*rand()))
                 g = SimpleGraph(nvg, neg; seed = seed)
                 z = spfa_shortest_paths(g, 1)
@@ -87,8 +87,8 @@
 
         @testset "Simple DiGraphs" begin
             for i = 1:5
-                nvg = 10
-                neg = 45
+                nvg = Int(ceil(250*rand()))
+                neg = Int(floor((nvg*(nvg-1)/2)*rand()))
                 seed = Int(floor(100*rand()))
                 g = SimpleDiGraph(nvg, neg; seed = seed)
                 z = spfa_shortest_paths(g, 1)

--- a/test/shortestpaths/spfa.jl
+++ b/test/shortestpaths/spfa.jl
@@ -153,8 +153,31 @@
         end
     end
 
+    @testset "Normal graph" begin
+        g4 = PathDiGraph(5)
+
+        d1 = float([0 1 2 3 4; 5 0 6 7 8; 9 10 0 11 12; 13 14 15 0 16; 17 18 19 20 0])
+        d2 = sparse(float([0 1 2 3 4; 5 0 6 7 8; 9 10 0 11 12; 13 14 15 0 16; 17 18 19 20 0]))
+        for g in testdigraphs(g4)
+            y = @inferred(spfa_shortest_paths(g, 2, d1))
+            z = @inferred(spfa_shortest_paths(g, 2, d2))
+            @test y == z == [Inf, 0, 6, 17, 33]
+            @test @inferred(!has_negative_edge_cycle_spfa(g))
+            @test @inferred(!has_negative_edge_cycle_spfa(g, d1))
+
+
+            y = @inferred(spfa_shortest_paths(g, 2, d1))
+            z = @inferred(spfa_shortest_paths(g, 2, d2))
+            @test y == z == [Inf, 0, 6, 17, 33]
+            @test @inferred(!has_negative_edge_cycle_spfa(g))
+            z = @inferred(spfa_shortest_paths(g, 2))
+            @test z == [typemax(Int), 0, 1, 2, 3]
+        end
+    end
+
+
     @testset "Negative Cycle" begin
-        # Negative cycle 1 
+        # Negative Cycle 1
         gx = CompleteGraph(3)
         for g in testgraphs(gx)
             d = [1 -3 1; -3 1 1; 1 1 1]
@@ -173,6 +196,6 @@
             @test_throws LightGraphs.NegativeCycleError spfa_shortest_paths(g, 1, d)
             @test has_negative_edge_cycle_spfa(g, d)
         end
-     end
+    end
 
 end

--- a/test/shortestpaths/spfa.jl
+++ b/test/shortestpaths/spfa.jl
@@ -158,11 +158,11 @@
     for g in testgraphs(gx)
         d = [1 -3 1; -3 1 1; 1 1 1]
         @test_throws LightGraphs.NegativeCycleError spfa_shortest_paths(g, 1, d)
-        @test has_negative_edge_cycle(g, d)
+        @test has_negative_edge_cycle_spfa(g, d)
 
         d = [1 -1 1; -1 1 1; 1 1 1]
         @test_throws LightGraphs.NegativeCycleError spfa_shortest_paths(g, 1, d)
-        @test has_negative_edge_cycle(g, d)
+        @test has_negative_edge_cycle_spfa(g, d)
     end
 
     # Negative cycle of length 3 in graph of diameter 4
@@ -170,7 +170,7 @@
     d = [1 -1 1 1; 1 1 1 -1; 1 1 1 1; 1 1 1 1]
     for g in testgraphs(gx)
         @test_throws LightGraphs.NegativeCycleError spfa_shortest_paths(g, 1, d)
-        @test has_negative_edge_cycle(g, d)
+        @test has_negative_edge_cycle_spfa(g, d)
     end
 
 end

--- a/test/shortestpaths/spfa.jl
+++ b/test/shortestpaths/spfa.jl
@@ -153,24 +153,26 @@
         end
     end
 
-    # Negative Cycle
-    gx = CompleteGraph(3)
-    for g in testgraphs(gx)
-        d = [1 -3 1; -3 1 1; 1 1 1]
-        @test_throws LightGraphs.NegativeCycleError spfa_shortest_paths(g, 1, d)
-        @test has_negative_edge_cycle_spfa(g, d)
+    @testset "Negative Cycle" begin
+        # Negative cycle 1 
+        gx = CompleteGraph(3)
+        for g in testgraphs(gx)
+            d = [1 -3 1; -3 1 1; 1 1 1]
+            @test_throws LightGraphs.NegativeCycleError spfa_shortest_paths(g, 1, d)
+            @test has_negative_edge_cycle_spfa(g, d)
 
-        d = [1 -1 1; -1 1 1; 1 1 1]
-        @test_throws LightGraphs.NegativeCycleError spfa_shortest_paths(g, 1, d)
-        @test has_negative_edge_cycle_spfa(g, d)
-    end
+            d = [1 -1 1; -1 1 1; 1 1 1]
+            @test_throws LightGraphs.NegativeCycleError spfa_shortest_paths(g, 1, d)
+            @test has_negative_edge_cycle_spfa(g, d)
+        end
 
-    # Negative cycle of length 3 in graph of diameter 4
-    gx = CompleteGraph(4)
-    d = [1 -1 1 1; 1 1 1 -1; 1 1 1 1; 1 1 1 1]
-    for g in testgraphs(gx)
-        @test_throws LightGraphs.NegativeCycleError spfa_shortest_paths(g, 1, d)
-        @test has_negative_edge_cycle_spfa(g, d)
-    end
+        # Negative cycle of length 3 in graph of diameter 4
+        gx = CompleteGraph(4)
+        d = [1 -1 1 1; 1 1 1 -1; 1 1 1 1; 1 1 1 1]
+        for g in testgraphs(gx)
+            @test_throws LightGraphs.NegativeCycleError spfa_shortest_paths(g, 1, d)
+            @test has_negative_edge_cycle_spfa(g, d)
+        end
+     end
 
 end


### PR DESCRIPTION
SPFA is an improvement of the Bellman-Ford algorithm which takes advantage of the fact that not all attempts at relaxation will work. The main idea is to create a queue containing only the vertices that were relaxed but that still could not relax their neighbors. And whenever you can relax some neighbor, you should put the neighbor in the queue. This algorithm work for negative edge weights and can also be used to detect negative cycles as the Bellman-Ford.

The worst case of this algorithm is equal to the `O(EV)` of the Bellman-Ford, but in practice it works much faster and it is found that it works even in `O(E)` on average. 

The only problem is that we can't find the parent vector through this algortihm. We can identify negative
weight cycles through this algortihm easily. `has_negative_cycle_spfa()` should be the goto function to check negative cycle in the graph because SPFA is faster and the way I have written it, it throws a `NegativeCycleError()` as soon as the negative cycle is detected. 
Contrary to this, the current implementation of Bellman Shortest path algorithm to detect negative cycle throws `NegativeCycleError()` after the `O(VE)` loop has completely finished. So this is slower.

Some benchmarks : 
```
julia> ee = SimpleGraph{Int32}(loadsnap(:email_enron_full))
{36692, 183831} undirected simple Int32 graph

julia> @benchmark spfa_shortest_paths(ee,1)
BenchmarkTools.Trial: 
  memory estimate:  722.84 KiB
  allocs estimate:  21
  --------------
  minimum time:     2.662 ms (0.00% GC)
  median time:      2.910 ms (0.00% GC)
  mean time:        2.988 ms (0.00% GC)
  maximum time:     5.158 ms (0.00% GC)
  --------------
  samples:          1643
  evals/sample:     1

julia> @benchmark bellman_ford_shortest_paths(ee,1)
BenchmarkTools.Trial: 
  memory estimate:  1.31 MiB
  allocs estimate:  142
  --------------
  minimum time:     5.218 ms (0.00% GC)
  median time:      5.552 ms (0.00% GC)
  mean time:        6.020 ms (1.62% GC)
  maximum time:     56.360 ms (90.36% GC)
  --------------
  samples:          829
  evals/sample:     1


julia> egu = SimpleGraph{Int32}(loadsnap(:ego_twitter_u))
{81306, 1342310} undirected simple Int32 graph

julia> @benchmark spfa_shortest_paths(egu,1)
BenchmarkTools.Trial: 
  memory estimate:  2.01 MiB
  allocs estimate:  23
  --------------
  minimum time:     14.253 ms (0.00% GC)
  median time:      14.670 ms (0.00% GC)
  mean time:        15.058 ms (0.00% GC)
  maximum time:     25.921 ms (0.00% GC)
  --------------
  samples:          328
  evals/sample:     1

julia> @benchmark bellman_ford_shortest_paths(egu,1)
BenchmarkTools.Trial: 
  memory estimate:  3.87 MiB
  allocs estimate:  153
  --------------
  minimum time:     23.616 ms (0.00% GC)
  median time:      25.901 ms (0.00% GC)
  mean time:        27.845 ms (1.43% GC)
  maximum time:     73.616 ms (67.55% GC)
  --------------
  samples:          180
  evals/sample:     1


julia> ss = SimpleDiGraph{Int32}(loadsnap(:soc_slashdot0902_d));

julia> @benchmark spfa_shortest_paths(ss,1)
BenchmarkTools.Trial: 
  memory estimate:  2.02 MiB
  allocs estimate:  23
  --------------
  minimum time:     7.871 ms (0.00% GC)
  median time:      8.119 ms (0.00% GC)
  mean time:        8.192 ms (0.00% GC)
  maximum time:     10.808 ms (0.00% GC)
  --------------
  samples:          601
  evals/sample:     1

julia> @benchmark bellman_ford_shortest_paths(ss,1)
BenchmarkTools.Trial: 
  memory estimate:  3.80 MiB
  allocs estimate:  158
  --------------
  minimum time:     15.901 ms (0.00% GC)
  median time:      16.422 ms (0.00% GC)
  mean time:        16.913 ms (1.53% GC)
  maximum time:     66.154 ms (74.78% GC)
  --------------
  samples:          296
  evals/sample:     1
```

