### PR TITLE
Improved Kruskal by removing collect

### DIFF
--- a/src/spanningtrees/kruskal.jl
+++ b/src/spanningtrees/kruskal.jl
@@ -34,7 +34,6 @@ function kruskal_mst end
         @inbounds for (i, e) in enumerate(edges(g))
             edge_list[i] = e
             weights[i] = distmx[src(e), dst(e)]
-            i += 1
         end
     end
 


### PR DESCRIPTION
Benchmarks - 
```julia
julia> g = loadsnap(:soc_slashdot0902_u)
{82168, 582533} undirected simple Int64 graph

julia> @btime kruskal_mst(g)	#new
  26.833 ms (18 allocations: 29.17 MiB)

julia> @btime kruskal_mst(g)	#old
  44.933 ms (19 allocations: 29.17 MiB)
```