### PR TITLE
is_directed interface more orthogonal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ docs/site/
 benchmark/.results/*
 benchmark/.tune.jld
 *.cov
+Manifest.toml

--- a/src/SimpleGraphs/simpledigraph.jl
+++ b/src/SimpleGraphs/simpledigraph.jl
@@ -352,8 +352,7 @@ fadj(g) == fadj(h) &&
 badj(g) == badj(h)
 
 is_directed(g::SimpleDiGraph) = true
-is_directed(::Type{SimpleDiGraph}) = true
-is_directed(::Type{SimpleDiGraph{T}}) where T = true
+is_directed(::Type{<:SimpleDiGraph}) = true
 
 function has_edge(g::SimpleDiGraph{T}, s, d) where T
     verts = vertices(g)

--- a/src/SimpleGraphs/simpledigraph.jl
+++ b/src/SimpleGraphs/simpledigraph.jl
@@ -351,7 +351,6 @@ ne(g) == ne(h) &&
 fadj(g) == fadj(h) &&
 badj(g) == badj(h)
 
-is_directed(g::SimpleDiGraph) = true
 is_directed(::Type{<:SimpleDiGraph}) = true
 
 function has_edge(g::SimpleDiGraph{T}, s, d) where T

--- a/src/SimpleGraphs/simplegraph.jl
+++ b/src/SimpleGraphs/simplegraph.jl
@@ -364,9 +364,7 @@ fadj(g) == fadj(h)
 
 Return `true` if `g` is a directed graph.
 """
-is_directed(::Type{SimpleGraph}) = false
-is_directed(::Type{SimpleGraph{T}}) where T = false
-is_directed(g::SimpleGraph) = false
+is_directed(::Type{<:SimpleGraph}) = false
 
 function has_edge(g::SimpleGraph{T}, s, d) where T
     verts = vertices(g)

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -198,7 +198,7 @@ edges(g) = _NI("edges")
     is_directed(g)
 
 Return `true` if the graph is a directed graph; `false` otherwise.
-
+New graph types must implement `is_directed(::Type{<:G})`.
 # Examples
 ```jldoctest
 julia> using LightGraphs
@@ -210,7 +210,7 @@ julia> is_directed(SimpleDiGraph(2))
 true
 ```
 """
-is_directed(g) = _NI("is_directed")
+is_directed(::G) where {G} = is_directed(G)
 is_directed(::Type{T}) where T = _NI("is_directed")
 
 """

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -195,15 +195,19 @@ julia> collect(edges(g))
 edges(g) = _NI("edges")
 
 """
-    is_directed(g)
+    is_directed(G)
 
-Return `true` if the graph is a directed graph; `false` otherwise.
+Return `true` if the graph type `G` is a directed graph; `false` otherwise.
 New graph types must implement `is_directed(::Type{<:G})`.
+The method can also be called with `is_directed(g::G)`
 # Examples
 ```jldoctest
 julia> using LightGraphs
 
 julia> is_directed(SimpleGraph(2))
+false
+
+julia> is_directed(SimpleGraph)
 false
 
 julia> is_directed(SimpleDiGraph(2))


### PR DESCRIPTION
The `is_directed` interface as-is has two redundant methods `is_directed(g::G)` and `is_directed(::Type{G})`. A simple default makes it simpler, as proven by removing redundant methods for Simple(Di)Graph