### PR TITLE
[breaking] Seed to rng

### DIFF
--- a/src/LightGraphs.jl
+++ b/src/LightGraphs.jl
@@ -10,6 +10,7 @@ using Inflate: InflateGzipStream
 using DataStructures: IntDisjointSets, PriorityQueue, dequeue!, dequeue_pair!, enqueue!, heappop!, heappush!, in_same_set, peek, union!
 using LinearAlgebra: I, Symmetric, diagm, eigen, eigvals, norm, rmul!, tril, triu
 import LinearAlgebra: Diagonal, issymmetric, mul!
+import Random
 using Random: AbstractRNG, GLOBAL_RNG, MersenneTwister, randperm, randsubseq!, shuffle, shuffle!
 using SparseArrays: SparseMatrixCSC, nonzeros, nzrange, rowvals
 import SparseArrays: blockdiag, sparse

--- a/src/LightGraphs.jl
+++ b/src/LightGraphs.jl
@@ -10,7 +10,7 @@ using Inflate: InflateGzipStream
 using DataStructures: IntDisjointSets, PriorityQueue, dequeue!, dequeue_pair!, enqueue!, heappop!, heappush!, in_same_set, peek, union!
 using LinearAlgebra: I, Symmetric, diagm, eigen, eigvals, norm, rmul!, tril, triu
 import LinearAlgebra: Diagonal, issymmetric, mul!
-using Random: AbstractRNG, GLOBAL_RNG, MersenneTwister, randperm, randsubseq!, seed!, shuffle, shuffle!
+using Random: AbstractRNG, GLOBAL_RNG, MersenneTwister, randperm, randsubseq!, shuffle, shuffle!
 using SparseArrays: SparseMatrixCSC, nonzeros, nzrange, rowvals
 import SparseArrays: blockdiag, sparse
 

--- a/src/Parallel/Parallel.jl
+++ b/src/Parallel/Parallel.jl
@@ -6,7 +6,8 @@ using Distributed: @distributed
 using Base.Threads: @threads, nthreads, Atomic, atomic_add!, atomic_cas!
 using SharedArrays: SharedMatrix, SharedVector, sdata
 using ArnoldiMethod
-using Random:shuffle
+import Random
+using Random: shuffle
 import SparseArrays: sparse
 import Base: push!, popfirst!, isempty, getindex
 

--- a/src/Parallel/dominatingset/minimal_dom_set.jl
+++ b/src/Parallel/dominatingset/minimal_dom_set.jl
@@ -11,9 +11,9 @@ used. This implementation is more efficient if `reps` is large.
 """
 function dominating_set(g::AbstractGraph{T}, reps::Integer, alg::MinimalDominatingSet; parallel=:threads, seed=-1) where T <: Integer
     function gen_func(g::AbstractGraph{T})
-        seed > 0 && seed!(seed)
+        rng = seed > 0 ? MersenneTwister(seed) : Random.GLOBAL_RNG
         LightGraphs.dominating_set(g, alg; rng=rng)
     end
-    compare_func(x::Vector{T}, y::Vector{T}) = length(x < length(y))
+    compare_func(x::Vector{T}, y::Vector{T}) = length(x) < length(y)
     LightGraphs.Parallel.generate_reduce(g, gen_func, compare_func, reps, parallel=parallel)
 end

--- a/src/Parallel/dominatingset/minimal_dom_set.jl
+++ b/src/Parallel/dominatingset/minimal_dom_set.jl
@@ -1,7 +1,7 @@
 """
     dominating_set(g, reps, MinimalDominatingSet(); parallel=:threads, seed=-1)
 
-Perform [`LightGraphs.dominating_set(g, MinimalDominatingSet())`](@ref) `reps` times in parallel 
+Perform [`LightGraphs.dominating_set(g, MinimalDominatingSet())`](@ref) `reps` times in parallel
 and return the solution with the fewest vertices.
 
 ### Optional Arguements
@@ -9,6 +9,11 @@ and return the solution with the fewest vertices.
 used. This implementation is more efficient if `reps` is large.
 - If `seed >= 0`, a random generator of each process/thread is seeded with this value.
 """
-dominating_set(g::AbstractGraph{T}, reps::Integer, alg::MinimalDominatingSet; parallel=:threads, seed=-1) where T <: Integer = 
-LightGraphs.Parallel.generate_reduce(g, (g::AbstractGraph{T})->LightGraphs.dominating_set(g, alg; seed=seed), 
-(x::Vector{T}, y::Vector{T})->length(x)<length(y), reps; parallel=parallel)
+function dominating_set(g::AbstractGraph{T}, reps::Integer, alg::MinimalDominatingSet; parallel=:threads, seed=-1) where T <: Integer
+    function gen_func(g::AbstractGraph{T})
+        seed > 0 && seed!(seed)
+        LightGraphs.dominating_set(g, alg; rng=rng)
+    end
+    compare_func(x::Vector{T}, y::Vector{T}) = length(x < length(y))
+    LightGraphs.Parallel.generate_reduce(g, gen_func, compare_func, reps, parallel=parallel)
+end

--- a/src/SimpleGraphs/generators/euclideangraphs.jl
+++ b/src/SimpleGraphs/generators/euclideangraphs.jl
@@ -1,5 +1,5 @@
 """
-    euclidean_graph(N, d; seed=-1, L=1., p=2., cutoff=-1., bc=:open)
+    euclidean_graph(N, d; rng=Random.GLOBAL_RNG, L=1., p=2., cutoff=-1., bc=:open)
 
 Generate `N` uniformly distributed points in the box ``[0,L]^{d}``
 and return a Euclidean graph, a map containing the distance on each edge and
@@ -20,9 +20,7 @@ Dict{LightGraphs.SimpleGraphs.SimpleEdge{Int64},Float64} with 4 entries:
   Edge 4 => 5 => 0.168372
 ```
 """
-function euclidean_graph(N::Int, d::Int;
-    L=1., seed = -1, kws...)
-    rng = LightGraphs.getRNG(seed)
+function euclidean_graph(N::Int, d::Int; L=1., rng::AbstractRNG=Random.GLOBAL_RNG, kws...)
     points = rmul!(rand(rng, d, N), L)
     return (euclidean_graph(points; L=L, kws...)..., points)
 end

--- a/src/SimpleGraphs/generators/euclideangraphs.jl
+++ b/src/SimpleGraphs/generators/euclideangraphs.jl
@@ -22,8 +22,8 @@ Dict{LightGraphs.SimpleGraphs.SimpleEdge{Int64},Float64} with 4 entries:
 """
 function euclidean_graph(N::Int, d::Int;
     L=1., seed = -1, kws...)
-    _rng = LightGraphs.getRNG(seed)
-    points = rmul!(rand(_rng, d, N), L)
+    rng = LightGraphs.getRNG(seed)
+    points = rmul!(rand(rng, d, N), L)
     return (euclidean_graph(points; L=L, kws...)..., points)
 end
 

--- a/src/SimpleGraphs/generators/randgraphs.jl
+++ b/src/SimpleGraphs/generators/randgraphs.jl
@@ -1,3 +1,4 @@
+import Random
 using Random:
     AbstractRNG, MersenneTwister, randperm, shuffle!
 using Statistics: mean
@@ -113,7 +114,7 @@ probability `p`.
 julia> erdos_renyi(10, 0.5)
 {10, 20} undirected simple Int64 graph
 
-julia> erdos_renyi(10, 0.5, is_directed=true, rng=Random.MersenneTwister(1))
+julia> erdos_renyi(10, 0.5, is_directed=true, rng=MersenneTwister(1))
 {10, 49} directed simple Int64 graph
 ```
 """
@@ -139,7 +140,7 @@ graph with `n` vertices and `ne` edges.
 julia> erdos_renyi(10, 30)
 {10, 30} undirected simple Int64 graph
 
-julia> erdos_renyi(10, 30, is_directed=true, rng=Random.MersenneTwister(2))
+julia> erdos_renyi(10, 30, is_directed=true, rng=MersenneTwister(2))
 {10, 30} directed simple Int64 graph
 ```
 """
@@ -174,7 +175,7 @@ julia> print(degree(g))
 [3, 0, 1, 1, 1]
 
 # 2)
-julia> g = expected_degree_graph([0.5, 0.5, 0.5], rng=Random.MersenneTwister(123))
+julia> g = expected_degree_graph([0.5, 0.5, 0.5], rng=MersenneTwister(123))
 {3, 1} undirected simple Int64 graph
 
 julia> print(degree(g))
@@ -232,7 +233,7 @@ randomized per the model based on probability `β`.
 julia> watts_strogatz(10, 4, 0.3)
 {10, 20} undirected simple Int64 graph
 
-julia> watts_strogatz(Int8(10), 4, 0.8, is_directed=true, rng=Random.MersenneTwister(123))
+julia> watts_strogatz(Int8(10), 4, 0.8, is_directed=true, rng=MersenneTwister(123))
 {10, 20} directed simple Int8 graph
 ```
 """
@@ -365,7 +366,7 @@ Initial graphs are undirected and consist of isolated vertices by default.
 julia> barabasi_albert(10, 3, 2)
 {10, 14} undirected simple Int64 graph
 
-julia> barabasi_albert(100, Int8(10), 3, is_directed=true, rng=Random.MersenneTwister(123))
+julia> barabasi_albert(100, Int8(10), 3, is_directed=true, rng=MersenneTwister(123))
 {100, 270} directed simple Int8 graph
 ```
 """
@@ -532,7 +533,7 @@ Time complexity is ``\\mathcal{O}(|V| + |E| log |E|)``.
 
 ## Examples
 ```jldoctest
-julia> g = static_fitness_model(6, [1, 0.2, 0.2, 0.2], [0.1, 0.1, 0.1, 0.9]; rng=Random.MersenneTwister(123))
+julia> g = static_fitness_model(6, [1, 0.2, 0.2, 0.2], [0.1, 0.1, 0.1, 0.9]; rng=MersenneTwister(123))
 {4, 6} directed simple Int64 graph
 
 julia> edges(g) |> collect
@@ -795,7 +796,7 @@ with `n` vertices.
 julia> random_tournament_digraph(5)
 {5, 10} directed simple Int64 graph
 
-julia> random_tournament_digraph(Int8(10), rng=Random.MersenneTwister(123))
+julia> random_tournament_digraph(Int8(10), rng=MersenneTwister(123))
 {10, 45} directed simple Int8 graph
 ```
 """
@@ -1125,7 +1126,7 @@ the `t`th stage of this algorithm by accessing the first `t` vertices with `g[1:
 julia> dorogovtsev_mendes(10)
 {10, 17} undirected simple Int64 graph
 
-julia> dorogovtsev_mendes(11, rng=Random.MersenneTwister(123))
+julia> dorogovtsev_mendes(11, rng=MersenneTwister(123))
 {11, 19} undirected simple Int64 graph
 ```
 """

--- a/src/community/label_propagation.jl
+++ b/src/community/label_propagation.jl
@@ -59,13 +59,12 @@ mutable struct NeighComm{T<:Integer}
 end
 
 """
-    range_shuffle!(r, a; seed=-1)
+    range_shuffle!(r, a; rng=Random.GLOBAL_RNG)
 
 Fast shuffle Array `a` in UnitRange `r`.
-Uses `seed` to initialize the random number generator, defaulting to `Random.GLOBAL_RNG` for `seed=-1`.
+Uses `rng` to provide the random number generator, defaulting to `Random.GLOBAL_RNG`.
 """
-function range_shuffle!(r::UnitRange, a::AbstractVector; seed::Int=-1)
-    rng = getRNG(seed)
+function range_shuffle!(r::UnitRange, a::AbstractVector; rng::AbstractRNG=Random.GLOBAL_RNG)
     (r.start > 0 && r.stop <= length(a)) || throw(DomainError(r, "range indices are out of bounds"))
     @inbounds for i = length(r):-1:2
         j = rand(rng, 1:i)

--- a/src/community/label_propagation.jl
+++ b/src/community/label_propagation.jl
@@ -59,14 +59,16 @@ mutable struct NeighComm{T<:Integer}
 end
 
 """
-    range_shuffle!(r, a)
+    range_shuffle!(r, a; seed=-1)
 
 Fast shuffle Array `a` in UnitRange `r`.
+Uses `seed` to initialize the random number generator, defaulting to `Random.GLOBAL_RNG` for `seed=-1`.
 """
-function range_shuffle!(r::UnitRange, a::AbstractVector)
-    (r.start > 0 && r.stop <= length(a)) || throw(ArgumentError("range indices are out of bounds")) # TODO 0.7: change to DomainError?
+function range_shuffle!(r::UnitRange, a::AbstractVector; seed::Int=-1)
+    rng = getRNG(seed)
+    (r.start > 0 && r.stop <= length(a)) || throw(DomainError(r, "range indices are out of bounds"))
     @inbounds for i = length(r):-1:2
-        j = rand(1:i)
+        j = rand(rng, 1:i)
         ii = i + r.start - 1
         jj = j + r.start - 1
         a[ii], a[jj] = a[jj], a[ii]

--- a/src/dominatingset/minimal_dom_set.jl
+++ b/src/dominatingset/minimal_dom_set.jl
@@ -3,15 +3,15 @@ export MinimalDominatingSet
 struct MinimalDominatingSet end
 
 """
-    dominating_set(g, MinimalDominatingSet(); seed=-1)
+    dominating_set(g, MinimalDominatingSet(); rng=Random.GLOBAL_RNG)
 
-Find a set of vertices that consitute a dominating set (all vertices in `g` are either adjacent to a vertex 
-in the set or is a vertex in the set) and it is not possible to delete a vertex from the set 
+Find a set of vertices that consitute a dominating set (all vertices in `g` are either adjacent to a vertex
+in the set or is a vertex in the set) and it is not possible to delete a vertex from the set
 without sacrificing the dominating property.
 
 ### Implementation Notes
 Initially, every vertex is in the dominating set.
-In some random order, we check if the removal of a vertex from the set will destroy the 
+In some random order, we check if the removal of a vertex from the set will destroy the
 dominating property. If no, the vertex is removed from the dominating set.
 
 ### Performance
@@ -19,23 +19,23 @@ Runtime: ``\\mathcal{O}(|V|+|E|)``
 Memory: ``\\mathcal{O}(|V|)``
 
 ### Optional Arguments
-- If `seed >= 0`, a random generator is seeded with this value.
-"""    
+- A random number generator `rng`, defaulting to `Random.GLOBAL_RNG`.
+"""
 function dominating_set(
     g::AbstractGraph{T},
     alg::MinimalDominatingSet;
-    seed::Int=-1
-    ) where T <: Integer 
+    rng::AbstractRNG=Random.GLOBAL_RNG
+    ) where T <: Integer
 
-    nvg = nv(g)  
-    in_dom_set = trues(nvg) 
+    nvg = nv(g)
+    in_dom_set = trues(nvg)
     length_ds = Int(nvg)
     dom_degree = degree(g)
     @inbounds @simd for v in vertices(g)
         dom_degree[v] -= (has_edge(g, v, v) ? 1 : 0)
     end
 
-    for v in randperm(getRNG(seed), nvg)
+    for v in randperm(rng, nvg)
     	(dom_degree[v] == 0) && continue #It is not adjacent to any dominating vertex
     	#Check if any vertex is depending on v to be dominated
         dependent = findfirst(u -> !in_dom_set[u] && dom_degree[u] <= 1, neighbors(g, v))
@@ -45,6 +45,6 @@ function dominating_set(
         length_ds -= 1
         dom_degree[neighbors(g, v)] .-= 1
     end
-    
+
     return LightGraphs.findall!(in_dom_set, Vector{T}(undef, length_ds))
 end

--- a/src/independentset/maximal_ind_set.jl
+++ b/src/independentset/maximal_ind_set.jl
@@ -3,9 +3,9 @@ export MaximalIndependentSet
 struct MaximalIndependentSet end
 
 """
-    independent_set(g, MaximalIndependentSet(); seed=-1)
+    independent_set(g, MaximalIndependentSet(); rng=Random.GLOBAL_RNG)
 
-Find a random set of vertices that are independent (no two vertices are adjacent to each other) and 
+Find a random set of vertices that are independent (no two vertices are adjacent to each other) and
 it is not possible to insert a vertex into the set without sacrificing the independence property.
 
 ### Implementation Notes
@@ -18,20 +18,20 @@ Memory: O(|V|)
 Approximation Factor: maximum(degree(g))+1
 
 ### Optional Arguments
-- If `seed >= 0`, a random generator is seeded with this value.
+- A random number generator `rng`, defaulting to `Random.GLOBAL_RNG`.
 """
 function independent_set(
     g::AbstractGraph{T},
     alg::MaximalIndependentSet;
-    seed::Int=-1
-    ) where T <: Integer 
-  
+    rng::AbstractRNG=Random.GLOBAL_RNG
+    ) where T <: Integer
+
     nvg = nv(g)
     ind_set = Vector{T}()
-    sizehint!(ind_set, nvg)  
+    sizehint!(ind_set, nvg)
     deleted = falses(nvg)
 
-    for v in randperm(getRNG(seed), nvg)
+    for v in randperm(rng, nvg)
         (deleted[v] || has_edge(g, v, v)) && continue
 
         deleted[v] = true

--- a/src/traversals/randomwalks.jl
+++ b/src/traversals/randomwalks.jl
@@ -1,11 +1,12 @@
 """
-    randomwalk(g, s, niter)
+    randomwalk(g, s, niter; seed=-1)
 
 Perform a random walk on graph `g` starting at vertex `s` and continuing for
 a maximum of `niter` steps. Return a vector of vertices visited in order.
 """
-function randomwalk(g::AG, s::Integer, niter::Integer) where AG <: AbstractGraph{T} where T
+function randomwalk(g::AG, s::Integer, niter::Integer; seed::Int=-1) where AG <: AbstractGraph{T} where T
     s in vertices(g) || throw(BoundsError())
+    rng = getRNG(seed)
     visited = Vector{T}()
     sizehint!(visited, niter)
     currs = s
@@ -15,13 +16,13 @@ function randomwalk(g::AG, s::Integer, niter::Integer) where AG <: AbstractGraph
         i += 1
         nbrs = outneighbors(g, currs)
         length(nbrs) == 0 && break
-        currs = rand(nbrs)
+        currs = rand(rng, nbrs)
     end
     return visited[1:(i - 1)]
 end
 
 """
-    non_backtracking_randomwalk(g, s, niter)
+    non_backtracking_randomwalk(g, s, niter; seed=-1)
 
 Perform a non-backtracking random walk on directed graph `g` starting at
 vertex `s` and continuing for a maximum of `niter` steps. Return a
@@ -29,8 +30,9 @@ vector of vertices visited in order.
 """
 function non_backtracking_randomwalk end
 # see https://github.com/mauro3/SimpleTraits.jl/issues/47#issuecomment-327880153 for syntax
-@traitfn function non_backtracking_randomwalk(g::AG::(!IsDirected), s::Integer, niter::Integer) where {T, AG<:AbstractGraph{T}}
+@traitfn function non_backtracking_randomwalk(g::AG::(!IsDirected), s::Integer, niter::Integer; seed::Int=-1) where {T, AG<:AbstractGraph{T}}
     s in vertices(g) || throw(BoundsError())
+    rng = getRNG(seed)
     visited = Vector{T}()
     sizehint!(visited, niter)
     currs = s
@@ -42,14 +44,14 @@ function non_backtracking_randomwalk end
     nbrs = outneighbors(g, currs)
     length(nbrs) == 0 && return visited[1:(i - 1)]
     prev = currs
-    currs = rand(nbrs)
+    currs = rand(rng, nbrs)
 
     while i <= niter
         push!(visited, currs)
         i += 1
         nbrs = outneighbors(g, currs)
         length(nbrs) == 1 && break
-        idnext = rand(1:(length(nbrs) - 1))
+        idnext = rand(rng, 1:(length(nbrs) - 1))
         next = nbrs[idnext]
         if next == prev
             next = nbrs[end]
@@ -61,8 +63,9 @@ function non_backtracking_randomwalk end
 end
 
 # see https://github.com/mauro3/SimpleTraits.jl/issues/47#issuecomment-327880153 for syntax
-@traitfn function non_backtracking_randomwalk(g::AG::IsDirected, s::Integer, niter::Integer) where {T, AG<:AbstractGraph{T}}
+@traitfn function non_backtracking_randomwalk(g::AG::IsDirected, s::Integer, niter::Integer; seed::Int=-1) where {T, AG<:AbstractGraph{T}}
     s in vertices(g) || throw(BoundsError())
+    rng = getRNG(seed)
     visited = Vector{T}()
     sizehint!(visited, niter)
     currs = s
@@ -74,10 +77,10 @@ end
         i += 1
         nbrs = outneighbors(g, currs)
         length(nbrs) == 0 && break
-        next = rand(nbrs)
+        next = rand(rng, nbrs)
         if next == prev
             length(nbrs) == 1 && break
-            idnext = rand(1:(length(nbrs) - 1))
+            idnext = rand(rng, 1:(length(nbrs) - 1))
             next = nbrs[idnext]
             if next == prev
                 next = nbrs[end]
@@ -90,14 +93,15 @@ end
 end
 
 """
-    saw(g, s, niter)
+    saw(g, s, niter; seed=-1)
 
 Perform a [self-avoiding walk](https://en.wikipedia.org/wiki/Self-avoiding_walk)
 on graph `g` starting at vertex `s` and continuing for a maximum of `niter` steps.
 Return a vector of vertices visited in order.
 """
-function saw(g::AG, s::Integer, niter::Integer) where AG <: AbstractGraph{T} where T
+function saw(g::AG, s::Integer, niter::Integer; seed::Int=-1) where AG <: AbstractGraph{T} where T
     s in vertices(g) || throw(BoundsError())
+    rng = getRNG(seed)
     visited = Vector{T}()
     svisited = Set{T}()
     sizehint!(visited, niter)
@@ -110,8 +114,7 @@ function saw(g::AG, s::Integer, niter::Integer) where AG <: AbstractGraph{T} whe
         i += 1
         nbrs = setdiff(Set(outneighbors(g, currs)), svisited)
         length(nbrs) == 0 && break
-        currs = rand(collect(nbrs))
+        currs = rand(rng, collect(nbrs))
     end
     return visited[1:(i - 1)]
 end
-

--- a/src/traversals/randomwalks.jl
+++ b/src/traversals/randomwalks.jl
@@ -1,12 +1,12 @@
 """
-    randomwalk(g, s, niter; seed=-1)
+    randomwalk(g, s, niter; rng=Random.GLOBAL_RNG)
 
 Perform a random walk on graph `g` starting at vertex `s` and continuing for
 a maximum of `niter` steps. Return a vector of vertices visited in order.
 """
-function randomwalk(g::AG, s::Integer, niter::Integer; seed::Int=-1) where AG <: AbstractGraph{T} where T
+function randomwalk(g::AG, s::Integer, niter::Integer; rng::AbstractRNG=Random.GLOBAL_RNG) where AG <: AbstractGraph{T} where T
     s in vertices(g) || throw(BoundsError())
-    rng = getRNG(seed)
+
     visited = Vector{T}()
     sizehint!(visited, niter)
     currs = s
@@ -22,7 +22,7 @@ function randomwalk(g::AG, s::Integer, niter::Integer; seed::Int=-1) where AG <:
 end
 
 """
-    non_backtracking_randomwalk(g, s, niter; seed=-1)
+    non_backtracking_randomwalk(g, s, niter; rng=Random.GLOBAL_RNG)
 
 Perform a non-backtracking random walk on directed graph `g` starting at
 vertex `s` and continuing for a maximum of `niter` steps. Return a
@@ -30,9 +30,9 @@ vector of vertices visited in order.
 """
 function non_backtracking_randomwalk end
 # see https://github.com/mauro3/SimpleTraits.jl/issues/47#issuecomment-327880153 for syntax
-@traitfn function non_backtracking_randomwalk(g::AG::(!IsDirected), s::Integer, niter::Integer; seed::Int=-1) where {T, AG<:AbstractGraph{T}}
+@traitfn function non_backtracking_randomwalk(g::AG::(!IsDirected), s::Integer, niter::Integer; rng::AbstractRNG=Random.GLOBAL_RNG) where {T, AG<:AbstractGraph{T}}
     s in vertices(g) || throw(BoundsError())
-    rng = getRNG(seed)
+
     visited = Vector{T}()
     sizehint!(visited, niter)
     currs = s
@@ -63,9 +63,9 @@ function non_backtracking_randomwalk end
 end
 
 # see https://github.com/mauro3/SimpleTraits.jl/issues/47#issuecomment-327880153 for syntax
-@traitfn function non_backtracking_randomwalk(g::AG::IsDirected, s::Integer, niter::Integer; seed::Int=-1) where {T, AG<:AbstractGraph{T}}
+@traitfn function non_backtracking_randomwalk(g::AG::IsDirected, s::Integer, niter::Integer; rng::AbstractRNG=Random.GLOBAL_RNG) where {T, AG<:AbstractGraph{T}}
     s in vertices(g) || throw(BoundsError())
-    rng = getRNG(seed)
+
     visited = Vector{T}()
     sizehint!(visited, niter)
     currs = s
@@ -93,15 +93,15 @@ end
 end
 
 """
-    saw(g, s, niter; seed=-1)
+    saw(g, s, niter; rng=Random.GLOBAL_RNG)
 
 Perform a [self-avoiding walk](https://en.wikipedia.org/wiki/Self-avoiding_walk)
 on graph `g` starting at vertex `s` and continuing for a maximum of `niter` steps.
 Return a vector of vertices visited in order.
 """
-function saw(g::AG, s::Integer, niter::Integer; seed::Int=-1) where AG <: AbstractGraph{T} where T
+function saw(g::AG, s::Integer, niter::Integer; rng::AbstractRNG=Random.GLOBAL_RNG) where AG <: AbstractGraph{T} where T
     s in vertices(g) || throw(BoundsError())
-    rng = getRNG(seed)
+
     visited = Vector{T}()
     svisited = Set{T}()
     sizehint!(visited, niter)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -27,10 +27,10 @@ function sample!(rng::AbstractRNG, a::AbstractVector, k::Integer; exclude=())
     res
 end
 
-sample!(a::AbstractVector, k::Integer; exclude=()) = sample!(getRNG(), a, k; exclude=exclude)
+sample!(a::AbstractVector, k::Integer; exclude=()) = sample!(Random.GLOBAL_RNG, a, k; exclude=exclude)
 
 """
-    sample([rng,] r, k)
+    sample(r, k; rng=Random.GLOBAL_RNG)
 
 Sample `k` element from unit range `r` without repetition and eventually excluding elements in `exclude`.
 
@@ -40,9 +40,7 @@ Sample `k` element from unit range `r` without repetition and eventually excludi
 ### Implementation Notes
 Unlike [`sample!`](@ref), does not produce side effects.
 """
-sample(a::AbstractVector, k::Integer; exclude=()) = sample!(getRNG(), collect(a), k; exclude=exclude)
-
-getRNG(seed::Integer=-1) = seed >= 0 ? MersenneTwister(seed) : GLOBAL_RNG
+sample(a::AbstractVector, k::Integer; exclude=(), rng::AbstractRNG=Random.GLOBAL_RNG) = sample!(rng, collect(a), k; exclude=exclude)
 
 """
     insorted(item, collection)
@@ -60,7 +58,7 @@ end
 """
     findall!(A, B)
 
-Set the `B[1:|I|]` to `I` where `I` is the set of indices `A[I]` returns true. 
+Set the `B[1:|I|]` to `I` where `I` is the set of indices `A[I]` returns true.
 
 Assumes `length(B) >= |I|`.
 """
@@ -102,7 +100,7 @@ end
 """
     greedy_contiguous_partition(weight, required_partitions, num_items=length(weight))
 
-Partition `1:num_items` into atmost `required_partitions` number of contiguous partitions with 
+Partition `1:num_items` into atmost `required_partitions` number of contiguous partitions with
 the objective of minimising the largest partition.
 The size of a partition is equal to the num of the weight of its elements.
 `weight[i] > 0`.
@@ -112,7 +110,7 @@ Time: O(num_items+required_partitions)
 Requires only one iteration over `weight` but may not output the optimal partition.
 
 ### Implementation Notes
-`Balance(wt, left, right, n_items, n_part) = 
+`Balance(wt, left, right, n_items, n_part) =
 max(sum(wt[left:right])*(n_part-1), sum(wt[right+1:n_items]))`.
 Find `right` that minimises `Balance(weight, 1, right, num_items, required_partitions)`.
 Set the first partition as `1:right`.
@@ -125,7 +123,7 @@ function greedy_contiguous_partition(
     ) where U <: Integer
 
     suffix_sum = cumsum(reverse(weight))
-    reverse!(suffix_sum) 
+    reverse!(suffix_sum)
     push!(suffix_sum, 0) #Eg. [2, 3, 1] => [6, 4, 1, 0]
 
     partitions = Vector{UnitRange{U}}()
@@ -134,13 +132,13 @@ function greedy_contiguous_partition(
     left = one(U)
     for partitions_remain in reverse(1:(required_partitions-1))
 
-        left >= num_items && break 
+        left >= num_items && break
 
         partition_size = weight[left]*partitions_remain #At least one item in each partition
         right = left
 
         #Find right: sum(wt[left:right])*partitions_remain and sum(wt[(right+1):num_items]) is balanced
-        while right+one(U) < num_items && partition_size < suffix_sum[right+one(U)] 
+        while right+one(U) < num_items && partition_size < suffix_sum[right+one(U)]
             right += one(U)
             partition_size += weight[right]*partitions_remain
         end
@@ -149,7 +147,7 @@ function greedy_contiguous_partition(
         if left != right && partition_size > suffix_sum[right]
             right -= one(U)
         end
-        
+
         push!(partitions, left:right)
         left = right + one(U)
     end
@@ -170,7 +168,7 @@ The size of a partition is equal to the sum of the weight of its elements.
 Time: O(num_items*log(sum(weight)))
 
 ### Implementation Notes
-Binary Search for the partitioning over `[fld(sum(weight)-1, required_partitions), sum(weight)]`. 
+Binary Search for the partitioning over `[fld(sum(weight)-1, required_partitions), sum(weight)]`.
 """
 function optimal_contiguous_partition(
     weight::Vector{<:Integer},
@@ -185,7 +183,7 @@ function optimal_contiguous_partition(
 
     # Find optimal balance
     while up_bound > low_bound+1
-        search_for = fld(up_bound+low_bound, 2) 
+        search_for = fld(up_bound+low_bound, 2)
 
         sum_part = 0
         remain_part = required_partitions

--- a/src/vertexcover/random_vertex_cover.jl
+++ b/src/vertexcover/random_vertex_cover.jl
@@ -3,9 +3,9 @@ export RandomVertexCover
 struct RandomVertexCover end
 
 """
-    vertex_cover(g, RandomVertexCover(); seed=-1)
+    vertex_cover(g, RandomVertexCover(); rng=Random.GLOBAL_RNG)
 
-Find a set of vertices such that every edge in `g` has some vertex in the set as 
+Find a set of vertices such that every edge in `g` has some vertex in the set as
 atleast one of its end point.
 
 ### Implementation Notes
@@ -18,20 +18,20 @@ Memory: O(|E|)
 Approximation Factor: 2
 
 ### Optional Arguments
-- If `seed >= 0`, a random generator is seeded with this value.
+- A random number generator `rng`, defaulting to `Random.GLOBAL_RNG`.
 """
 function vertex_cover(
     g::AbstractGraph{T},
     alg::RandomVertexCover;
-    seed::Int=-1
-    ) where T <: Integer 
+    rng::AbstractRNG=Random.GLOBAL_RNG
+    ) where T <: Integer
 
     (ne(g) > 0) || return Vector{T}() #Shuffle raises error
-    nvg = nv(g)  
+    nvg = nv(g)
     in_cover = falses(nvg)
     length_cover = 0
 
-    @inbounds for e in shuffle(getRNG(seed), collect(edges(g)))
+    @inbounds for e in shuffle(rng, collect(edges(g)))
         u = src(e)
         v = dst(e)
         if !(in_cover[u] || in_cover[v])
@@ -42,4 +42,3 @@ function vertex_cover(
 
     return LightGraphs.findall!(in_cover, Vector{T}(undef, length_cover))
 end
-

--- a/test/cycles/hawick-james.jl
+++ b/test/cycles/hawick-james.jl
@@ -58,7 +58,7 @@
 
     # These test cases cover a bug that occurred in a previous version
     @testset "bugfix (unknown issue; PR#1007) ($seed)" for seed in [1, 2, 3], (n, k) in [(14, 18), (10, 22), (7, 16)]
-        g = erdos_renyi(n, k, is_directed=true, seed=seed)
+        g = erdos_renyi(n, k, is_directed=true, rng=rng)
         cycles1 = simplecycles(g)
         cycles2 = simplecycles_hawick_james(g)
         foreach(sort!, cycles1)

--- a/test/cycles/hawick-james.jl
+++ b/test/cycles/hawick-james.jl
@@ -58,7 +58,8 @@
 
     # These test cases cover a bug that occurred in a previous version
     @testset "bugfix (unknown issue; PR#1007) ($seed)" for seed in [1, 2, 3], (n, k) in [(14, 18), (10, 22), (7, 16)]
-        g = erdos_renyi(n, k, is_directed=true, rng=rng)
+        Random.seed!(seed)
+        g = erdos_renyi(n, k, is_directed=true)
         cycles1 = simplecycles(g)
         cycles2 = simplecycles_hawick_james(g)
         foreach(sort!, cycles1)

--- a/test/dominatingset/minimal_dom_set.jl
+++ b/test/dominatingset/minimal_dom_set.jl
@@ -2,37 +2,37 @@
  
     g0 = SimpleGraph(0)
     for g in testgraphs(g0)
-        d = @inferred(dominating_set(g, MinimalDominatingSet(); seed=3))
+        d = @inferred(dominating_set(g, MinimalDominatingSet(); rng=Random.MersenneTwister(3)))
         @test isempty(d)
     end
 
     g1 = SimpleGraph(1)
     for g in testgraphs(g1)
-        d = @inferred(dominating_set(g, MinimalDominatingSet(); seed=3))
+        d = @inferred(dominating_set(g, MinimalDominatingSet(); rng=Random.MersenneTwister(3)))
         @test (d == [1,])
     end
 
     add_edge!(g1, 1, 1)
     for g in testgraphs(g1)
-        d = @inferred(dominating_set(g, MinimalDominatingSet(); seed=3))
+        d = @inferred(dominating_set(g, MinimalDominatingSet(); rng=Random.MersenneTwister(3)))
         @test (d == [1,])
     end
 
     g3 = StarGraph(5)
     for g in testgraphs(g3)
-        d = @inferred(dominating_set(g, MinimalDominatingSet(); seed=3))
+        d = @inferred(dominating_set(g, MinimalDominatingSet(); rng=Random.MersenneTwister(3)))
         @test (length(d)== 1 || (length(d)== 4 && minimum(d) > 1 ))
     end
     
     g4 = CompleteGraph(5)
     for g in testgraphs(g4)
-        d = @inferred(dominating_set(g, MinimalDominatingSet(); seed=3))
+        d = @inferred(dominating_set(g, MinimalDominatingSet(); rng=Random.MersenneTwister(3)))
         @test length(d)== 1 #Exactly one vertex
     end
 
     g5 = PathGraph(4)
     for g in testgraphs(g5)
-        d = @inferred(dominating_set(g, MinimalDominatingSet(); seed=3))
+        d = @inferred(dominating_set(g, MinimalDominatingSet(); rng=Random.MersenneTwister(3)))
         sort!(d)
         @test (d == [1, 2, 4] || d == [1, 3] || d == [1, 4] || d == [2, 3] || d == [2, 4])
     end
@@ -40,7 +40,7 @@
     add_edge!(g5, 2, 2)
     add_edge!(g5, 3, 3)
     for g in testgraphs(g5)
-        d = @inferred(dominating_set(g, MinimalDominatingSet(); seed=3))
+        d = @inferred(dominating_set(g, MinimalDominatingSet(); rng=Random.MersenneTwister(3)))
         sort!(d)
         @test (d == [1, 2, 4] || d == [1, 3] || d == [1, 4] || d == [2, 3] || d == [2, 4])
     end

--- a/test/dominatingset/minimal_dom_set.jl
+++ b/test/dominatingset/minimal_dom_set.jl
@@ -2,37 +2,37 @@
  
     g0 = SimpleGraph(0)
     for g in testgraphs(g0)
-        d = @inferred(dominating_set(g, MinimalDominatingSet(); rng=Random.MersenneTwister(3)))
+        d = @inferred(dominating_set(g, MinimalDominatingSet(); rng=MersenneTwister(3)))
         @test isempty(d)
     end
 
     g1 = SimpleGraph(1)
     for g in testgraphs(g1)
-        d = @inferred(dominating_set(g, MinimalDominatingSet(); rng=Random.MersenneTwister(3)))
+        d = @inferred(dominating_set(g, MinimalDominatingSet(); rng=MersenneTwister(3)))
         @test (d == [1,])
     end
 
     add_edge!(g1, 1, 1)
     for g in testgraphs(g1)
-        d = @inferred(dominating_set(g, MinimalDominatingSet(); rng=Random.MersenneTwister(3)))
+        d = @inferred(dominating_set(g, MinimalDominatingSet(); rng=MersenneTwister(3)))
         @test (d == [1,])
     end
 
     g3 = StarGraph(5)
     for g in testgraphs(g3)
-        d = @inferred(dominating_set(g, MinimalDominatingSet(); rng=Random.MersenneTwister(3)))
+        d = @inferred(dominating_set(g, MinimalDominatingSet(); rng=MersenneTwister(3)))
         @test (length(d)== 1 || (length(d)== 4 && minimum(d) > 1 ))
     end
     
     g4 = CompleteGraph(5)
     for g in testgraphs(g4)
-        d = @inferred(dominating_set(g, MinimalDominatingSet(); rng=Random.MersenneTwister(3)))
+        d = @inferred(dominating_set(g, MinimalDominatingSet(); rng=MersenneTwister(3)))
         @test length(d)== 1 #Exactly one vertex
     end
 
     g5 = PathGraph(4)
     for g in testgraphs(g5)
-        d = @inferred(dominating_set(g, MinimalDominatingSet(); rng=Random.MersenneTwister(3)))
+        d = @inferred(dominating_set(g, MinimalDominatingSet(); rng=MersenneTwister(3)))
         sort!(d)
         @test (d == [1, 2, 4] || d == [1, 3] || d == [1, 4] || d == [2, 3] || d == [2, 4])
     end
@@ -40,7 +40,7 @@
     add_edge!(g5, 2, 2)
     add_edge!(g5, 3, 3)
     for g in testgraphs(g5)
-        d = @inferred(dominating_set(g, MinimalDominatingSet(); rng=Random.MersenneTwister(3)))
+        d = @inferred(dominating_set(g, MinimalDominatingSet(); rng=MersenneTwister(3)))
         sort!(d)
         @test (d == [1, 2, 4] || d == [1, 3] || d == [1, 4] || d == [2, 3] || d == [2, 4])
     end

--- a/test/experimental/isomorphism.jl
+++ b/test/experimental/isomorphism.jl
@@ -1,5 +1,6 @@
-using Random: MersenneTwister, randperm
+import Random
 
+using Random: MersenneTwister, randperm
 
 # helper function that permutates the vertices of a graph
 function shuffle_vertices(g::AbstractGraph, σ)
@@ -104,7 +105,7 @@ end
     @test count_isomorph(CompleteGraph(4), CycleGraph(4)) == 0
     @test isempty(all_isomorph(CompleteGraph(4), CycleGraph(4)))
     @test count_subgraphisomorph(CompleteGraph(3), CompleteGraph(4)) == 0
-    
+
 
     # this tests triggers the shortcut in the vf2 algorithm if the first graph is smaller than the second one
     @test has_isomorph(CompleteGraph(3), CompleteGraph(4)) == false

--- a/test/independentset/maximal_ind_set.jl
+++ b/test/independentset/maximal_ind_set.jl
@@ -2,37 +2,37 @@
 
     g0 = SimpleGraph(0)
     for g in testgraphs(g0)
-        z = @inferred(independent_set(g, MaximalIndependentSet(); rng=Random.MersenneTwister(3)))
+        z = @inferred(independent_set(g, MaximalIndependentSet(); rng=MersenneTwister(3)))
         @test isempty(z)
     end
 
     g1 = SimpleGraph(1)
     for g in testgraphs(g1)
-        z = @inferred(independent_set(g, MaximalIndependentSet(); rng=Random.MersenneTwister(3)))
+        z = @inferred(independent_set(g, MaximalIndependentSet(); rng=MersenneTwister(3)))
         @test (z == [1,])
     end
 
     add_edge!(g1, 1, 1)
     for g in testgraphs(g1)
-        z = @inferred(independent_set(g, MaximalIndependentSet(); rng=Random.MersenneTwister(3)))
+        z = @inferred(independent_set(g, MaximalIndependentSet(); rng=MersenneTwister(3)))
         isempty(z)
     end
   
     g3 = StarGraph(5)
     for g in testgraphs(g3)
-        z = @inferred(independent_set(g, MaximalIndependentSet(); rng=Random.MersenneTwister(3)))
+        z = @inferred(independent_set(g, MaximalIndependentSet(); rng=MersenneTwister(3)))
         @test (length(z)== 1 || length(z)== 4)
     end
     
     g4 = CompleteGraph(5)
     for g in testgraphs(g4)
-        z = @inferred(independent_set(g, MaximalIndependentSet(); rng=Random.MersenneTwister(3)))
+        z = @inferred(independent_set(g, MaximalIndependentSet(); rng=MersenneTwister(3)))
         @test length(z)== 1 #Exactly one vertex 
     end
 
     g5 = PathGraph(5)
     for g in testgraphs(g5)
-        z = @inferred(independent_set(g, MaximalIndependentSet(); rng=Random.MersenneTwister(3)))
+        z = @inferred(independent_set(g, MaximalIndependentSet(); rng=MersenneTwister(3)))
         sort!(z)
         @test (z == [2, 4] || z == [2, 5] || z == [1, 3, 5] || z == [1, 4])
     end
@@ -40,7 +40,7 @@
     add_edge!(g5, 2, 2)
     add_edge!(g5, 3, 3)
     for g in testgraphs(g5)
-        z = @inferred(independent_set(g, MaximalIndependentSet(); rng=Random.MersenneTwister(3)))
+        z = @inferred(independent_set(g, MaximalIndependentSet(); rng=MersenneTwister(3)))
         sort!(z)
         @test (z == [4,] || z == [5,] || z == [1, 5] || z == [1, 4])
     end

--- a/test/independentset/maximal_ind_set.jl
+++ b/test/independentset/maximal_ind_set.jl
@@ -2,37 +2,37 @@
 
     g0 = SimpleGraph(0)
     for g in testgraphs(g0)
-        z = @inferred(independent_set(g, MaximalIndependentSet(); seed=3))
+        z = @inferred(independent_set(g, MaximalIndependentSet(); rng=Random.MersenneTwister(3)))
         @test isempty(z)
     end
 
     g1 = SimpleGraph(1)
     for g in testgraphs(g1)
-        z = @inferred(independent_set(g, MaximalIndependentSet(); seed=3))
+        z = @inferred(independent_set(g, MaximalIndependentSet(); rng=Random.MersenneTwister(3)))
         @test (z == [1,])
     end
 
     add_edge!(g1, 1, 1)
     for g in testgraphs(g1)
-        z = @inferred(independent_set(g, MaximalIndependentSet(); seed=3))
+        z = @inferred(independent_set(g, MaximalIndependentSet(); rng=Random.MersenneTwister(3)))
         isempty(z)
     end
   
     g3 = StarGraph(5)
     for g in testgraphs(g3)
-        z = @inferred(independent_set(g, MaximalIndependentSet(); seed=3))
+        z = @inferred(independent_set(g, MaximalIndependentSet(); rng=Random.MersenneTwister(3)))
         @test (length(z)== 1 || length(z)== 4)
     end
     
     g4 = CompleteGraph(5)
     for g in testgraphs(g4)
-        z = @inferred(independent_set(g, MaximalIndependentSet(); seed=3))
+        z = @inferred(independent_set(g, MaximalIndependentSet(); rng=Random.MersenneTwister(3)))
         @test length(z)== 1 #Exactly one vertex 
     end
 
     g5 = PathGraph(5)
     for g in testgraphs(g5)
-        z = @inferred(independent_set(g, MaximalIndependentSet(); seed=3))
+        z = @inferred(independent_set(g, MaximalIndependentSet(); rng=Random.MersenneTwister(3)))
         sort!(z)
         @test (z == [2, 4] || z == [2, 5] || z == [1, 3, 5] || z == [1, 4])
     end
@@ -40,7 +40,7 @@
     add_edge!(g5, 2, 2)
     add_edge!(g5, 3, 3)
     for g in testgraphs(g5)
-        z = @inferred(independent_set(g, MaximalIndependentSet(); seed=3))
+        z = @inferred(independent_set(g, MaximalIndependentSet(); rng=Random.MersenneTwister(3)))
         sort!(z)
         @test (z == [4,] || z == [5,] || z == [1, 5] || z == [1, 4])
     end

--- a/test/shortestpaths/desopo-pape.jl
+++ b/test/shortestpaths/desopo-pape.jl
@@ -115,9 +115,8 @@
         @test isapprox(z.dists, y.dists)
 
         G = StarGraph(9)
-        z = deso
+        z = desopo_pape_shortest_paths(G, 1)
         rng = MersenneTwister(Int(floor(100*rand())))
-        po_pape_shortest_paths(G, 1)
         y = dijkstra_shortest_paths(G, 1)
         @test isapprox(z.dists, y.dists)
 

--- a/test/shortestpaths/desopo-pape.jl
+++ b/test/shortestpaths/desopo-pape.jl
@@ -9,7 +9,7 @@
         @test y.parents == z.parents == [0, 0, 2, 3, 4]
         @test y.dists == z.dists == [Inf, 0, 6, 17, 33]
     end
-        
+
     gx = PathGraph(5)
     add_edge!(gx, 2, 4)
     d = ones(Int, 5, 5)
@@ -73,8 +73,8 @@
         for i = 1:5
             nvg = Int(ceil(250*rand()))
             neg = Int(floor((nvg*(nvg-1)/2)*rand()))
-            seed = Int(floor(100*rand()))
-            g = SimpleGraph(nvg, neg; seed = seed)
+            rng = Random.MersenneTwister(Int(floor(100*rand())))
+            g = SimpleGraph(nvg, neg; rng=rng)
             z = desopo_pape_shortest_paths(g, 1)
             y = dijkstra_shortest_paths(g, 1)
             @test isapprox(z.dists, y.dists)
@@ -85,8 +85,8 @@
         for i = 1:5
             nvg = Int(ceil(250*rand()))
             neg = Int(floor((nvg*(nvg-1)/2)*rand()))
-            seed = Int(floor(100*rand()))
-            g = SimpleDiGraph(nvg, neg; seed = seed)
+            rng = Random.MersenneTwister(Int(floor(100*rand())))
+            g = SimpleDiGraph(nvg, neg; rng=rng)
             z = desopo_pape_shortest_paths(g, 1)
             y = dijkstra_shortest_paths(g, 1)
             @test isapprox(z.dists, y.dists)
@@ -115,7 +115,9 @@
         @test isapprox(z.dists, y.dists)
 
         G = StarGraph(9)
-        z = desopo_pape_shortest_paths(G, 1)
+        z = deso
+        rng = Random.MersenneTwister(Int(floor(100*rand())))
+        po_pape_shortest_paths(G, 1)
         y = dijkstra_shortest_paths(G, 1)
         @test isapprox(z.dists, y.dists)
 
@@ -136,10 +138,10 @@
     end
 
     @testset "smallgraphs: $s" for s in [
-        :bull, :chvatal, :cubical, :desargues, 
-        :diamond, :dodecahedral, :frucht, :heawood, 
+        :bull, :chvatal, :cubical, :desargues,
+        :diamond, :dodecahedral, :frucht, :heawood,
         :house, :housex, :icosahedral, :krackhardtkite, :moebiuskantor,
-        :octahedral, :pappus, :petersen, :sedgewickmaze, :tutte, 
+        :octahedral, :pappus, :petersen, :sedgewickmaze, :tutte,
         :tetrahedral, :truncatedcube, :truncatedtetrahedron,
         :truncatedtetrahedron_dir
      ]
@@ -148,7 +150,7 @@
         y = dijkstra_shortest_paths(G, 1)
         @test isapprox(z.dists, y.dists)
     end
-    
+
     @testset "errors" begin
         g = Graph()
         @test_throws DomainError desopo_pape_shortest_paths(g, 1)

--- a/test/shortestpaths/desopo-pape.jl
+++ b/test/shortestpaths/desopo-pape.jl
@@ -73,7 +73,7 @@
         for i = 1:5
             nvg = Int(ceil(250*rand()))
             neg = Int(floor((nvg*(nvg-1)/2)*rand()))
-            rng = Random.MersenneTwister(Int(floor(100*rand())))
+            rng = MersenneTwister(Int(floor(100*rand())))
             g = SimpleGraph(nvg, neg; rng=rng)
             z = desopo_pape_shortest_paths(g, 1)
             y = dijkstra_shortest_paths(g, 1)
@@ -85,7 +85,7 @@
         for i = 1:5
             nvg = Int(ceil(250*rand()))
             neg = Int(floor((nvg*(nvg-1)/2)*rand()))
-            rng = Random.MersenneTwister(Int(floor(100*rand())))
+            rng = MersenneTwister(Int(floor(100*rand())))
             g = SimpleDiGraph(nvg, neg; rng=rng)
             z = desopo_pape_shortest_paths(g, 1)
             y = dijkstra_shortest_paths(g, 1)
@@ -116,7 +116,7 @@
 
         G = StarGraph(9)
         z = deso
-        rng = Random.MersenneTwister(Int(floor(100*rand())))
+        rng = MersenneTwister(Int(floor(100*rand())))
         po_pape_shortest_paths(G, 1)
         y = dijkstra_shortest_paths(G, 1)
         @test isapprox(z.dists, y.dists)

--- a/test/shortestpaths/spfa.jl
+++ b/test/shortestpaths/spfa.jl
@@ -77,8 +77,8 @@
             for i = 1:5
                 nvg = Int(ceil(250*rand()))
                 neg = Int(floor((nvg*(nvg-1)/2)*rand()))
-                seed = Int(floor(100*rand()))
-                g = SimpleGraph(nvg, neg; seed = seed)
+                rng = Random.MersenneTwister(Int(floor(100*rand())))
+                g = SimpleGraph(nvg, neg; rng=rng)
                 z = spfa_shortest_paths(g, 1)
                 y = dijkstra_shortest_paths(g, 1)
                 @test isapprox(z, y.dists)
@@ -89,8 +89,8 @@
             for i = 1:5
                 nvg = Int(ceil(250*rand()))
                 neg = Int(floor((nvg*(nvg-1)/2)*rand()))
-                seed = Int(floor(100*rand()))
-                g = SimpleDiGraph(nvg, neg; seed = seed)
+                rng = Random.MersenneTwister(Int(floor(100*rand())))
+                g = SimpleDiGraph(nvg, neg; rng=rng)
                 z = spfa_shortest_paths(g, 1)
                 y = dijkstra_shortest_paths(g, 1)
                 @test isapprox(z, y.dists)

--- a/test/shortestpaths/spfa.jl
+++ b/test/shortestpaths/spfa.jl
@@ -77,7 +77,7 @@
             for i = 1:5
                 nvg = Int(ceil(250*rand()))
                 neg = Int(floor((nvg*(nvg-1)/2)*rand()))
-                rng = Random.MersenneTwister(Int(floor(100*rand())))
+                rng = MersenneTwister(Int(floor(100*rand())))
                 g = SimpleGraph(nvg, neg; rng=rng)
                 z = spfa_shortest_paths(g, 1)
                 y = dijkstra_shortest_paths(g, 1)
@@ -89,7 +89,7 @@
             for i = 1:5
                 nvg = Int(ceil(250*rand()))
                 neg = Int(floor((nvg*(nvg-1)/2)*rand()))
-                rng = Random.MersenneTwister(Int(floor(100*rand())))
+                rng = MersenneTwister(Int(floor(100*rand())))
                 g = SimpleDiGraph(nvg, neg; rng=rng)
                 z = spfa_shortest_paths(g, 1)
                 y = dijkstra_shortest_paths(g, 1)

--- a/test/simplegraphs/generators/randgraphs.jl
+++ b/test/simplegraphs/generators/randgraphs.jl
@@ -9,11 +9,11 @@
         @test eltype(r1) == Int
         @test eltype(r2) == Int
 
-        @test SimpleGraph(10, 20, rng=Random.MersenneTwister(3)) == SimpleGraph(10, 20, rng=Random.MersenneTwister(3))
-        @test SimpleDiGraph(10, 20, rng=Random.MersenneTwister(3)) == SimpleDiGraph(10, 20, rng=Random.MersenneTwister(3))
-        @test SimpleGraph(10, 20, rng=Random.MersenneTwister(3)) == erdos_renyi(10, 20, rng=Random.MersenneTwister(3))
-        @test ne(Graph(10, 40, rng=Random.MersenneTwister(3))) == 40
-        @test ne(DiGraph(10, 80, rng=Random.MersenneTwister(3))) == 80
+        @test SimpleGraph(10, 20, rng=MersenneTwister(3)) == SimpleGraph(10, 20, rng=MersenneTwister(3))
+        @test SimpleDiGraph(10, 20, rng=MersenneTwister(3)) == SimpleDiGraph(10, 20, rng=MersenneTwister(3))
+        @test SimpleGraph(10, 20, rng=MersenneTwister(3)) == erdos_renyi(10, 20, rng=MersenneTwister(3))
+        @test ne(Graph(10, 40, rng=MersenneTwister(3))) == 40
+        @test ne(DiGraph(10, 80, rng=MersenneTwister(3))) == 80
     end
 
     @testset "(UInt8, Mixed) eltype" begin
@@ -36,7 +36,7 @@
         @test nv(er) == 10
         @test is_directed(er) == true
 
-        er = erdos_renyi(10, 0.5, rng=Random.MersenneTwister(17))
+        er = erdos_renyi(10, 0.5, rng=MersenneTwister(17))
         @test nv(er) == 10
         @test is_directed(er) == false
 
@@ -47,16 +47,16 @@
     end
 
     @testset "expected degree" begin
-        cl = expected_degree_graph(zeros(10), rng=Random.MersenneTwister(17))
+        cl = expected_degree_graph(zeros(10), rng=MersenneTwister(17))
         @test nv(cl) == 10
         @test ne(cl) == 0
         @test is_directed(cl) == false
 
-        cl = expected_degree_graph([3, 2, 1, 2], rng=Random.MersenneTwister(17))
+        cl = expected_degree_graph([3, 2, 1, 2], rng=MersenneTwister(17))
         @test nv(cl) == 4
         @test is_directed(cl) == false
 
-        cl = expected_degree_graph(fill(99, 100), rng=Random.MersenneTwister(17))
+        cl = expected_degree_graph(fill(99, 100), rng=MersenneTwister(17))
         @test nv(cl) == 100
         @test all(degree(cl) .> 90)
 
@@ -171,7 +171,7 @@
         @test ne(rd) == 0
         @test is_directed(rd)
 
-        rr = random_regular_graph(10, 8, rng=Random.MersenneTwister(4))
+        rr = random_regular_graph(10, 8, rng=MersenneTwister(4))
         @test nv(rr) == 10
         @test ne(rr) == 40
         @test is_directed(rr) == false
@@ -200,14 +200,14 @@
         indegree_rd = @inferred(indegree(rd))
         @test all(indegree_rd .== indegree_rd[1])
 
-        rd = random_regular_digraph(10, 8, dir=:out, rng=Random.MersenneTwister(4))
+        rd = random_regular_digraph(10, 8, dir=:out, rng=MersenneTwister(4))
         @test nv(rd) == 10
         @test ne(rd) == 80
         @test is_directed(rd)
     end
 
     @testset "random configuration model" begin
-        rr = random_configuration_model(10, repeat([2,4], 5), rng=Random.MersenneTwister(3))
+        rr = random_configuration_model(10, repeat([2,4], 5), rng=MersenneTwister(3))
         @test nv(rr) == 10
         @test ne(rr) == 15
         @test is_directed(rr) == false

--- a/test/simplegraphs/generators/randgraphs.jl
+++ b/test/simplegraphs/generators/randgraphs.jl
@@ -9,11 +9,11 @@
         @test eltype(r1) == Int
         @test eltype(r2) == Int
 
-        @test SimpleGraph(10, 20, seed=3) == SimpleGraph(10, 20, seed=3)
-        @test SimpleDiGraph(10, 20, seed=3) == SimpleDiGraph(10, 20, seed=3)
-        @test SimpleGraph(10, 20, seed=3) == erdos_renyi(10, 20, seed=3)
-        @test ne(Graph(10, 40, seed=3)) == 40
-        @test ne(DiGraph(10, 80, seed=3)) == 80
+        @test SimpleGraph(10, 20, rng=Random.MersenneTwister(3)) == SimpleGraph(10, 20, rng=Random.MersenneTwister(3))
+        @test SimpleDiGraph(10, 20, rng=Random.MersenneTwister(3)) == SimpleDiGraph(10, 20, rng=Random.MersenneTwister(3))
+        @test SimpleGraph(10, 20, rng=Random.MersenneTwister(3)) == erdos_renyi(10, 20, rng=Random.MersenneTwister(3))
+        @test ne(Graph(10, 40, rng=Random.MersenneTwister(3))) == 40
+        @test ne(DiGraph(10, 80, rng=Random.MersenneTwister(3))) == 80
     end
 
     @testset "(UInt8, Mixed) eltype" begin
@@ -36,7 +36,7 @@
         @test nv(er) == 10
         @test is_directed(er) == true
 
-        er = erdos_renyi(10, 0.5, seed=17)
+        er = erdos_renyi(10, 0.5, rng=Random.MersenneTwister(17))
         @test nv(er) == 10
         @test is_directed(er) == false
 
@@ -47,16 +47,16 @@
     end
 
     @testset "expected degree" begin
-        cl = expected_degree_graph(zeros(10), seed=17)
+        cl = expected_degree_graph(zeros(10), rng=Random.MersenneTwister(17))
         @test nv(cl) == 10
         @test ne(cl) == 0
         @test is_directed(cl) == false
 
-        cl = expected_degree_graph([3, 2, 1, 2], seed=17)
+        cl = expected_degree_graph([3, 2, 1, 2], rng=Random.MersenneTwister(17))
         @test nv(cl) == 4
         @test is_directed(cl) == false
 
-        cl = expected_degree_graph(fill(99, 100), seed=17)
+        cl = expected_degree_graph(fill(99, 100), rng=Random.MersenneTwister(17))
         @test nv(cl) == 100
         @test all(degree(cl) .> 90)
 
@@ -171,7 +171,7 @@
         @test ne(rd) == 0
         @test is_directed(rd)
 
-        rr = random_regular_graph(10, 8, seed=4)
+        rr = random_regular_graph(10, 8, rng=Random.MersenneTwister(4))
         @test nv(rr) == 10
         @test ne(rr) == 40
         @test is_directed(rr) == false
@@ -200,14 +200,14 @@
         indegree_rd = @inferred(indegree(rd))
         @test all(indegree_rd .== indegree_rd[1])
 
-        rd = random_regular_digraph(10, 8, dir=:out, seed=4)
+        rd = random_regular_digraph(10, 8, dir=:out, rng=Random.MersenneTwister(4))
         @test nv(rd) == 10
         @test ne(rd) == 80
         @test is_directed(rd)
     end
 
     @testset "random configuration model" begin
-        rr = random_configuration_model(10, repeat([2,4], 5), seed=3)
+        rr = random_configuration_model(10, repeat([2,4], 5), rng=Random.MersenneTwister(3))
         @test nv(rr) == 10
         @test ne(rr) == 15
         @test is_directed(rr) == false

--- a/test/simplegraphs/generators/randgraphs.jl
+++ b/test/simplegraphs/generators/randgraphs.jl
@@ -348,7 +348,7 @@
         @test !is_cyclic(rog2)
 
         # testing with abstract RNG
-        rog3 = random_orientation_dag(SimpleGraph(10,15), 323)
+        rog3 = random_orientation_dag(SimpleGraph(10,15), MersenneTwister(123))
         @test isvalid_simplegraph(rog3)
         @test !is_cyclic(rog3)
     end

--- a/test/simplegraphs/simpleedgeiter.jl
+++ b/test/simplegraphs/simpleedgeiter.jl
@@ -1,8 +1,8 @@
 @testset "SimpleEdgeIter" begin
-    ga = @inferred(SimpleGraph(10, 20; rng=Random.MersenneTwister(1)))
-    gb = @inferred(SimpleGraph(10, 20; rng=Random.MersenneTwister(1)))
-    dga = @inferred(SimpleDiGraph(10, 20; rng=Random.MersenneTwister(1)))
-    dgb = @inferred(SimpleDiGraph(10, 20; rng=Random.MersenneTwister(1)))
+    ga = @inferred(SimpleGraph(10, 20; rng=MersenneTwister(1)))
+    gb = @inferred(SimpleGraph(10, 20; rng=MersenneTwister(1)))
+    dga = @inferred(SimpleDiGraph(10, 20; rng=MersenneTwister(1)))
+    dgb = @inferred(SimpleDiGraph(10, 20; rng=MersenneTwister(1)))
     @testset "string representation" begin
         @test sprint(show, edges(ga)) == "SimpleEdgeIter 20"
     # note: we don't get the first iterator state,

--- a/test/simplegraphs/simpleedgeiter.jl
+++ b/test/simplegraphs/simpleedgeiter.jl
@@ -1,8 +1,8 @@
 @testset "SimpleEdgeIter" begin
-    ga = @inferred(SimpleGraph(10, 20; seed=1))
-    gb = @inferred(SimpleGraph(10, 20; seed=1))
-    dga = @inferred(SimpleDiGraph(10, 20; seed=1))
-    dgb = @inferred(SimpleDiGraph(10, 20; seed=1))
+    ga = @inferred(SimpleGraph(10, 20; rng=Random.MersenneTwister(1)))
+    gb = @inferred(SimpleGraph(10, 20; rng=Random.MersenneTwister(1)))
+    dga = @inferred(SimpleDiGraph(10, 20; rng=Random.MersenneTwister(1)))
+    dgb = @inferred(SimpleDiGraph(10, 20; rng=Random.MersenneTwister(1)))
     @testset "string representation" begin
         @test sprint(show, edges(ga)) == "SimpleEdgeIter 20"
     # note: we don't get the first iterator state,

--- a/test/simplegraphs/simplegraphs.jl
+++ b/test/simplegraphs/simplegraphs.jl
@@ -199,7 +199,7 @@ import Random
 
      # Tests for constructors from iterators of edges
     let
-        g_undir = erdos_renyi(200, 100; seed=0)
+        g_undir = erdos_renyi(200, 100; rng=Random.MersenneTwister(0))
         add_edge!(g_undir, 200, 1) # ensure that the result uses all vertices
         add_edge!(g_undir, 2, 2) # add a self-loop
         for g in testgraphs(g_undir)
@@ -218,7 +218,7 @@ import Random
             edge_set_any = Set{Any}(edge_list)
 
             g1 = @inferred SimpleGraph(edge_list)
-            # we can't infer the return type of SimpleGraphFromIterator at the moment 
+            # we can't infer the return type of SimpleGraphFromIterator at the moment
             g2 = SimpleGraphFromIterator(edge_list)
             g3 = SimpleGraphFromIterator(edge_iter)
             g4 = SimpleGraphFromIterator(edge_set)
@@ -235,20 +235,20 @@ import Random
             @test edgetype(g) == edgetype(g4)
             @test edgetype(g) == edgetype(g5)
         end
-        g_dir = erdos_renyi(200, 100; is_directed=true, seed=0)
+        g_dir = erdos_renyi(200, 100; is_directed=true, rng=Random.MersenneTwister(0))
         add_edge!(g_dir, 200, 1)
         add_edge!(g_dir, 2, 2)
         for g in testdigraphs(g_dir)
             # We create an edge list and shuffle it
             edge_list = [e for e in edges(g)]
             shuffle!(MersenneTwister(0), edge_list)
-            
+
             edge_iter = (e for e in edge_list)
             edge_set = Set(edge_list)
             edge_set_any = Set{Any}(edge_list)
 
             g1 = @inferred SimpleDiGraph(edge_list)
-            # we can't infer the return type of SimpleDiGraphFromIterator at the moment 
+            # we can't infer the return type of SimpleDiGraphFromIterator at the moment
             g2 = SimpleDiGraphFromIterator(edge_list)
             g3 = SimpleDiGraphFromIterator(edge_iter)
             g4 = SimpleDiGraphFromIterator(edge_set)
@@ -274,7 +274,7 @@ import Random
         @test edgetype(SimpleGraphFromIterator(empty_iter)) == edgetype(SimpleGraph(0))
         @test edgetype(SimpleDiGraphFromIterator(empty_iter)) == edgetype(SimpleDiGraph(0))
 
-        # check if multiple edges && multiple self-loops result in the 
+        # check if multiple edges && multiple self-loops result in the
         # correct number of edges & vertices
         # edges using integers < 1 should be ignored
         g_undir = SimpleGraph(0)
@@ -296,7 +296,7 @@ import Random
             @test nv(g3) == 4
             @test nv(g4) == 4
             @test nv(g5) == 4
- 
+
             @test ne(g1) == 2
             @test ne(g2) == 2
             @test ne(g3) == 2
@@ -322,7 +322,7 @@ import Random
             @test nv(g3) == 4
             @test nv(g4) == 4
             @test nv(g5) == 4
- 
+
             @test ne(g1) == 3
             @test ne(g2) == 3
             @test ne(g3) == 3

--- a/test/simplegraphs/simplegraphs.jl
+++ b/test/simplegraphs/simplegraphs.jl
@@ -199,7 +199,7 @@ import Random
 
      # Tests for constructors from iterators of edges
     let
-        g_undir = erdos_renyi(200, 100; rng=Random.MersenneTwister(0))
+        g_undir = erdos_renyi(200, 100; rng=MersenneTwister(0))
         add_edge!(g_undir, 200, 1) # ensure that the result uses all vertices
         add_edge!(g_undir, 2, 2) # add a self-loop
         for g in testgraphs(g_undir)
@@ -235,7 +235,7 @@ import Random
             @test edgetype(g) == edgetype(g4)
             @test edgetype(g) == edgetype(g5)
         end
-        g_dir = erdos_renyi(200, 100; is_directed=true, rng=Random.MersenneTwister(0))
+        g_dir = erdos_renyi(200, 100; is_directed=true, rng=MersenneTwister(0))
         add_edge!(g_dir, 200, 1)
         add_edge!(g_dir, 2, 2)
         for g in testdigraphs(g_dir)

--- a/test/vertexcover/random_vertex_cover.jl
+++ b/test/vertexcover/random_vertex_cover.jl
@@ -2,37 +2,37 @@
 
     g0 = SimpleGraph(0)
     for g in testgraphs(g0)
-        c = @inferred(vertex_cover(g, RandomVertexCover(); seed=3))
+        c = @inferred(vertex_cover(g, RandomVertexCover(); rng=Random.MersenneTwister(3)))
         @test isempty(c)
     end
 
     g1 = SimpleGraph(1)
     for g in testgraphs(g1)
-        c = @inferred(vertex_cover(g, RandomVertexCover(); seed=3))
+        c = @inferred(vertex_cover(g, RandomVertexCover(); rng=Random.MersenneTwister(3)))
         @test isempty(c)
     end
 
     add_edge!(g1, 1, 1)
     for g in testgraphs(g1)
-        c = @inferred(vertex_cover(g, RandomVertexCover(); seed=3))
+        c = @inferred(vertex_cover(g, RandomVertexCover(); rng=Random.MersenneTwister(3)))
         @test c == [1,]
     end
 
     g3 = StarGraph(5)
     for g in testgraphs(g3)
-        c = @inferred(vertex_cover(g, RandomVertexCover(); seed=3))
+        c = @inferred(vertex_cover(g, RandomVertexCover(); rng=Random.MersenneTwister(3)))
         @test (length(c)== 2 && (c[1] == 1 || c[2] == 1))
     end
 
     g4 = CompleteGraph(5)
     for g in testgraphs(g4)
-        c = @inferred(vertex_cover(g, RandomVertexCover(); seed=3))
+        c = @inferred(vertex_cover(g, RandomVertexCover(); rng=Random.MersenneTwister(3)))
         @test length(c)== 4 #All except one vertex 
     end
     
     g5 = PathGraph(5)
     for g in testgraphs(g5)
-        c = @inferred(vertex_cover(g, RandomVertexCover(); seed=3))
+        c = @inferred(vertex_cover(g, RandomVertexCover(); rng=Random.MersenneTwister(3)))
         sort!(c)
         @test (c == [1, 2, 3, 4] || c == [1, 2, 4, 5] || c == [2, 3, 4, 5])
     end
@@ -40,7 +40,7 @@
     add_edge!(g5, 2, 2)
     add_edge!(g5, 3, 3)
     for g in testgraphs(g5)
-        c = @inferred(vertex_cover(g, RandomVertexCover(); seed=3))
+        c = @inferred(vertex_cover(g, RandomVertexCover(); rng=Random.MersenneTwister(3)))
         sort!(c)
         @test (c == [1, 2, 3, 4] || c == [1, 2, 3, 4, 5] || c == [2, 3, 4] || c == [2, 3, 4, 5])
     end

--- a/test/vertexcover/random_vertex_cover.jl
+++ b/test/vertexcover/random_vertex_cover.jl
@@ -2,37 +2,37 @@
 
     g0 = SimpleGraph(0)
     for g in testgraphs(g0)
-        c = @inferred(vertex_cover(g, RandomVertexCover(); rng=Random.MersenneTwister(3)))
+        c = @inferred(vertex_cover(g, RandomVertexCover(); rng=MersenneTwister(3)))
         @test isempty(c)
     end
 
     g1 = SimpleGraph(1)
     for g in testgraphs(g1)
-        c = @inferred(vertex_cover(g, RandomVertexCover(); rng=Random.MersenneTwister(3)))
+        c = @inferred(vertex_cover(g, RandomVertexCover(); rng=MersenneTwister(3)))
         @test isempty(c)
     end
 
     add_edge!(g1, 1, 1)
     for g in testgraphs(g1)
-        c = @inferred(vertex_cover(g, RandomVertexCover(); rng=Random.MersenneTwister(3)))
+        c = @inferred(vertex_cover(g, RandomVertexCover(); rng=MersenneTwister(3)))
         @test c == [1,]
     end
 
     g3 = StarGraph(5)
     for g in testgraphs(g3)
-        c = @inferred(vertex_cover(g, RandomVertexCover(); rng=Random.MersenneTwister(3)))
+        c = @inferred(vertex_cover(g, RandomVertexCover(); rng=MersenneTwister(3)))
         @test (length(c)== 2 && (c[1] == 1 || c[2] == 1))
     end
 
     g4 = CompleteGraph(5)
     for g in testgraphs(g4)
-        c = @inferred(vertex_cover(g, RandomVertexCover(); rng=Random.MersenneTwister(3)))
+        c = @inferred(vertex_cover(g, RandomVertexCover(); rng=MersenneTwister(3)))
         @test length(c)== 4 #All except one vertex 
     end
     
     g5 = PathGraph(5)
     for g in testgraphs(g5)
-        c = @inferred(vertex_cover(g, RandomVertexCover(); rng=Random.MersenneTwister(3)))
+        c = @inferred(vertex_cover(g, RandomVertexCover(); rng=MersenneTwister(3)))
         sort!(c)
         @test (c == [1, 2, 3, 4] || c == [1, 2, 4, 5] || c == [2, 3, 4, 5])
     end
@@ -40,7 +40,7 @@
     add_edge!(g5, 2, 2)
     add_edge!(g5, 3, 3)
     for g in testgraphs(g5)
-        c = @inferred(vertex_cover(g, RandomVertexCover(); rng=Random.MersenneTwister(3)))
+        c = @inferred(vertex_cover(g, RandomVertexCover(); rng=MersenneTwister(3)))
         sort!(c)
         @test (c == [1, 2, 3, 4] || c == [1, 2, 3, 4, 5] || c == [2, 3, 4] || c == [2, 3, 4, 5])
     end


### PR DESCRIPTION
As mentioned by @simonschoelly  in #1211, it would be interesting to let users provide their own RNG instead of having to use only MersenneTwister. This PR is thus replacing the seed keyword with rng, defaulting to GLOBAL_RNG 