### PR TITLE
Add the functions inedges and outedges

### DIFF
--- a/src/LightGraphs.jl
+++ b/src/LightGraphs.jl
@@ -25,7 +25,7 @@ AbstractGraph, AbstractEdge, AbstractEdgeIter,
 Edge, Graph, SimpleGraph, SimpleGraphFromIterator, DiGraph, SimpleDiGraphFromIterator,
 SimpleDiGraph, vertices, edges, edgetype, nv, ne, src, dst,
 is_directed, IsDirected,
-has_vertex, has_edge, inneighbors, outneighbors,
+has_vertex, has_edge, inneighbors, outneighbors, inedges, outedges,
 
 # core
 is_ordered, add_vertices!, indegree, outdegree, degree,

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -24,7 +24,6 @@ An abstract type representing a graph.
 """
 abstract type AbstractGraph{T} end
 
-
 @traitdef IsDirected{G<:AbstractGraph}
 @traitimpl IsDirected{G} <- is_directed(G)
 
@@ -333,7 +332,7 @@ julia> inedges(g, 4)
  Edge 5 => 4
 ```
 """
-inedges(g, v) = [edgetype(g)(x, v) for x in inneighbors(g, v)]
+inedges(g, v) = (edgetype(g)(x, v) for x in inneighbors(g, v))
 
 """
     outedges(g, v)
@@ -349,4 +348,4 @@ julia> outedges(g, 4)
  Edge 4 => 5
 ```
 """
-outedges(g, v) = [edgetype(g)(v, x) for x in outneighbors(g, v)]
+outedges(g, v) = (edgetype(g)(v, x) for x in outneighbors(g, v))

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -333,7 +333,7 @@ julia> inedges(g, 4)
  Edge 5 => 4
 ```
 """
-inedges(g, v) = [Edge(iv, v) for iv in inneighbors(g, v)]
+inedges(g, v) = [edgetype(g)(x, v) for x in inneighbors(g, v)]
 
 """
     outedges(g, v)
@@ -349,4 +349,4 @@ julia> outedges(g, 4)
  Edge 4 => 5
 ```
 """
-outedges(g, v) = [Edge(v, ov) for ov in outneighbors(g, v)]
+outedges(g, v) = [edgetype(g)(v, x) for x in outneighbors(g, v)]

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -317,3 +317,36 @@ julia> zero(g)
 ```
 """
 zero(g::AbstractGraph) = _NI("zero")
+
+"""
+    inedges(g, v)
+
+Return a list of all incoming edges to vertex `v` .
+
+# Examples
+```jldoctest
+julia> g = SimpleDiGraph([0 1 0 0 0; 0 0 1 0 0; 1 0 0 1 0; 0 0 0 0 1; 0 0 0 1 0]);
+
+julia> inedges(g, 4)
+2-element Array{LightGraphs.SimpleGraphs.SimpleEdge{Int64},1}:
+ Edge 3 => 4
+ Edge 5 => 4
+```
+"""
+inedges(g, v) = [Edge(iv, v) for iv in inneighbors(g, v)]
+
+"""
+    outedges(g, v)
+
+Return a list of all outgoing edges from vertex `v` .
+
+# Examples
+```jldoctest
+julia> g = SimpleDiGraph([0 1 0 0 0; 0 0 1 0 0; 1 0 0 1 0; 0 0 0 0 1; 0 0 0 1 0]);
+
+julia> outedges(g, 4)
+1-element Array{LightGraphs.SimpleGraphs.SimpleEdge{Int64},1}:
+ Edge 4 => 5
+```
+"""
+outedges(g, v) = [Edge(v, ov) for ov in outneighbors(g, v)]

--- a/test/interface.jl
+++ b/test/interface.jl
@@ -25,7 +25,7 @@ mutable struct DummyEdge <: AbstractEdge{Int} end
     end
 
     for graphfun1int in [
-        has_vertex, inneighbors, outneighbors
+        has_vertex, inneighbors, outneighbors, inedges, outedges
     ]
         @test_throws ErrorException graphfun1int(dummygraph, 1)
     end

--- a/test/simplegraphs/simplegraphs.jl
+++ b/test/simplegraphs/simplegraphs.jl
@@ -65,6 +65,8 @@ import Random
         @test add_edge!(gc, 4, 1) && gc == CycleGraph(4)
 
         @test @inferred(inneighbors(g, 2)) == @inferred(outneighbors(g, 2)) == @inferred(neighbors(g, 2)) == [1, 3]
+        @test @inferred(inedges(g, 2)) == [Edge(1, 2), Edge(3, 2)]
+        @test @inferred(outedges(g, 2)) == [Edge(2, 1), Edge(2, 3)]
         @test @inferred(add_vertex!(gc))   # out of order, but we want it for issubset
         @test @inferred(g ⊆ gc)
         @test @inferred(has_vertex(gc, 5))
@@ -218,7 +220,7 @@ import Random
             edge_set_any = Set{Any}(edge_list)
 
             g1 = @inferred SimpleGraph(edge_list)
-            # we can't infer the return type of SimpleGraphFromIterator at the moment 
+            # we can't infer the return type of SimpleGraphFromIterator at the moment
             g2 = SimpleGraphFromIterator(edge_list)
             g3 = SimpleGraphFromIterator(edge_iter)
             g4 = SimpleGraphFromIterator(edge_set)
@@ -242,13 +244,13 @@ import Random
             # We create an edge list and shuffle it
             edge_list = [e for e in edges(g)]
             shuffle!(MersenneTwister(0), edge_list)
-            
+
             edge_iter = (e for e in edge_list)
             edge_set = Set(edge_list)
             edge_set_any = Set{Any}(edge_list)
 
             g1 = @inferred SimpleDiGraph(edge_list)
-            # we can't infer the return type of SimpleDiGraphFromIterator at the moment 
+            # we can't infer the return type of SimpleDiGraphFromIterator at the moment
             g2 = SimpleDiGraphFromIterator(edge_list)
             g3 = SimpleDiGraphFromIterator(edge_iter)
             g4 = SimpleDiGraphFromIterator(edge_set)
@@ -274,7 +276,7 @@ import Random
         @test edgetype(SimpleGraphFromIterator(empty_iter)) == edgetype(SimpleGraph(0))
         @test edgetype(SimpleDiGraphFromIterator(empty_iter)) == edgetype(SimpleDiGraph(0))
 
-        # check if multiple edges && multiple self-loops result in the 
+        # check if multiple edges && multiple self-loops result in the
         # correct number of edges & vertices
         # edges using integers < 1 should be ignored
         g_undir = SimpleGraph(0)
@@ -296,7 +298,7 @@ import Random
             @test nv(g3) == 4
             @test nv(g4) == 4
             @test nv(g5) == 4
- 
+
             @test ne(g1) == 2
             @test ne(g2) == 2
             @test ne(g3) == 2
@@ -322,7 +324,7 @@ import Random
             @test nv(g3) == 4
             @test nv(g4) == 4
             @test nv(g5) == 4
- 
+
             @test ne(g1) == 3
             @test ne(g2) == 3
             @test ne(g3) == 3

--- a/test/simplegraphs/simplegraphs.jl
+++ b/test/simplegraphs/simplegraphs.jl
@@ -65,8 +65,8 @@ import Random
         @test add_edge!(gc, 4, 1) && gc == CycleGraph(4)
 
         @test @inferred(inneighbors(g, 2)) == @inferred(outneighbors(g, 2)) == @inferred(neighbors(g, 2)) == [1, 3]
-        @test @inferred(inedges(g, 2)) == [Edge(1, 2), Edge(3, 2)]
-        @test @inferred(outedges(g, 2)) == [Edge(2, 1), Edge(2, 3)]
+        @test @inferred(collect(inedges(g, 2))) == [Edge(1, 2), Edge(3, 2)]
+        @test @inferred(collect(outedges(g, 2))) == [Edge(2, 1), Edge(2, 3)]
         @test @inferred(add_vertex!(gc))   # out of order, but we want it for issubset
         @test @inferred(g ⊆ gc)
         @test @inferred(has_vertex(gc, 5))


### PR DESCRIPTION
Working with `inneighbors` and `outneighbors`, I was puzzled not to find related functions that return the corresponding edges. Hence this PR :)! 

For now, the test are not passing for type-related issues (how to create an edge with the right type, as the implementation should work for pretty much any graph type?): 

```
SimpleGraphs: Error During Test at C:\Users\Thibaut\.julia\dev\LightGraphs\test\simplegraphs\simplegraphs.jl:68
  Test threw exception
  Expression: #= C:\Users\Thibaut\.julia\dev\LightGraphs\test\simplegraphs\simplegraphs.jl:68 =# @inferred(inedges(g, 2)) == [Edge(1, 2), Edge(3, 2)]
  MethodError: no method matching SimpleEdge(::UInt8, ::Int64)
  Closest candidates are:
    SimpleEdge(::T<:Integer, !Matched::T<:Integer) where T<:Integer at C:\Users\Thibaut\.julia\dev\LightGraphs\src\SimpleGraphs\simpleedge.jl:7
  Stacktrace:
   [1] (::getfield(LightGraphs, Symbol("##1#2")){Int64})(::UInt8) at .\none:0
   [2] iterate at .\generator.jl:47 [inlined]
   [3] collect at .\array.jl:606 [inlined]
   [4] inedges(::SimpleGraph{UInt8}, ::Int64) at C:\Users\Thibaut\.julia\dev\LightGraphs\src\interface.jl:336
   [5] top-level scope at C:\Users\Thibaut\.julia\dev\LightGraphs\test\simplegraphs\simplegraphs.jl:68
   [6] top-level scope at C:\cygwin\home\Administrator\buildbot\worker\package_win64\build\usr\share\julia\stdlib\v1.1\Test\src\Test.jl:1083
   [7] top-level scope at C:\Users\Thibaut\.julia\dev\LightGraphs\test\simplegraphs\simplegraphs.jl:4
SimpleGraphs: Error During Test at C:\Users\Thibaut\.julia\dev\LightGraphs\test\simplegraphs\simplegraphs.jl:69
  Test threw exception
  Expression: #= C:\Users\Thibaut\.julia\dev\LightGraphs\test\simplegraphs\simplegraphs.jl:69 =# @inferred(outedges(g, 2)) == [Edge(2, 1), Edge(2, 3)]
  MethodError: no method matching SimpleEdge(::Int64, ::UInt8)
  Closest candidates are:
    SimpleEdge(::T<:Integer, !Matched::T<:Integer) where T<:Integer at C:\Users\Thibaut\.julia\dev\LightGraphs\src\SimpleGraphs\simpleedge.jl:7
  Stacktrace:
   [1] (::getfield(LightGraphs, Symbol("##3#4")){Int64})(::UInt8) at .\none:0
   [2] iterate at .\generator.jl:47 [inlined]
   [3] collect at .\array.jl:606 [inlined]
   [4] outedges(::SimpleGraph{UInt8}, ::Int64) at C:\Users\Thibaut\.julia\dev\LightGraphs\src\interface.jl:352
   [5] top-level scope at C:\Users\Thibaut\.julia\dev\LightGraphs\test\simplegraphs\simplegraphs.jl:69
   [6] top-level scope at C:\cygwin\home\Administrator\buildbot\worker\package_win64\build\usr\share\julia\stdlib\v1.1\Test\src\Test.jl:1083
   [7] top-level scope at C:\Users\Thibaut\.julia\dev\LightGraphs\test\simplegraphs\simplegraphs.jl:4
SimpleGraphs: Error During Test at C:\Users\Thibaut\.julia\dev\LightGraphs\test\simplegraphs\simplegraphs.jl:68
  Test threw exception
  Expression: #= C:\Users\Thibaut\.julia\dev\LightGraphs\test\simplegraphs\simplegraphs.jl:68 =# @inferred(inedges(g, 2)) == [Edge(1, 2), Edge(3, 2)]
  MethodError: no method matching SimpleEdge(::Int16, ::Int64)
  Closest candidates are:
    SimpleEdge(::T<:Integer, !Matched::T<:Integer) where T<:Integer at C:\Users\Thibaut\.julia\dev\LightGraphs\src\SimpleGraphs\simpleedge.jl:7
  Stacktrace:
   [1] (::getfield(LightGraphs, Symbol("##1#2")){Int64})(::Int16) at .\none:0
   [2] iterate at .\generator.jl:47 [inlined]
   [3] collect at .\array.jl:606 [inlined]
   [4] inedges(::SimpleGraph{Int16}, ::Int64) at C:\Users\Thibaut\.julia\dev\LightGraphs\src\interface.jl:336
   [5] top-level scope at C:\Users\Thibaut\.julia\dev\LightGraphs\test\simplegraphs\simplegraphs.jl:68
   [6] top-level scope at C:\cygwin\home\Administrator\buildbot\worker\package_win64\build\usr\share\julia\stdlib\v1.1\Test\src\Test.jl:1083
   [7] top-level scope at C:\Users\Thibaut\.julia\dev\LightGraphs\test\simplegraphs\simplegraphs.jl:4
SimpleGraphs: Error During Test at C:\Users\Thibaut\.julia\dev\LightGraphs\test\simplegraphs\simplegraphs.jl:69
  Test threw exception
  Expression: #= C:\Users\Thibaut\.julia\dev\LightGraphs\test\simplegraphs\simplegraphs.jl:69 =# @inferred(outedges(g, 2)) == [Edge(2, 1), Edge(2, 3)]
  MethodError: no method matching SimpleEdge(::Int64, ::Int16)
  Closest candidates are:
    SimpleEdge(::T<:Integer, !Matched::T<:Integer) where T<:Integer at C:\Users\Thibaut\.julia\dev\LightGraphs\src\SimpleGraphs\simpleedge.jl:7
  Stacktrace:
   [1] (::getfield(LightGraphs, Symbol("##3#4")){Int64})(::Int16) at .\none:0
   [2] iterate at .\generator.jl:47 [inlined]
   [3] collect at .\array.jl:606 [inlined]
   [4] outedges(::SimpleGraph{Int16}, ::Int64) at C:\Users\Thibaut\.julia\dev\LightGraphs\src\interface.jl:352
   [5] top-level scope at C:\Users\Thibaut\.julia\dev\LightGraphs\test\simplegraphs\simplegraphs.jl:69
   [6] top-level scope at C:\cygwin\home\Administrator\buildbot\worker\package_win64\build\usr\share\julia\stdlib\v1.1\Test\src\Test.jl:1083
   [7] top-level scope at C:\Users\Thibaut\.julia\dev\LightGraphs\test\simplegraphs\simplegraphs.jl:4
```