### PR TITLE
deprecating saw

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,5 +1,0 @@
-julia 0.7
-DataStructures
-SimpleTraits
-ArnoldiMethod
-Inflate

--- a/docs/src/pathing.md
+++ b/docs/src/pathing.md
@@ -48,7 +48,7 @@ mincut
 ```@docs
 randomwalk
 non_backtracking_randomwalk
-saw
+self_avoiding_walk
 ```
 
 ## Connectivity / Bipartiteness

--- a/src/LightGraphs.jl
+++ b/src/LightGraphs.jl
@@ -64,7 +64,7 @@ is_bipartite, bipartite_map,
 is_cyclic, topological_sort_by_dfs, dfs_tree,
 
 # random
-randomwalk, saw, non_backtracking_randomwalk,
+randomwalk, self_avoiding_walk, non_backtracking_randomwalk,
 
 # diffusion
 diffusion, diffusion_rate,

--- a/src/deprecations.jl
+++ b/src/deprecations.jl
@@ -3,3 +3,6 @@
 
 # Deprecated to fix spelling. Can be removed for version 2.0.
 @deprecate simplecycles_hadwick_james simplecycles_hawick_james
+
+# Deprecated for more explicit function name. Can be removed for version 2.0.
+@deprecate saw self_avoiding_walk

--- a/src/traversals/randomwalks.jl
+++ b/src/traversals/randomwalks.jl
@@ -93,13 +93,13 @@ end
 end
 
 """
-    saw(g, s, niter; seed=-1)
+    self_avoiding_walk(g, s, niter; seed=-1)
 
 Perform a [self-avoiding walk](https://en.wikipedia.org/wiki/Self-avoiding_walk)
 on graph `g` starting at vertex `s` and continuing for a maximum of `niter` steps.
 Return a vector of vertices visited in order.
 """
-function saw(g::AG, s::Integer, niter::Integer; seed::Int=-1) where AG <: AbstractGraph{T} where T
+function self_avoiding_walk(g::AG, s::Integer, niter::Integer; seed::Int=-1) where AG <: AbstractGraph{T} where T
     s in vertices(g) || throw(BoundsError())
     rng = getRNG(seed)
     visited = Vector{T}()

--- a/test/traversals/randomwalks.jl
+++ b/test/traversals/randomwalks.jl
@@ -38,8 +38,8 @@
 
     gx = path_graph(10)
     for g in testgraphs(gx)
-      @test @inferred(saw(g, 1, 20)) == [1:10;]
-      @test_throws BoundsError saw(g, 20, 20)
+      @test @inferred(self_avoiding_walk(g, 1, 20)) == [1:10;]
+      @test_throws BoundsError self_avoiding_walk(g, 20, 20)
       @test @inferred(non_backtracking_randomwalk(g, 1, 20)) == [1:10;]
       @test_throws BoundsError non_backtracking_randomwalk(g, 20, 20)
     end


### PR DESCRIPTION
"saw" is a valid English work and can take different meanings, it requires looking at the doc to actually see what it does, initials with lowercase makes it hard to get that. 

`saw` is deprecated and replaced by self_avoiding_walk