### PR TITLE
Remove unnecessary @simd macros

### DIFF
--- a/src/Experimental/ShortestPaths/bfs.jl
+++ b/src/Experimental/ShortestPaths/bfs.jl
@@ -58,7 +58,7 @@ function shortest_paths(
     end
     while !isempty(cur_level)
         @inbounds for v in cur_level
-            @inbounds @simd for i in outneighbors(g, v)
+            @inbounds for i in outneighbors(g, v)
                 if !visited[i]
                     push!(next_level, i)
                     dists[i] = n_level

--- a/src/digraph/transitivity.jl
+++ b/src/digraph/transitivity.jl
@@ -171,7 +171,7 @@ function transitivereducion end
         fill!(visited, false)
         stacksize = 0
         for v in outneighbors(cg,u)
-      @simd for w in outneighbors(cg, v)
+            for w in outneighbors(cg, v)
                 if !visited[w]
                     visited[w] = true
                     stacksize += 1
@@ -183,7 +183,7 @@ function transitivereducion end
             v = stack[stacksize]
             stacksize -= 1
             reachable[v] = true
-      @simd for w in outneighbors(cg, v)
+            for w in outneighbors(cg, v)
                 if !visited[w]
                     visited[w] = true
                     stacksize += 1
@@ -192,7 +192,7 @@ function transitivereducion end
             end
         end
 # Add the edges from the condensation graph to the resulting graph.
-  @simd for v in outneighbors(cg,u)
+    for v in outneighbors(cg,u)
             if !reachable[v]
                 add_edge!(resultg, scc[u][1], scc[v][1])
             end

--- a/src/dominatingset/degree_dom_set.jl
+++ b/src/dominatingset/degree_dom_set.jl
@@ -22,7 +22,7 @@ function update_dominated!(
         if !in_dom_set[v] 
             degree_queue[v] -= 1
         end
-        @inbounds @simd for u in neighbors(g, v)
+        @inbounds for u in neighbors(g, v)
             if !in_dom_set[u] 
                 degree_queue[u] -= ifelse(in_dom_set[u], 0, 1)
             end

--- a/src/dominatingset/minimal_dom_set.jl
+++ b/src/dominatingset/minimal_dom_set.jl
@@ -31,7 +31,7 @@ function dominating_set(
     in_dom_set = trues(nvg) 
     length_ds = Int(nvg)
     dom_degree = degree(g)
-    @inbounds @simd for v in vertices(g)
+    @inbounds for v in vertices(g)
         dom_degree[v] -= (has_edge(g, v, v) ? 1 : 0)
     end
 

--- a/src/independentset/degree_ind_set.jl
+++ b/src/independentset/degree_ind_set.jl
@@ -38,7 +38,7 @@ function independent_set(
         for u in neighbors(g, v)
             deleted[u] && continue
             deleted[u] = true
-            @inbounds @simd for w in neighbors(g, u)
+            @inbounds for w in neighbors(g, u)
                 if !deleted[w] 
                     degree_queue[w] -= 1
                 end

--- a/src/traversals/bfs.jl
+++ b/src/traversals/bfs.jl
@@ -50,7 +50,7 @@ function _bfs_parents(g::AbstractGraph{T}, source, neighborfn::Function) where T
     end
     while !isempty(cur_level)
         @inbounds for v in cur_level
-            @inbounds @simd for i in  neighborfn(g, v)
+            @inbounds for i in  neighborfn(g, v)
                 if !visited[i]
                     push!(next_level, i)
                     parents[i] = v
@@ -107,7 +107,7 @@ function gdistances!(g::AbstractGraph{T}, source, vert_level; sort_alg = QuickSo
     end
     while !isempty(cur_level)
         @inbounds for v in cur_level
-            @inbounds @simd for i in outneighbors(g, v)
+            @inbounds for i in outneighbors(g, v)
                 if !visited[i]
                     push!(next_level, i)
                     vert_level[i] = n_level

--- a/src/vertexcover/degree_vertex_cover.jl
+++ b/src/vertexcover/degree_vertex_cover.jl
@@ -45,7 +45,7 @@ function vertex_cover(
         in_cover[v] = true
         length_cover += 1
 
-        @inbounds @simd for u in neighbors(g, v)
+        @inbounds for u in neighbors(g, v)
             if !in_cover[u] 
                 degree_queue[u] -= 1
             end


### PR DESCRIPTION
This PR removes unnecessary `@simd macros`. The reason that they are unnecessary is that the loops contain branching statements, in which case `@simd` will not work, unless the compiler is able to create branchless code.
Furthermore `@simd` does not work for abritrary iterators, so if we have some graph type, that does not return a vector for functions such as `vertices` or `outneighbors` and we use `@simd` for looping over them, then we will get an error message.

See: https://docs.julialang.org/en/v1/base/base/#Base.SimdLoop.@simd