### PR TITLE
Update travis and appveyor script for Julia v1.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ os:
 #  - osx
 
 julia:
- - 1.1
+ - 1.2
  - nightly
  
 allow_failures:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,6 @@
 environment:
   matrix:
-  - julia_version: 0.7
-  - julia_version: 1
+  - julia_version: 1.2
   - julia_version: nightly
 
 platform:


### PR DESCRIPTION
Also I took the liberty of removing Julia v0.7, if we still want to support older versions, I can add it back.