### PR TITLE
improved performance of core_number

### DIFF
--- a/src/degeneracy.jl
+++ b/src/degeneracy.jl
@@ -40,6 +40,8 @@ julia> core_number(g)
 function core_number(g::AbstractGraph{T}) where T
     has_self_loops(g) && throw(ArgumentError("graph must not have self-loops"))
     degrees = degree(g)
+    visited = Set{Int}() # we'll use this repeatedly.
+    sizehint!(visited, maximum(degrees))
     vs = sortperm(degrees)
     bin_boundaries = [1]
     curr_degree = 0
@@ -52,11 +54,11 @@ function core_number(g::AbstractGraph{T}) where T
     vertex_pos = sortperm(vs)
     # initial guesses for core is degree
     core = degrees
-    nbrs = [Set(all_neighbors(g, v)) for v in vertices(g)]
     for v in vs
-        for u in nbrs[v]
-            if core[u] > core[v]
-                pop!(nbrs[u], v)
+        empty!(visited)
+        for u in all_neighbors(g, v)
+            if core[u] > core[v] && !(u ∈ visited)
+                push!(visited, u)
                 pos = vertex_pos[u]
                 bin_start = bin_boundaries[core[u] + 1]
                 vertex_pos[u] = bin_start


### PR DESCRIPTION
core_number was inspired by NetworkX but there are some efficiencies that we can apply. Here are the results of the new code (`core_number2` below):
```
julia> g = DiGraph(200_000, 5_000_000)                                                                                                       
{200000, 5000000} directed simple Int64 graph                                                                                                
                                                                                                                                             
julia> c = core_number(g);                                                                                                                   
                                                                                                                                             
julia> include("core_number.jl")                                                                                                             
core_number2 (generic function with 1 method)                                                                                                
                                                                                                                                             
julia> c2 = core_number2(g);                                                                                                                 
                                                                                                                                             
julia> c == c2                                                                                                                               
true                                              

julia> @benchmark core_number(g)                                                                                                             
BenchmarkTools.Trial:                                                                                                                        
  memory estimate:  1.53 GiB                                                                                                                 
  allocs estimate:  5625718                                                                                                                  
  --------------                                                                                                                             
  minimum time:     3.842 s (7.01% GC)
  median time:      3.851 s (9.58% GC)
  mean time:        3.851 s (9.58% GC)
  maximum time:     3.859 s (12.15% GC)
  --------------
  samples:          2
  evals/sample:     1


julia> @benchmark core_number2(g)
BenchmarkTools.Trial: 
  memory estimate:  925.09 MiB
  allocs estimate:  3520476
  --------------
  minimum time:     1.245 s (5.69% GC)
  median time:      1.255 s (5.61% GC)
  mean time:        1.258 s (5.64% GC)
  maximum time:     1.278 s (5.26% GC)
  --------------
  samples:          4
  evals/sample:     1
```