### PR TITLE
Fixing doc for .parents

### DIFF
--- a/docs/src/pathing.md
+++ b/docs/src/pathing.md
@@ -154,7 +154,7 @@ information, accessible via the type:
 Holds a vector of distances computed, indexed by source vertex.
 
 `.parents`
-Holds a vector of parents of each source vertex. The parent of a source vertex
+Holds a vector of parents of each vertex on the paths. The parent of a source vertex
 is always `0`.
 
 (`YenState` substitutes `.paths` for `.parents`.)


### PR DESCRIPTION
the doc for `.parents` talks about source vertex only. But it shows parents for every vertex (on the shortest path to that vertex)