### PR TITLE
mutating functions in LG itself

### DIFF
--- a/src/LightGraphs.jl
+++ b/src/LightGraphs.jl
@@ -33,7 +33,7 @@ is_ordered, add_vertices!, indegree, outdegree, degree,
 neighbors, all_neighbors, common_neighbors,
 has_self_loops, num_self_loops, density, squash, weights,
 
-# simplegraphs
+# mutations
 add_edge!, add_vertex!, add_vertices!, rem_edge!, rem_vertex!, rem_vertices!,
 
 # decomposition
@@ -189,9 +189,10 @@ include("interface.jl")
 include("utils.jl")
 include("deprecations.jl")
 include("core.jl")
-
+include("mutation.jl")
 include("SimpleGraphs/SimpleGraphs.jl")
 using .SimpleGraphs
+
 """
     Graph
 

--- a/src/SimpleGraphs/SimpleGraphs.jl
+++ b/src/SimpleGraphs/SimpleGraphs.jl
@@ -12,6 +12,7 @@ import LightGraphs:
     _NI, AbstractGraph, AbstractEdge, AbstractEdgeIter,
     src, dst, edgetype, nv, ne, vertices, edges, is_directed,
     has_vertex, has_edge, inneighbors, outneighbors, deepcopy_adjlist,
+    add_vertex!, add_edge!, rem_vertex!, rem_vertices!, rem_edge!,
     indegree, outdegree, degree, has_self_loops, num_self_loops, insorted
 
 using Random: GLOBAL_RNG, AbstractRNG
@@ -19,7 +20,6 @@ using Random: GLOBAL_RNG, AbstractRNG
 export AbstractSimpleGraph, AbstractSimpleEdge,
     SimpleEdge, SimpleGraph, SimpleGraphFromIterator, SimpleGraphEdge,
     SimpleDiGraph, SimpleDiGraphFromIterator, SimpleDiGraphEdge,
-    add_vertex!, add_edge!, rem_vertex!, rem_vertices!, rem_edge!,
     # randgraphs
     erdos_renyi, expected_degree_graph, watts_strogatz, random_regular_graph,
     random_regular_digraph, random_configuration_model, random_tournament_digraph,
@@ -122,10 +122,9 @@ function rem_edge!(g::AbstractSimpleGraph{T}, u::Integer, v::Integer) where T
 end
 
 """
-    rem_vertex!(g, v)
+    rem_vertex!(g::AbstractSimpleGraph, v::Integer)
 
-Remove the vertex `v` from graph `g`. Return `false` if removal fails
-(e.g., if vertex is not in the graph); `true` otherwise.
+Remove the vertex from the graph.
 
 ### Performance
 Time complexity is ``\\mathcal{O}(k^2)``, where ``k`` is the max of the degrees
@@ -137,19 +136,6 @@ data structures indexed by edges or vertices in the graph, since
 internally the removal is performed swapping the vertices `v`  and ``|V|``,
 and removing the last vertex ``|V|`` from the graph. After removal the
 vertices in `g` will be indexed by ``1:|V|-1``.
-
-# Examples
-```jldoctest
-julia> using LightGraphs
-
-julia> g = SimpleGraph(2);
-
-julia> rem_vertex!(g, 2)
-true
-
-julia> rem_vertex!(g, 2)
-false
-```
 """
 function rem_vertex!(g::AbstractSimpleGraph, v::Integer)
     v in vertices(g) || return false

--- a/src/mutation.jl
+++ b/src/mutation.jl
@@ -1,0 +1,28 @@
+"""
+    rem_vertex!(g, v)
+
+Remove the vertex `v` from graph `g`. Return `false` if removal fails
+(e.g., if vertex is not in the graph); `true` otherwise.
+
+# Examples
+```jldoctest
+julia> using LightGraphs
+
+julia> g = SimpleGraph(2);
+
+julia> rem_vertex!(g, 2)
+true
+
+julia> rem_vertex!(g, 2)
+false
+```
+"""
+function rem_vertex! end
+
+function rem_vertices! end
+
+function rem_edge! end
+
+function add_vertex! end
+
+function add_edge! end


### PR DESCRIPTION
This one has been biting me for a while, since the mutating functions can be defined by many graph types, even though they are not in the mandatory interface, they should be defined at the LG level, and then imported and implemented by simple graphs