### PR TITLE
update travis sudo and allow_failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: julia
-sudo: false
 os:
   - linux
 #  - osx
@@ -8,13 +7,12 @@ julia:
  - 1.3
  - nightly
 
-allow_failures:
- - julia: nightly
-
 notifications:
   email: false
 
 jobs:
+  allow_failures:
+    - julia: nightly
   include:
     - stage: "Documentation"
       julia: 1.3


### PR DESCRIPTION
Travis has mentioned warnings about `sudo` being depreciated, and has not used `allow_failures` since it belongs under `jobs`
This PR aims to fix that.