### PR TITLE
iterative biconnected components

### DIFF
--- a/src/biconnectivity13/biconnect.jl
+++ b/src/biconnectivity13/biconnect.jl
@@ -1,4 +1,3 @@
-
 """
     biconnected_components(g) -> Vector{Vector{Edge{eltype(g)}}}
 
@@ -29,7 +28,7 @@ function biconnected_components end
 @traitfn function biconnected_components(g::::(!IsDirected))
     nvg = nv(g)
     T = eltype(g)
-    S = Array{Tuple{T, T}, 1}(undef, nvg)
+    S = Vector{Tuple{T, T}}()
     E = Edge{eltype(g)}
     edge_st = Vector{E}()
     components = Vector{Vector{E}}()
@@ -41,11 +40,12 @@ function biconnected_components end
     stack_ptr = zero(T) #stack pointer to emulate what happens in function  call, that will make us avoid the reallocation of push and pop vector
     @inbounds for us in vertices(g)
         pre[us] == 0 || continue # don’t go to visited nodes again
-        stack_ptr += 1
-        S[stack_ptr] = (us, 1)
+        #stack_ptr += 1
+        #S[stack_ptr] = (us, 1)
+        push!(S, (us, 1))
         ptr = one(T)    
-        while stack_ptr > 0
-            v, _ = S[stack_ptr]
+        while length(S) > 0
+            v, _ = S[end]
             if ptr == 1  # if ptr == 1 then we all in this node for the first time
                 idx += 1
                 low[v] = pre[v] = idx
@@ -56,10 +56,11 @@ function biconnected_components end
                 if pre[i] ==  0
                     e = i < v ? E(i, v) : E(v, i)
                     push!(edge_st, e)
-                    stack_ptr += 1
-                    S[stack_ptr] = (i, ptr+1)
+                    #stack_ptr += 1
+                    #S[stack_ptr] = (i, ptr+1)
+                    push!(S, (i, ptr + 1))
                     break
-                elseif (!(stack_ptr > 1 && i == S[stack_ptr-1][1])) && pre[i] < low[v]
+                elseif (!(length(S) > 1 && i == S[end-1][1])) && pre[i] < low[v]
                     low[v] = pre[i]
                     e = i < v ? E(i, v) : E(v, i)
                     push!(edge_st, e)
@@ -70,10 +71,11 @@ function biconnected_components end
             #if ptr > length(neighs) then i finished my processing
             # and will return to my parent, else i will go to new node
             if ptr > length(neighs)
-                _, ptr = S[stack_ptr]
-                stack_ptr -= 1
-                if stack_ptr >= 1
-                    p, _ = S[stack_ptr]   #  my parent
+                _, ptr = S[end]
+                #stack_ptr -= 1
+                pop!(S)
+                if length(S) >= 1
+                    p, _ = S[end]   #  my parent
                     if low[v] < low[p]
                         low[p] = low[v]
                     elseif low[v] >= pre[p] # find if my parent is an articulation point
@@ -94,15 +96,3 @@ function biconnected_components end
     end       
     return components
 end
-    
-
-    
-    
-
-
-            
-            
-    
-        
-    
-        

--- a/src/biconnectivity13/biconnect.jl
+++ b/src/biconnectivity13/biconnect.jl
@@ -32,21 +32,22 @@ function biconnected_components end
         E = Edge{eltype(g)}
         edge_st = Vector{E}()
         components = Vector{Vector{E}}()
-        us = one(Int)
-        idx = zero(Int)
+        idx = zero(Int)      # preorder counter
         low = zeros(Int, nv(g))
         pre = zeros(Int, nv(g))
-        stack_ptr = zero(Int)
-    @inbounds for us in vertices(g)
-        pre[us] == 0 || continue
-        stack_ptr+=1
-        S[stack_ptr] = (us, 1)
+        #stack pointer to emulate what happens in function call,
+        #that will make us avoid the reallocation of push and pop vector
+        stack_ptr = zero(Int) #stack pointer to emulate what happens in function  call, that will make us avoid the reallocation of push and pop vector
 
+    @inbounds for us in vertices(g)
+        pre[us] == 0 || continue # don’t go to visited nodes again
+        stack_ptr += 1
+        S[stack_ptr] = (us, 1)
         ptr = one(Int)
 
         while stack_ptr > 0
             v, _ = S[stack_ptr]
-            if ptr == 1
+            if ptr == 1  # if ptr == 1 then we all in this node for the first time
                 idx+=1
                 low[v] = pre[v] = idx
             end
@@ -57,7 +58,7 @@ function biconnected_components end
 
                 if pre[i] ==  0
                     push!(edge_st, E(min(i, v), max(i, v)))
-                    stack_ptr+=1
+                    stack_ptr += 1
                     S[stack_ptr] = (i, ptr+1)
                     break
                 elseif (!(stack_ptr > 1 && i == S[stack_ptr-1][1])) && pre[i] < low[v]
@@ -68,15 +69,18 @@ function biconnected_components end
                 ptr += 1
             end
 
+            #if ptr > length(neighs) then i finished my processing
+            # and will return to my parent, else i will go to new node
+
             if ptr > length(neighs)
                 _, ptr = S[stack_ptr]
-                stack_ptr-=1
+                stack_ptr -= 1
                 if stack_ptr >= 1
-                    p, _ = S[stack_ptr]
+                    p, _ = S[stack_ptr]   #  my parent
                    if low[v] < low[p]
                         low[p] = low[v]
-                    elseif low[v] >= pre[p]
-                    e = E(0, 0) 
+                    elseif low[v] >= pre[p] # find if my parent is an articulation point
+                    e = E(0, 0) #Invalid Edge, used for comparison only
                     st = Vector{E}()
                     while e != E(min(p, v), max(p, v))
                         e = pop!(edge_st)

--- a/src/biconnectivity13/biconnect.jl
+++ b/src/biconnectivity13/biconnect.jl
@@ -47,21 +47,21 @@ function biconnected_components end
         while stack_ptr > 0
             v, _ = S[stack_ptr]
             if ptr == 1  # if ptr == 1 then we all in this node for the first time
-                idx+=1
+                idx += 1
                 low[v] = pre[v] = idx
             end
             neighs = outneighbors(g, v)
             while ptr <= length(neighs)
                 i = neighs[ptr]            
                 if pre[i] ==  0
-                    e = p < v ? E(p, v) : E(v, p)
+                    e = i < v ? E(i, v) : E(v, i)
                     push!(edge_st, e)
                     stack_ptr += 1
                     S[stack_ptr] = (i, ptr+1)
                     break
                 elseif (!(stack_ptr > 1 && i == S[stack_ptr-1][1])) && pre[i] < low[v]
                     low[v] = pre[i]
-                    e = p < v ? E(p, v) : E(v, p)
+                    e = p < v ? E(i, v) : E(v, i)
                     push!(edge_st, e)
                 end
         

--- a/src/biconnectivity13/biconnect.jl
+++ b/src/biconnectivity13/biconnect.jl
@@ -27,72 +27,82 @@ julia> biconnected_components(cycle_graph(5))
 """
 function biconnected_components end
 @traitfn function biconnected_components(g::::(!IsDirected))
-        n = nv(g)
-        S = Array{Tuple{Int, Int}, 1}(undef,n)
-        E = Edge{eltype(g)}
-        edge_st = Vector{E}()
-        components = Vector{Vector{E}}()
-        idx = zero(Int)      # preorder counter
-        low = zeros(Int, nv(g))
-        pre = zeros(Int, nv(g))
-        #stack pointer to emulate what happens in function call,
-        #that will make us avoid the reallocation of push and pop vector
-        stack_ptr = zero(Int) #stack pointer to emulate what happens in function  call, that will make us avoid the reallocation of push and pop vector
-
+    nvg = nv(g)
+    T = eltype(g)
+    S = Array{Tuple{T, T}, 1}(undef, nvg)
+    E = Edge{eltype(g)}
+    edge_st = Vector{E}()
+    components = Vector{Vector{E}}()
+    idx = zero(T)      # preorder counter
+    low = zeros(T, nvg)
+    pre = zeros(T, nvg)
+    #stack pointer to emulate what happens in function call,
+    #that will make us avoid the reallocation of push and pop vector
+    stack_ptr = zero(T) #stack pointer to emulate what happens in function  call, that will make us avoid the reallocation of push and pop vector
     @inbounds for us in vertices(g)
         pre[us] == 0 || continue # don’t go to visited nodes again
         stack_ptr += 1
         S[stack_ptr] = (us, 1)
-        ptr = one(Int)
-
+        ptr = one(T)    
         while stack_ptr > 0
             v, _ = S[stack_ptr]
             if ptr == 1  # if ptr == 1 then we all in this node for the first time
                 idx+=1
                 low[v] = pre[v] = idx
             end
-
             neighs = outneighbors(g, v)
-             while ptr <= length(neighs)
-                i = neighs[ptr]
-
+            while ptr <= length(neighs)
+                i = neighs[ptr]            
                 if pre[i] ==  0
-                    push!(edge_st, E(min(i, v), max(i, v)))
+                    e = p < v ? E(p, v) : E(v, p)
+                    push!(edge_st, e)
                     stack_ptr += 1
                     S[stack_ptr] = (i, ptr+1)
                     break
                 elseif (!(stack_ptr > 1 && i == S[stack_ptr-1][1])) && pre[i] < low[v]
                     low[v] = pre[i]
-                    push!(edge_st, E(min(v, i), max(v, i)))
+                    e = p < v ? E(p, v) : E(v, p)
+                    push!(edge_st, e)
                 end
-
+        
                 ptr += 1
             end
-
             #if ptr > length(neighs) then i finished my processing
             # and will return to my parent, else i will go to new node
-
             if ptr > length(neighs)
                 _, ptr = S[stack_ptr]
                 stack_ptr -= 1
                 if stack_ptr >= 1
                     p, _ = S[stack_ptr]   #  my parent
-                   if low[v] < low[p]
+                    if low[v] < low[p]
                         low[p] = low[v]
                     elseif low[v] >= pre[p] # find if my parent is an articulation point
-                    e = E(0, 0) #Invalid Edge, used for comparison only
-                    st = Vector{E}()
-                    while e != E(min(p, v), max(p, v))
-                        e = pop!(edge_st)
-                        push!(st, e)
-                    end
-                    push!(components, st)
-                    end
+                        e = E(0, 0) #Invalid Edge, used for comparison only
+                        st = Vector{E}()
+                        e2 = p < v ? E(p, v) : E(v, p)
+                        while e != e2
+                            e = pop!(edge_st)
+                            push!(st, e)
+                        end
+                        push!(components, st)                    
+                    end                   
                 end
             else
-                ptr = 1
-            end
-        end
-    end
-        return components
-    end
+                ptr = 1                
+            end           
+        end   
+    end       
+    return components
+end
+    
+
+    
+    
+
+
+            
+            
+    
+        
+    
+        

--- a/src/biconnectivity13/biconnect.jl
+++ b/src/biconnectivity13/biconnect.jl
@@ -61,7 +61,7 @@ function biconnected_components end
                     break
                 elseif (!(stack_ptr > 1 && i == S[stack_ptr-1][1])) && pre[i] < low[v]
                     low[v] = pre[i]
-                    e = p < v ? E(i, v) : E(v, i)
+                    e = i < v ? E(i, v) : E(v, i)
                     push!(edge_st, e)
                 end
         

--- a/src/biconnectivity13/biconnect.jl
+++ b/src/biconnectivity13/biconnect.jl
@@ -37,7 +37,6 @@ function biconnected_components end
     pre = zeros(T, nvg)
     #stack pointer to emulate what happens in function call,
     #that will make us avoid the reallocation of push and pop vector
-    stack_ptr = zero(T) #stack pointer to emulate what happens in function  call, that will make us avoid the reallocation of push and pop vector
     @inbounds for us in vertices(g)
         pre[us] == 0 || continue # don’t go to visited nodes again
         #stack_ptr += 1
@@ -56,8 +55,6 @@ function biconnected_components end
                 if pre[i] ==  0
                     e = i < v ? E(i, v) : E(v, i)
                     push!(edge_st, e)
-                    #stack_ptr += 1
-                    #S[stack_ptr] = (i, ptr+1)
                     push!(S, (i, ptr + 1))
                     break
                 elseif (!(length(S) > 1 && i == S[end-1][1])) && pre[i] < low[v]
@@ -72,7 +69,6 @@ function biconnected_components end
             # and will return to my parent, else i will go to new node
             if ptr > length(neighs)
                 _, ptr = S[end]
-                #stack_ptr -= 1
                 pop!(S)
                 if length(S) >= 1
                     p, _ = S[end]   #  my parent


### PR DESCRIPTION
in #1336 i tried to make biconnected components by using the new vistor function, but it was always slower than the old one however i tried to optimize it , i tried to make an iterative version with no relying on the visitor function, and the results pretty competitive.

```
g = loadsnap(:patent_cit_us)

@benchmark biconnected_components2(g)

BenchmarkTools.Trial: 
  memory estimate:  2.49 MiB
  allocs estimate:  2929
  --------------
  minimum time:     13.033 ms (0.00% GC)
  median time:      13.495 ms (0.00% GC)
  mean time:        14.398 ms (5.53% GC)
  maximum time:     20.228 ms (0.00% GC)
  --------------
  samples:          346
  evals/sample:     1

@benchmark biconnected_components(g)
BenchmarkTools.Trial: 
  memory estimate:  1.89 MiB
  allocs estimate:  2914
  --------------
  minimum time:     12.667 ms (0.00% GC)
  median time:      13.164 ms (0.00% GC)
  mean time:        14.051 ms (5.58% GC)
  maximum time:     26.715 ms (37.31% GC)
  --------------
  samples:          356
  evals/sample:     1


g = loadsnap(:email_enron)

@benchmark biconnected_components2(g)

BenchmarkTools.Trial: 
  memory estimate:  4.19 MiB
  allocs estimate:  22452
  --------------
  minimum time:     20.877 ms (0.00% GC)
  median time:      21.521 ms (0.00% GC)
  mean time:        24.503 ms (12.22% GC)
  maximum time:     41.203 ms (42.50% GC)
  --------------
  samples:          204
  evals/sample:     1

@benchmark biconnected_components(g)

BenchmarkTools.Trial: 
  memory estimate:  3.93 MiB
  allocs estimate:  22450
  --------------
  minimum time:     22.608 ms (0.00% GC)
  median time:      23.550 ms (0.00% GC)
  mean time:        26.155 ms (10.65% GC)
  maximum time:     35.348 ms (29.61% GC)
  --------------
  samples:          191
  evals/sample:     1
```

the reason for that might be when i make my own dfs algorithm i have access to the dfs stack, which means i no longer need parent array, because the parent will always be the node before me in the stack .