### PR TITLE
iterative johnson

### DIFF
--- a/src/cycles13/johnson.jl
+++ b/src/cycles13/johnson.jl
@@ -68,6 +68,7 @@ function unblock!(v::T, blocked::BitVector, B::Vector{Set{T}}) where T <: Intege
     while !isempty(S)
         u = pop!(S)
         for w in B[u]
+            delete!(B[v], w)
             if blocked[w]
                 blocked[w] = false
                 push!(S, w)
@@ -190,7 +191,7 @@ function visit(
             if done
               if length(S) >= 1
                   p, pptr, pdone = S[end]
-                  if pdone
+                  if !pdone
                     S[end] = (p, pptr, true)
                   end
               end

--- a/src/cycles13/johnson.jl
+++ b/src/cycles13/johnson.jl
@@ -242,7 +242,7 @@ function itercycles end
             visit(wdg, T(1), putoncycles(vmap)) # 1 is the startnode.
         end
     end
-    return cycles
+    return cycle
 end
 
 """


### PR DESCRIPTION
in the old code there was a function circuit for iter and  another almost identical one for simple, i have make new one that take function as an argument and apply that function when a cycle is found.
 making the function iterative didn’t affect the performance  , here is some benchmark

```

completedg = complete_digraph(7)

@benchmark simplecycleslength(completedg)

BenchmarkTools.Trial: 
  memory estimate:  620.76 KiB
  allocs estimate:  17085
  --------------
  minimum time:     105.372 ms (0.00% GC)
  median time:      111.234 ms (0.00% GC)
  mean time:        110.982 ms (0.00% GC)
  maximum time:     123.570 ms (0.00% GC)
  --------------
  samples:          46
  evals/sample:     1

@benchmark simplecycles2length(completedg)

BenchmarkTools.Trial: 
  memory estimate:  894.00 KiB
  allocs estimate:  21801
  --------------
  minimum time:     107.132 ms (0.00% GC)
  median time:      109.772 ms (0.00% GC)
  mean time:        111.262 ms (0.25% GC)
  maximum time:     128.585 ms (0.00% GC)
  --------------
  samples:          46
  evals/sample:     1


@benchmark simplecycles(completedg)

BenchmarkTools.Trial: 
  memory estimate:  597.36 KiB
  allocs estimate:  9974
  --------------
  minimum time:     1.673 ms (0.00% GC)
  median time:      2.364 ms (0.00% GC)
  mean time:        2.571 ms (8.90% GC)
  maximum time:     59.557 ms (96.60% GC)
  --------------
  samples:          1936
  evals/sample:     1


@benchmark simplecycles2(completedg)
BenchmarkTools.Trial: 
  memory estimate:  869.90 KiB
  allocs estimate:  14683
  --------------
  minimum time:     1.734 ms (0.00% GC)
  median time:      2.675 ms (0.00% GC)
  mean time:        2.907 ms (11.06% GC)
  maximum time:     60.321 ms (94.97% GC)
  --------------
  samples:          1711
  evals/sample:     1


g = cycle_digraph(1000_000)

@benchmark simplecycleslength(completedg)
BenchmarkTools.Trial:
  memory estimate:  620.76 KiB
  allocs estimate:  17085
  --------------
  minimum time:     96.046 ms (0.00% GC)
  median time:      98.212 ms (0.00% GC)
  mean time:        99.876 ms (0.00% GC)
  maximum time:     123.274 ms (0.00% GC)
  --------------
  samples:          51
  evals/sample:     1

 @benchmark simplecycles2length(completedg)
BenchmarkTools.Trial: 
  memory estimate:  894.00 KiB
  allocs estimate:  21801
  --------------
  minimum time:     96.596 ms (0.00% GC)
  median time:      97.985 ms (0.00% GC)
  mean time:        99.195 ms (0.00% GC)
  maximum time:     121.115 ms (0.00% GC)
  --------------
  samples:          51
  evals/sample:     1

g = cycle_digraph(100)

@benchmark simplecycles(g)

BenchmarkTools.Trial: 
  memory estimate:  3.80 MiB
  allocs estimate:  49761
  --------------
  minimum time:     39.161 ms (0.00% GC)
  median time:      41.482 ms (0.00% GC)
  mean time:        42.593 ms (2.20% GC)
  maximum time:     54.828 ms (11.36% GC)
  --------------
  samples:          118
  evals/sample:     1

@benchmark simplecycles2(g)
BenchmarkTools.Trial: 
  memory estimate:  3.83 MiB
  allocs estimate:  49663
  --------------
  minimum time:     6.604 ms (0.00% GC)
  median time:      7.263 ms (0.00% GC)
  mean time:        8.302 ms (11.39% GC)
  maximum time:     17.430 ms (49.59% GC)
  --------------
  samples:          601
  evals/sample:     1

```