### PR TITLE
implemented circulant graph generator

### DIFF
--- a/src/LightGraphs.jl
+++ b/src/LightGraphs.jl
@@ -122,7 +122,7 @@ complete_graph, star_graph, path_graph, wheel_graph, cycle_graph,
 complete_bipartite_graph, complete_multipartite_graph, turan_graph,
 complete_digraph, star_digraph, path_digraph, grid, wheel_digraph, cycle_digraph,
 binary_tree, double_binary_tree, roach_graph, clique_graph, ladder_graph,
-circular_ladder_graph, barbell_graph, lollipop_graph,
+circular_ladder_graph, barbell_graph, lollipop_graph, circulant_graph, circulant_digraph,
 
 #generator deprecations
 BullGraph, ChvatalGraph, CubicalGraph, DesarguesGraph, DiamondGraph,

--- a/src/SimpleGraphs/SimpleGraphs.jl
+++ b/src/SimpleGraphs/SimpleGraphs.jl
@@ -32,7 +32,7 @@ export AbstractSimpleGraph, AbstractSimpleEdge,
     complete_bipartite_graph, complete_multipartite_graph, turan_graph, complete_digraph,
     star_digraph, path_digraph, grid, wheel_digraph, cycle_digraph, binary_tree,
     double_binary_tree, roach_graph, clique_graph, barbell_graph, lollipop_graph,
-    ladder_graph, circular_ladder_graph,
+    ladder_graph, circular_ladder_graph, circulant_graph, circulant_digraph,
     #smallgraphs
     smallgraph,
     # Euclidean graphs

--- a/src/SimpleGraphs/generators/staticgraphs.jl
+++ b/src/SimpleGraphs/generators/staticgraphs.jl
@@ -763,3 +763,61 @@ function lollipop_graph(n1::T, n2::T) where {T <: Integer}
     add_edge!(g, n1, n1+1)
     return g
 end
+
+"""
+    circulant_graph(n, connection_set)
+
+Create a [circulant graph](https://en.wikipedia.org/wiki/Circulant_graph) with `n` vertices with connection set as `connection_set`.
+
+### Implementation Notes
+`n` must be at least 1 so that the graph has at least one vertex.
+The modulo and addition operations are carried assuming vertex lables from 0:n-1 and 1 is added to them.
+
+# Examples
+```jldoctest
+julia> circulant_graph(2, [1])
+{2, 1} undirected simple Int64 graph
+
+julia> circulant_graph(Int8(3), [Int8(1)])
+{3, 3} undirected simple Int8 graph
+```
+"""
+function circulant_graph(n::T, connection_set::Vector{T}) where {T <: Integer}
+    (n < 1) && throw(DomainError("n=$n must be at least 1"))
+    g = SimpleGraph(n)
+
+    @inbounds for u = 0:n-1, j in connection_set
+        add_edge!(g, u+1, (u+j)%n+1)
+    end
+
+    return g
+end
+
+"""
+    circulant_digraph(n, connection_set)
+
+Create a directed [circulant graph](https://en.wikipedia.org/wiki/Circulant_graph) with `n` vertices with connection set as `connection_set`.
+
+### Implementation Notes
+`n` must be at least 1 so that the graph has at least one vertex.
+The modulo and addition operations are carried assuming vertex lables from 0:n-1 and 1 is added to them.
+
+# Examples
+```jldoctest
+julia> g = circulant_digraph(3, [1])
+{3, 2} directed simple Int64 graph
+
+julia> circulant_digraph(Int8(3), [Int8(1)])
+{3, 3} directed simple Int8 graph
+```
+"""
+function circulant_digraph(n::T, connection_set::Vector{T}) where {T <: Integer}
+    (n < 1) && throw(DomainError("n=$n must be at least 1"))
+    g = SimpleDiGraph(n)
+
+    @inbounds for u = 0:n-1, j in connection_set
+        add_edge!(g, u + 1, (u + j)%n + 1)
+    end
+
+    return g
+end

--- a/src/SimpleGraphs/generators/staticgraphs.jl
+++ b/src/SimpleGraphs/generators/staticgraphs.jl
@@ -783,11 +783,13 @@ julia> circulant_graph(Int8(3), [Int8(1)])
 ```
 """
 function circulant_graph(n::T, connection_set::Vector{T}) where {T <: Integer}
-    (n < 1) && throw(DomainError("n=$n must be at least 1"))
+    (n < 1) && throw(DomainError(n, "n must be at least 1"))
     g = SimpleGraph(n)
 
-    @inbounds for u = 0:n-1, j in connection_set
-        add_edge!(g, u+1, (u+j)%n+1)
+    @inbounds for u = 1:n-1, v = u+1:n
+        if mod(v - u, n) in connection_set || mod(u - v, n) in connection_set
+            add_edge!(g, u, v)
+        end
     end
 
     return g
@@ -812,11 +814,16 @@ julia> circulant_digraph(Int8(3), [Int8(1)])
 ```
 """
 function circulant_digraph(n::T, connection_set::Vector{T}) where {T <: Integer}
-    (n < 1) && throw(DomainError("n=$n must be at least 1"))
+    (n < 1) && throw(DomainError(n, "n must be at least 1"))
     g = SimpleDiGraph(n)
 
-    @inbounds for u = 0:n-1, j in connection_set
-        add_edge!(g, u + 1, (u + j)%n + 1)
+    @inbounds for u = 1:n-1, v = u+1:n
+        if mod(v - u, n) in connection_set
+            add_edge!(g, u, v)
+        end
+        if mod(u - v, n) in connection_set
+            add_edge!(g, v, u)
+        end
     end
     return g
 end
@@ -833,7 +840,7 @@ In this implementation, the common vertex is index 1.
 """
 function friendship_graph(n::T) where {T <: Integer}
     n <= 0 && return SimpleGraph(1)
-    
+
     g = SimpleGraph(2 * n + 1)
     for indx in 1:n
         u = indx * 2

--- a/test/simplegraphs/generators/staticgraphs.jl
+++ b/test/simplegraphs/generators/staticgraphs.jl
@@ -536,4 +536,54 @@
         @test_throws DomainError lollipop_graph(0, 1)
         @test_throws DomainError lollipop_graph(-1, -1)
     end
+
+    # checking if edgeset of g is equal to edges
+    function isEdgeSet(g, edges)
+        ne(g) != length(edges) && return false
+
+        for (i, j) in edges
+            !has_edge(g, i, j) && return false
+        end
+
+        return true
+    end
+
+    @testset "Circulant Graphs" begin
+        # point graph
+        g = @inferred(circulant_graph(1, Vector{Int64}()))
+        @test nv(g) == 1 && ne(g) == 0
+        # path graph
+        g = circulant_graph(2, [1])
+        @test nv(g) == 2 && ne(g) == 1
+        # triangle graph
+        g = circulant_graph(3, [1])
+        @test nv(g) == 3 && ne(g) == 3
+        @test isEdgeSet(g, [(1, 2), (1, 3), (2, 3)])
+        # tetrahedral graph
+        @test circulant_graph(4, [1, 2]) == complete_graph(4)
+        # utility graph
+        g = circulant_graph(6, [1, 3])
+        @test nv(g) == 6 && ne(g) == 9
+        @test isEdgeSet(g, [(1, 2), (2, 3), (3, 4), (4, 5), (5, 6), (1, 6), (1, 4), (2, 5), (3, 6)])
+        @test_throws DomainError circulant_graph(0, [1, 2])
+    end
+
+    @testset "Circulant DiGraphs" begin
+        # point graph
+        g = @inferred(circulant_digraph(1, Vector{Int64}()))
+        @test nv(g) == 1 && ne(g) == 0
+        # path graph
+        g = circulant_digraph(2, [1])
+        @test nv(g) == 2 && ne(g) == 2
+        @test isEdgeSet(g, [(1, 2), (2, 1)])
+        # triangle graph
+        g = circulant_digraph(3, [1])
+        @test nv(g) == 3 && ne(g) == 3
+        @test isEdgeSet(g, [(1, 2), (2, 3), (3, 1)])
+        # utility graph
+        g = circulant_digraph(6, [1, 3])
+        @test nv(g) == 6 && ne(g) == 12
+        @test isEdgeSet(g, [(1, 2), (2, 3), (3, 4), (4, 5), (5, 6), (6, 1), (1, 4), (4, 1), (2, 5), (3, 6), (5, 2), (6, 3)])
+        @test_throws DomainError circulant_digraph(0, [1, 2])
+    end
 end


### PR DESCRIPTION
Fixes #1342 

This PR implements a circulant graph generator. It has two signatures:

1. `circulant_graph(n, connection_set)`
2. `circulant_digraph(n, connection_set)`