### PR TITLE
fix transtitve reduction

### DIFF
--- a/src/digraph13/transitivity.jl
+++ b/src/digraph13/transitivity.jl
@@ -161,7 +161,7 @@ function transitivereducion end
     resultg = SimpleDiGraph{eltype(g)}(nv(g))
     verts_rep = map(s -> s[1], scc)
     state = Traversals.DiSpanTree(verts_rep, zeros(eltype(g), nv(cg)), eltype(g)(0), resultg)
-    Traversals.traverse_graph!(cg, vertices(cg), DepthFirst(), state)
+    Traversals.traverse_graph!(cg, vertices(cg), Traversals.DepthFirst(), state)
     
 # Replace each strongly connected component with a directed cycle.
     @inbounds(


### PR DESCRIPTION
the transitive reduction can take so long, it is basically do a dfs on every node on the condensation graph, which may lead to O(n ^ 2) running time., while we can just find a spanning tree on single dfs call.
```
@benchmark transitivereduction(path_digraph(10_000))

BenchmarkTools.Trial: 
  memory estimate:  7.90 MiB
  allocs estimate:  120058
  --------------
  minimum time:     1.051 s (0.00% GC)
  median time:      1.151 s (0.00% GC)
  mean time:        1.186 s (0.17% GC)
  maximum time:     1.325 s (0.77% GC)
  --------------
  samples:          5
  evals/sample:     1

@benchmark transitivereduction2(path_digraph(10_000))

BenchmarkTools.Trial: 
  memory estimate:  8.09 MiB
  allocs estimate:  120073
  --------------
  minimum time:     13.221 ms (0.00% GC)
  median time:      14.123 ms (0.00% GC)
  mean time:        16.652 ms (12.73% GC)
  maximum time:     32.674 ms (37.70% GC)
  --------------
  samples:          300
  evals/sample:     1
```

edit : ported into #1392