### PR TITLE
added SSSPAlgorithm and APSPAlgorithm

### DIFF
--- a/src/ShortestPaths/ShortestPaths.jl
+++ b/src/ShortestPaths/ShortestPaths.jl
@@ -39,12 +39,31 @@ the type of shortest path calculation used by [`shortest_paths`](@ref).
 Some concrete subtypes (most notably [`Dijkstra`](@ref) have fields
 that specify algorithm parameters.
 
+Concrete subtypes are further classified into [`SSSPAlgorithm`](@ref) for
+single-source shortest-paths algorithms, or [`APSPAlgorithm`](@) for
+all-pairs shortest-paths algorithms, as appropriate.
+
 See [`AStar`](@ref), [`BellmanFord`](@ref), [`BFS`](@ref),
 [`DEspopoPape`](@ref), [`Dijkstra`](@ref), [`FloydWarshall`](@ref),
 [`Johnson`](@ref), and [`SPFA`](@ref) for specific requirements and
 usage details.
 """
 abstract type ShortestPathAlgorithm <: AbstractGraphAlgorithm end
+
+"""
+    abstract type SSSPAlgorithm <: ShortestPathAlgorithm
+
+An abstract type representing a single-source shortest-paths algorithm.
+"""
+abstract type SSSPAlgorithm <: ShortestPathAlgorithm end
+
+"""
+    abstract type APSPAlgorithm <: ShortestPathAlgorithm
+
+An abstract type representing an all-pairs shortest-paths algorithm.
+"""
+abstract type APSPAlgorithm <: ShortestPathAlgorithm end
+
 
 
 ################################

--- a/src/ShortestPaths/bellman-ford.jl
+++ b/src/ShortestPaths/bellman-ford.jl
@@ -5,7 +5,7 @@
 
 
 """
-    struct BellmanFord <: ShortestPathAlgorithm
+    struct BellmanFord <: SSSPAlgorithm
 
 The structure used to configure and specify that [`shortest_paths`](@ref)
 should use the [Bellman-Ford algorithm](http://en.wikipedia.org/wiki/Bellman–Ford_algorithm).
@@ -17,7 +17,7 @@ No fields are specified or required.
 - (optional) multiple sources
 - all destinations
 """
-struct BellmanFord <: ShortestPathAlgorithm end
+struct BellmanFord <: SSSPAlgorithm end
 struct BellmanFordResult{T, U<:Integer} <: ShortestPathResult
     parents::Vector{U}
     dists::Vector{T}

--- a/src/ShortestPaths/bfs.jl
+++ b/src/ShortestPaths/bfs.jl
@@ -1,5 +1,5 @@
 """
-    struct BFS <: ShortestPathAlgorithm
+    struct BFS <: SSSPAlgorithm
 
 The structure used to configure and specify that [`shortest_paths`](@ref)
 should use the [Breadth-First Search algorithm](https://en.m.wikipedia.org/wiki/Breadth-first_search).
@@ -21,7 +21,7 @@ beyond which all path distances are assumed to be infinite (that is, they do not
 - (optional) multiple sources
 - all destinations
 """
-struct BFS{T} <: ShortestPathAlgorithm
+struct BFS{T} <: SSSPAlgorithm
     traversal::T
     maxdist::Int64
 end

--- a/src/ShortestPaths/desopo-pape.jl
+++ b/src/ShortestPaths/desopo-pape.jl
@@ -1,5 +1,5 @@
 """
-    struct DEsopoPape <: ShortestPathAlgorithm
+    struct DEsopoPape <: SSSPAlgorithm
 
 The structure used to configure and specify that [`shortest_paths`](@ref)
 should use the [D'Esopo-Pape algorithm](http://web.mit.edu/dimitrib/www/SLF.pdf).
@@ -12,7 +12,7 @@ should use the [D'Esopo-Pape algorithm](http://web.mit.edu/dimitrib/www/SLF.pdf)
 - non-negative distance matrices / weights
 - all destinations
 """
-struct DEsopoPape{T<:Real} <: ShortestPathAlgorithm
+struct DEsopoPape{T<:Real} <: SSSPAlgorithm
     maxdist::T
 end
 

--- a/src/ShortestPaths/dijkstra.jl
+++ b/src/ShortestPaths/dijkstra.jl
@@ -7,7 +7,7 @@ struct DijkstraResult{T, U<:Integer}  <: ShortestPathResult
 end
 
 """
-    struct Dijkstra <: ShortestPathAlgorithm
+    struct Dijkstra <: SSSPAlgorithm
 
 The structure used to configure and specify that [`shortest_paths`](@ref)
 should use [Dijkstra's algorithm](http://en.wikipedia.org/wiki/Dijkstra%27s_algorithm)
@@ -39,7 +39,7 @@ D = transpose(sparse(transpose(D)))
 Be aware that realizing the sparse transpose of `D` incurs a heavy one-time penalty, so this strategy
 should only be used when multiple calls to [`shortest_paths`](@ref) with the distance matrix are planned.
 """
-struct Dijkstra{F<:Function, T<:Real} <: ShortestPathAlgorithm
+struct Dijkstra{F<:Function, T<:Real} <: SSSPAlgorithm
     all_paths::Bool
     track_vertices::Bool
     maxdist::T

--- a/src/ShortestPaths/distributed-dijkstra.jl
+++ b/src/ShortestPaths/distributed-dijkstra.jl
@@ -1,5 +1,5 @@
 """
-    struct DistributedDijkstra <: ShortestPathAlgorithm end
+    struct DistributedDijkstra <: SSSPAlgorithm end
 
 A struct representing a parallel implementation of the Dijkstra shortest-paths algorithm. Optional
 fields for this structure incldue
@@ -7,7 +7,7 @@ fields for this structure incldue
 - `neighborfn::Function` (default: [`outneighbors`](@ref) - specify the neighbor function to use during the
    graph traversal.
 """
-struct DistributedDijkstra{F<:Function} <: ShortestPathAlgorithm
+struct DistributedDijkstra{F<:Function} <: SSSPAlgorithm
     neighborfn::F
 end
 

--- a/src/ShortestPaths/distributed-johnson.jl
+++ b/src/ShortestPaths/distributed-johnson.jl
@@ -1,9 +1,9 @@
 """
-    struct DistributedJohnson <: ShortestPathAlgorithm end
+    struct DistributedJohnson <: APSPAlgorithm end
 
 A struct representing a parallel implementation of the Johnson shortest-paths algorithm.
 """
-struct DistributedJohnson <: ShortestPathAlgorithm end
+struct DistributedJohnson <: APSPAlgorithm end
 
 function shortest_paths(g::AbstractGraph{U},
     distmx::AbstractMatrix{T}, ::DistributedJohnson) where {T<:Real, U<:Integer}

--- a/src/ShortestPaths/floyd-warshall.jl
+++ b/src/ShortestPaths/floyd-warshall.jl
@@ -2,7 +2,7 @@
 # licensing details.
 
 """
-    struct FloydWarshall <: ShortestPathAlgorithm
+    struct FloydWarshall <: APSPAlgorithm
 
 The structure used to configure and specify that [`shortest_paths`](@ref)
 should use the [Floyd-Warshall algorithm](http://en.wikipedia.org/wiki/Floyd–Warshall_algorithm).
@@ -18,7 +18,8 @@ No additional configuration parameters are specified or required.
 ### Performance
 Space complexity is on the order of ``\\mathcal{O}(|V|^2)``.
 """
-struct FloydWarshall <: ShortestPathAlgorithm end
+struct FloydWarshall <: APSPAlgorithm end
+
 struct FloydWarshallResult{T, U<:Integer} <: ShortestPathResult
     dists::Matrix{T}
     parents::Matrix{U}

--- a/src/ShortestPaths/johnson.jl
+++ b/src/ShortestPaths/johnson.jl
@@ -1,5 +1,5 @@
 """
-    struct Johnson <: ShortestPathAlgorithm
+    struct Johnson <: APSPAlgorithm
 
 The structure used to configure and specify that [`shortest_paths`](@ref)
 should use the [Johnson algorithm](https://en.wikipedia.org/wiki/Johnson%27s_algorithm).
@@ -15,7 +15,7 @@ should use the [Johnson algorithm](https://en.wikipedia.org/wiki/Johnson%27s_alg
 ### Performance
 Complexity: O(|V|*|E|)
 """
-struct Johnson{T<:Real} <: ShortestPathAlgorithm
+struct Johnson{T<:Real} <: APSPAlgorithm
     maxdist::T
 end
 

--- a/src/ShortestPaths/spfa.jl
+++ b/src/ShortestPaths/spfa.jl
@@ -9,7 +9,7 @@
 using LightGraphs: nv, weights, outneighbors
 
 """
-    struct SPFA <: ShortestPathAlgorithm
+    struct SPFA <: SSSPAlgorithm
 
 The structure used to configure and specify that [`shortest_paths`](@ref)
 should use the [Shortest Path Faster Algorithm](https://en.wikipedia.org/wiki/Shortest_Path_Faster_Algorithm).
@@ -22,7 +22,7 @@ should use the [Shortest Path Faster Algorithm](https://en.wikipedia.org/wiki/Sh
 - non-negative distance matrices / weights
 - all destinations
 """
-struct SPFA{T} <: ShortestPathAlgorithm
+struct SPFA{T} <: SSSPAlgorithm
     maxdist::T
 end
 

--- a/src/ShortestPaths/threaded-bellman-ford.jl
+++ b/src/ShortestPaths/threaded-bellman-ford.jl
@@ -1,4 +1,17 @@
-struct ThreadedBellmanFord <: ShortestPathAlgorithm end
+"""
+    struct ThreadedBellmanFord <: SSSPAlgorithm
+
+The structure used to configure and specify that [`shortest_paths`](@ref)
+should use a threaded version of the [Bellman-Ford algorithm](http://en.wikipedia.org/wiki/Bellman–Ford_algorithm).
+No fields are specified or required.
+
+### Implementation Notes
+`BellmanFord` supports the following shortest-path functionality:
+- negative distance matrices / weights
+- (optional) multiple sources
+- all destinations
+"""
+struct ThreadedBellmanFord <: SSSPAlgorithm end
 
 function shortest_paths(g::AbstractGraph{U}, sources::AbstractVector{<:Integer}, distmx::AbstractMatrix{T}, ::ThreadedBellmanFord) where {T<:Real, U<:Integer}
     nvg = nv(g)

--- a/src/ShortestPaths/threaded-bfs.jl
+++ b/src/ShortestPaths/threaded-bfs.jl
@@ -1,5 +1,5 @@
 """
-    struct ThreadedBFS <: ShortestPathAlgorithm
+    struct ThreadedBFS <: SSSPAlgorithm
         queue_segment_size::Int
     end
 
@@ -15,7 +15,7 @@ improve performance.
 - [Avoiding Locks and Atomic Instructions in Shared-Memory Parallel BFS Using Optimistic 
 Parallelization](https://www.computer.org/csdl/proceedings/ipdpsw/2013/4979/00/4979b628-abs.html).
 """
-struct ThreadedBFS <: ShortestPathAlgorithm
+struct ThreadedBFS <: SSSPAlgorithm
     queue_segment_size::Int
 end
 

--- a/src/ShortestPaths/threaded-floyd-warshall.jl
+++ b/src/ShortestPaths/threaded-floyd-warshall.jl
@@ -1,9 +1,9 @@
 """
-    struct ThreadedFloydWarshall <: ShortestPathAlgorithm end
+    struct ThreadedFloydWarshall <: APSPAlgorithm end
 
 A struct representing a threaded implementation of the Floyd-Warshall shortest-paths algorithm.
 """
-struct ThreadedFloydWarshall <: ShortestPathAlgorithm end
+struct ThreadedFloydWarshall <: APSPAlgorithm end
 
 #Helper function used due to performance bug in @threads. 
 function _loopbody!(

--- a/src/ShortestPaths/trackingbfs.jl
+++ b/src/ShortestPaths/trackingbfs.jl
@@ -1,5 +1,5 @@
 """
-    struct TrackingBFS <: ShortestPathAlgorithm
+    struct TrackingBFS <: SSSPAlgorithm
 
 The structure used to configure and specify that [`shortest_paths`](@ref)
 should use the [Breadth-First Search algorithm](https://en.m.wikipedia.org/wiki/Breadth-first_search).
@@ -22,7 +22,7 @@ beyond which all path distances are assumed to be infinite (that is, they do not
 - redundant equivalent path tracking
 - vertex tracking
 """
-struct TrackingBFS{T} <: ShortestPathAlgorithm
+struct TrackingBFS{T} <: SSSPAlgorithm
     traversal::T
     maxdist::Int64
 end


### PR DESCRIPTION
This further subdivides `ShortestPathAlgorithm` into `SSSPAlgorithm <: ShortestPathAlgorithm` and `APSPAlgorithm <: ShortestPathAlgorithm` for use by upcoming modules. Most `ShortestPathAlgorithms` fall into one of these two types; the only outliers are `AStar` and `Yen`.

Since this doesn't add new functionality, just a level of abstract type, I will merge as soon as tests pass.