### PR TITLE
change from NOOPSort to QuickSort

### DIFF
--- a/src/Traversals/breadthfirst.jl
+++ b/src/Traversals/breadthfirst.jl
@@ -11,7 +11,7 @@ struct BreadthFirst{F<:Function, T<:Base.Sort.Algorithm} <: TraversalAlgorithm
     sort_alg::T
 end
 
-BreadthFirst(; neighborfn=outneighbors, sort_alg=NOOPSort) = BreadthFirst(neighborfn, sort_alg)
+BreadthFirst(; neighborfn=outneighbors, sort_alg=QuickSort) = BreadthFirst(neighborfn, sort_alg)
 
 """
     traverse_graph!(g, ss, alg, state)


### PR DESCRIPTION
Changes the breadth first frontier sorting algorithm from NOOPSort to QuickSort. This results in a minor performance penalty on small graphs but a huge performance increase on large graphs.

I plan on merging this nonbreaking change as soon as tests pass.