### PR TITLE
Sbromberger/fix tracking

### DIFF
--- a/src/ShortestPaths/dijkstra.jl
+++ b/src/ShortestPaths/dijkstra.jl
@@ -2,7 +2,7 @@ struct DijkstraResult{T, U<:Integer}  <: ShortestPathResult
     parents::Vector{U}
     dists::Vector{T}
     predecessors::Vector{Vector{U}}
-    pathcounts::Vector{UInt64}
+    pathcounts::Vector{Float64}
     closest_vertices::Vector{U}
 end
 
@@ -55,7 +55,7 @@ function shortest_paths(g::AbstractGraph, srcs::Vector{U}, distmx::AbstractMatri
     parents = zeros(U, nvg)
     visited = zeros(Bool, nvg)
 
-    pathcounts = zeros(UInt64, nvg)
+    pathcounts = zeros(nvg)
     preds = fill(Vector{U}(), nvg)
     H = PriorityQueue{U,T}()
     # fill creates only one array.
@@ -63,7 +63,7 @@ function shortest_paths(g::AbstractGraph, srcs::Vector{U}, distmx::AbstractMatri
     for src in srcs
         dists[src] = zero(T)
         visited[src] = true
-        pathcounts[src] = 1
+        pathcounts[src] = one(Float64)
         H[src] = zero(T)
     end
 
@@ -121,7 +121,7 @@ function shortest_paths(g::AbstractGraph, srcs::Vector{U}, distmx::AbstractMatri
     end
 
     for src in srcs
-        pathcounts[src] = 1
+        pathcounts[src] = one(Float64)
         parents[src] = 0
         empty!(preds[src])
     end

--- a/src/ShortestPaths/distributed-dijkstra.jl
+++ b/src/ShortestPaths/distributed-dijkstra.jl
@@ -21,7 +21,7 @@ A [`ShortestPathResult`](@ref) designed for parallel Dijkstra shortest paths cal
 struct DistributedDijkstraResult{T <: Real,U <: Integer} <: ShortestPathResult
     dists::Matrix{T}
     parents::Matrix{U}
-    pathcounts::Matrix{U}
+    pathcounts::Matrix{Float64}
 end
 
 # """
@@ -41,7 +41,7 @@ function shortest_paths(g::AbstractGraph{U},
     # TODO: remove `Int` once julialang/#23029 / #23032 are resolved
     dists      = SharedMatrix{T}(Int(r_v), Int(n_v))
     parents    = SharedMatrix{U}(Int(r_v), Int(n_v))
-    pathcounts = SharedMatrix{U}(Int(r_v), Int(n_v))
+    pathcounts = SharedMatrix{Float64}(Int(r_v), Int(n_v))
 
     @sync @distributed for i in 1:r_v
         state = shortest_paths(g, sources[i], distmx, ShortestPaths.Dijkstra(neighborfn=alg.neighborfn))

--- a/src/ShortestPaths/trackingbfs.jl
+++ b/src/ShortestPaths/trackingbfs.jl
@@ -34,7 +34,7 @@ mutable struct TrackingBFSSPState{U} <: Traversals.TraversalState
     parents::Vector{U}
     dists::Vector{U}
     n_level::U
-    pathcounts::Vector{U}
+    pathcounts::Vector{Float64}
     predecessors::Vector{Vector{U}}
     closest_vertices::Vector{U}
     maxdist::U
@@ -42,7 +42,7 @@ end
 
 @inline function initfn!(s::TrackingBFSSPState, u)
     s.dists[u] = 0
-    s.pathcounts[u] = 1
+    s.pathcounts[u] = one(Float64)
     push!(s.closest_vertices, u)
     return true
 end
@@ -74,7 +74,7 @@ end
 struct TrackingBFSResult{U<:Integer} <: ShortestPathResult
     parents::Vector{U}
     dists::Vector{U}
-    pathcounts::Vector{U}
+    pathcounts::Vector{Float64}
     predecessors::Vector{Vector{U}}
     closest_vertices::Vector{U}
 end
@@ -89,7 +89,7 @@ function shortest_paths(
     dists = fill(typemax(U), n)
     parents = zeros(U, n)
     predecessors = fill(Vector{U}(), n)
-    pathcounts = zeros(U, n)
+    pathcounts = zeros(n)
     closest_vertices = Vector{U}()
     sizehint!(closest_vertices, n)
 

--- a/test/Centrality/betweenness.jl
+++ b/test/Centrality/betweenness.jl
@@ -3,7 +3,7 @@
     s2 = SimpleDiGraph(3)
     add_edge!(s2, 1, 2); add_edge!(s2, 2, 3); add_edge!(s2, 3, 3)
     s1 = SimpleGraph(s2)
-    g3 = SimpleGraph(SGGEN.Path(5))
+    g3 = path_graph(5)
 
     gint = loadgraph(joinpath(testdir, "testdata", "graph-50-500.jgz"), "graph-50-500")
 

--- a/test/Centrality/betweenness.jl
+++ b/test/Centrality/betweenness.jl
@@ -71,7 +71,7 @@
         @test isapprox(LCENT.centrality(g, distmx2, LCENT.Betweenness(vs=vertices(g), normalize=true, endpoints=true)), [2.0,2.5,2.0])
     end
     # test 1405
-    g = SimpleGraph(LightGraphs.Generators.Grid([30, 30]))
+    g = grid([50, 50])
     z = @inferred(LCENT.centrality(g, LCENT.Betweenness(normalize=false)))
     zd = @inferred(LCENT.centrality(g, weights(g), LCENT.Betweenness(normalize=false)))
     @test isapprox(z, zd)

--- a/test/Centrality/betweenness.jl
+++ b/test/Centrality/betweenness.jl
@@ -70,4 +70,8 @@
         @test isapprox(LCENT.centrality(g, distmx2, LCENT.Betweenness(vs=vertices(g), normalize=true)), [0.0,0.5,0.0])
         @test isapprox(LCENT.centrality(g, distmx2, LCENT.Betweenness(vs=vertices(g), normalize=true, endpoints=true)), [2.0,2.5,2.0])
     end
+    # test 1405
+    g = SimpleGraph(LightGraphs.Generators.Grid([30, 30]))
+    z = @inferred(LCENT.centrality(g, LCENT.Betweenness(normalize=false)))
+    @test maximum(z) < nv(g) * (nv(g)-1)
 end

--- a/test/Centrality/betweenness.jl
+++ b/test/Centrality/betweenness.jl
@@ -3,7 +3,7 @@
     s2 = SimpleDiGraph(3)
     add_edge!(s2, 1, 2); add_edge!(s2, 2, 3); add_edge!(s2, 3, 3)
     s1 = SimpleGraph(s2)
-    g3 = path_graph(5)
+    g3 = SimpleGraph(SGGEN.Path(5))
 
     gint = loadgraph(joinpath(testdir, "testdata", "graph-50-500.jgz"), "graph-50-500")
 
@@ -40,7 +40,7 @@
     @test z[1] == z[5] == 0.0
 
     # Weighted Graph tests
-    g = Graph(6)
+    g = SimpleGraph(6)
     add_edge!(g, 1, 2)
     add_edge!(g, 2, 3)
     add_edge!(g, 3, 4)
@@ -73,5 +73,8 @@
     # test 1405
     g = SimpleGraph(LightGraphs.Generators.Grid([30, 30]))
     z = @inferred(LCENT.centrality(g, LCENT.Betweenness(normalize=false)))
+    zd = @inferred(LCENT.centrality(g, weights(g), LCENT.Betweenness(normalize=false)))
+    @test isapprox(z, zd)
     @test maximum(z) < nv(g) * (nv(g)-1)
+    @test maximum(zd) < nv(g) * (nv(g)-1)
 end


### PR DESCRIPTION
Fixes #1405 by changing `pathcounts` on tracking traversals from Integer to Float64. This gives up precision for larger maximum values, which are needed because pathcounts on some graphs (like grids) explode towards the end.