### PR TITLE
Fix bug in core_number with bidirectional edges

### DIFF
--- a/src/Degeneracy/batagelj.jl
+++ b/src/Degeneracy/batagelj.jl
@@ -47,7 +47,7 @@ function core_number(g::AbstractGraph{T}, ::Batagelj) where {T}
     for i = 1:n
         v = vert[i]
         # for each neighbor u of vertex v with higher degree we have to decrease its degree and move it for one bin to the left
-        for u in all_neighbors(g, v)
+        for u in outneighbors(g, v)
             if deg[u] > deg[v]
                 du = deg[u]
                 pu = pos[u]
@@ -61,6 +61,24 @@ function core_number(g::AbstractGraph{T}, ::Batagelj) where {T}
                 end
                 bin[du+1] += one(T)
                 deg[u] -= one(T)
+            end
+        end
+        if is_directed(g)
+            for u in inneighbors(g, v)
+                if deg[u] > deg[v]
+                    du = deg[u]
+                    pu = pos[u]
+                    pw = bin[du+1]
+                    w = vert[pw]
+                    if u != w
+                        pos[u] = pw
+                        vert[pu] = w
+                        pos[w] = pu
+                        vert[pw] = u
+                    end
+                    bin[du+1] += one(T)
+                    deg[u] -= one(T)
+                end
             end
         end
     end


### PR DESCRIPTION
```julia
julia> Base.Threads.nthreads()
2

julia> g = loadsnap(:amazon0302)
{262111, 1234877} directed simple UInt32 graph

julia> kcore_list = core_number(g);

julia> kcore_list = convert(Array{Int32}, kcore_list);

julia> key = unique(kcore_list)
10-element Array{Int32,1}:
  6
  7
  8
  1
 10
  4
  3
  5
  2
  9

julia> d1=Dict([(i,count(x->x==i,kcore_list)) for i in key])
Dict{Int32,Int64} with 10 entries:
  7  => 60860
  4  => 7555
  9  => 2023
  10 => 1254
  2  => 4717
  3  => 4747
  8  => 14203
  5  => 18808
  6  => 145331
  1  => 2613

julia> kcore_list = Degeneracy.core_number(g, Degeneracy.KabirMadduri(frac=0.5));

julia> kcore_list = convert(Array{Int32}, kcore_list);

julia> key = unique(kcore_list)
10-element Array{Int32,1}:
  6
  7
  8
  1
 10
  4
  3
  5
  2
  9

julia> d2=Dict([(i,count(x->x==i,kcore_list)) for i in key])
Dict{Int32,Int64} with 10 entries:
  7  => 60860
  4  => 7555
  9  => 2023
  10 => 1254
  2  => 4717
  3  => 4747
  8  => 14203
  5  => 18808
  6  => 145331
  1  => 2613

julia> d1 == d2
true
```