### PR TITLE
fix line break in noop doc

### DIFF
--- a/src/linalg13/graphmatrices.jl
+++ b/src/linalg13/graphmatrices.jl
@@ -104,8 +104,7 @@ perron(m::PunchedAdjacency) = m.perron
 A type that represents no action.
 
 ### Implementation Notes
-- The purpose of `Noop` is to help write more general code for the
-different scaled GraphMatrix types.
+- The purpose of `Noop` is to help write more general code for the different scaled GraphMatrix types.
 """
 struct Noop end
 


### PR DESCRIPTION
The sentence breaks half way in the complied doc, bringing it into one line. As seen below:


![image](https://user-images.githubusercontent.com/2780093/81762939-c7627800-9482-11ea-8f1c-a7398ede0e51.png)
