### PR TITLE
bug fix in parallel kcore and correct indentation in issubset

### DIFF
--- a/src/Degeneracy/kabirmadduri.jl
+++ b/src/Degeneracy/kabirmadduri.jl
@@ -95,7 +95,7 @@ end
 # Also increases locality in memory access pattern because of the smaller size
 function subgraph(g::AbstractGraph{T}, deg::Vector{Atomic{T}}, level::Int64, nvg_small::Int64) where T
     g_small = SimpleGraph{T}(nvg_small)
-    in_gsmall = falses(nv(g))
+    in_gsmall = zeros(Bool, nv(g))
     @threads for v in 1:nv(g)
         if deg[v][] >= level
             in_gsmall[v] = true

--- a/src/SimpleGraphsCore/SimpleGraphsCore.jl
+++ b/src/SimpleGraphsCore/SimpleGraphsCore.jl
@@ -82,7 +82,7 @@ function issubset(g::T, h::T) where T <: AbstractSimpleGraph
         u_nbrs_h = neighbors(h, u)
         p = 1
         len_u_nbrs_g > length(u_nbrs_h) && return false
-		(u_nbrs_g[1] < u_nbrs_h[1] || u_nbrs_g[end] > u_nbrs_h[end]) && return false
+        (u_nbrs_g[1] < u_nbrs_h[1] || u_nbrs_g[end] > u_nbrs_h[end]) && return false
         @inbounds for v in u_nbrs_h
             if v == u_nbrs_g[p]
                 p == len_u_nbrs_g && break


### PR DESCRIPTION
I wasn't aware that `BitArrays` are not thread-safe. Although, there were no inconsistencies in my tests, it might cause unpredictable results. Also I made a mistake with indentation in an old PR, I've corrected them both here.