### PR TITLE
Add more return types for visitor functions

### DIFF
--- a/src/Connectivity/Connectivity.jl
+++ b/src/Connectivity/Connectivity.jl
@@ -9,6 +9,7 @@ using LightGraphs.Traversals
 using DataStructures: Queue, dequeue!, enqueue!, IntDisjointSets, find_root!, union!
 using SimpleTraits
 import LightGraphs.Traversals: initfn!, newvisitfn!, postlevelfn!, visitfn!, previsitfn!
+using LightGraphs.Traversals: VSUCCESS, VTERMINATE
 using Base.Threads
 using LightGraphs: greedy_contiguous_partition
 

--- a/src/Connectivity/dfs.jl
+++ b/src/Connectivity/dfs.jl
@@ -13,18 +13,18 @@ end
 
 @inline function initfn!(state::VisitedState, u)
     state.component_map[u] = state.current_component
-    return true
+    return VSUCCESS
 end
 
 @inline function newvisitfn!(state::VisitedState, u, v)
-    state.component_map[v] > 0 && return false
+    state.component_map[v] > 0 && return VTERMINATE
     state.component_map[v] = state.component_map[u]
-    return true
+    return VSUCCESS
 end
 
 @inline function postlevelfn!(state::VisitedState)
     state.current_component += 1
-    return true
+    return VSUCCESS
 end
 
 function connected_components(g::AbstractGraph{T}, ::DFS) where {T}

--- a/src/Connectivity/kosaraju.jl
+++ b/src/Connectivity/kosaraju.jl
@@ -14,13 +14,13 @@ end
 
 @inline function previsitfn!(s::RevPostOrderState{T}, u) where T
     s.lastnode = u
-    return true
+    return VSUCCESS
 end
 
 @inline function postlevelfn!(s::RevPostOrderState{T}) where T
     s.result[s.cnt] = s.lastnode
     s.cnt -= 1
-    return true
+    return VSUCCESS
 end
 
 mutable struct KosarajuState{T <: Integer} <: LightGraphs.Traversals.TraversalState
@@ -33,12 +33,12 @@ end
         push!(s.comps, s.curr_comp)
     end
     s.curr_comp = Vector{T}([u])
-    return true
+    return VSUCCESS
 end
 
 @inline function newvisitfn!(s::KosarajuState, u, v)
     push!(s.curr_comp, v)
-    return true
+    return VSUCCESS
 end
 
 @traitfn function connected_components(g::AG::IsDirected, ::Kosaraju) where {T<:Integer, AG<:AbstractGraph{T}}

--- a/src/Connectivity/neighborhood_dists.jl
+++ b/src/Connectivity/neighborhood_dists.jl
@@ -7,9 +7,8 @@ end
 @inline function initfn!(state::NeighborState{T, U}, u) where {T, U}
     state.maxdist < zero(U) && return VTERMINATE
     push!(state.vdists, (u, zero(T)))
-    state.maxdist > zero(U) && return VSUCCESS
-    return VTERMINATE
-end
+    return state.maxdist > zero(U) ? VSUCCESS : VTERMINATE
+    end
 
 @inline function newvisitfn!(state::NeighborState, u, v)
     push!(state.vdists, (v, state.nlevel))
@@ -18,8 +17,7 @@ end
 
 @inline function postlevelfn!(state::NeighborState{T, U}) where {T, U}
     state.nlevel += one(T)
-    state.nlevel <= state.maxdist && return VSUCCESS
-    return VTERMINATE
+    return state.nlevel <= state.maxdist ? VSUCCESS : VTERMINATE
 end
 
 

--- a/src/Connectivity/neighborhood_dists.jl
+++ b/src/Connectivity/neighborhood_dists.jl
@@ -5,19 +5,21 @@ mutable struct NeighborState{T, U} <: LightGraphs.Traversals.TraversalState
 end
 
 @inline function initfn!(state::NeighborState{T, U}, u) where {T, U}
-    state.maxdist < zero(U) && return false
+    state.maxdist < zero(U) && return VTERMINATE
     push!(state.vdists, (u, zero(T)))
-    return state.maxdist > zero(U)
+    state.maxdist > zero(U) && return VSUCCESS
+    return VTERMINATE
 end
 
 @inline function newvisitfn!(state::NeighborState, u, v)
     push!(state.vdists, (v, state.nlevel))
-    return true
+    return VSUCCESS
 end
 
 @inline function postlevelfn!(state::NeighborState{T, U}) where {T, U}
     state.nlevel += one(T)
-    return state.nlevel <= state.maxdist
+    state.nlevel <= state.maxdist && return VSUCCESS
+    return VTERMINATE
 end
 
 

--- a/src/Connectivity/tarjan.jl
+++ b/src/Connectivity/tarjan.jl
@@ -20,7 +20,7 @@ end
 @inline function initfn!(s::TarjanState, u)
     s.up = false
     push!(s.stack, u)
-    return true
+    return VSUCCESS
 end
 
 @inline function previsitfn!(s::TarjanState{T}, u) where T
@@ -34,19 +34,19 @@ end
         s.low[u] = s.order[u] = s.cnt
     end
     s.lastnode = u
-    return true
+    return VSUCCESS
 end
 
 @inline function newvisitfn!(s::TarjanState, u, v)
     s.up = false
-    return true
+    return VSUCCESS
 end
 
 @inline function visitfn!(s::TarjanState, u, v)
     if s.onstack[v]
         s.low[u] = min(s.order[v], s.low[u])
     end
-    return true
+    return VSUCCESS
 end
 
 @inline function postlevelfn!(s::TarjanState{T}) where T
@@ -62,7 +62,7 @@ end
         reverse!(new_component)
         push!(s.comps, new_component)
     end
-    return true
+    return VSUCCESS
 end
 
 @traitfn function connected_components(g::AG::IsDirected, ::Tarjan) where {T<:Integer, AG<:AbstractGraph{T}}

--- a/src/ShortestPaths/ShortestPaths.jl
+++ b/src/ShortestPaths/ShortestPaths.jl
@@ -7,6 +7,7 @@ using SparseArrays: sparse
 using Distributed: @distributed
 using Base.Threads: @threads, nthreads
 using SharedArrays: SharedMatrix, sdata
+using LightGraphs.Traversals: VSUCCESS, VTERMINATE
 
 import Base: ==
 import LightGraphs.Traversals: initfn!, previsitfn!, visitfn!, newvisitfn!, revisitfn!, postvisitfn!, postlevelfn!

--- a/src/ShortestPaths/bfs.jl
+++ b/src/ShortestPaths/bfs.jl
@@ -47,8 +47,7 @@ end
 end
 @inline function postlevelfn!(s::BFSSPState{U}) where U
     s.n_level += one(U)
-    s.n_level <= s.maxdist && return VSUCCESS
-    return VTERMINATE
+    return s.n_level <= s.maxdist ? VSUCCESS : VTERMINATE
 end
 
 struct BFSResult{U<:Integer} <: ShortestPathResult

--- a/src/ShortestPaths/bfs.jl
+++ b/src/ShortestPaths/bfs.jl
@@ -38,16 +38,17 @@ end
 
 @inline function initfn!(s::BFSSPState, u)
     s.dists[u] = 0
-    return true
+    return VSUCCESS
 end
 @inline function newvisitfn!(s::BFSSPState, u, v)
     s.dists[v] = s.n_level
     s.parents[v] = u
-    return true
+    return VSUCCESS
 end
 @inline function postlevelfn!(s::BFSSPState{U}) where U
     s.n_level += one(U)
-    return s.n_level <= s.maxdist
+    s.n_level <= s.maxdist && return VSUCCESS
+    return VTERMINATE
 end
 
 struct BFSResult{U<:Integer} <: ShortestPathResult

--- a/src/ShortestPaths/trackingbfs.jl
+++ b/src/ShortestPaths/trackingbfs.jl
@@ -44,7 +44,7 @@ end
     s.dists[u] = 0
     s.pathcounts[u] = one(Float64)
     push!(s.closest_vertices, u)
-    return true
+    return VSUCCESS
 end
 
 @inline function newvisitfn!(s::TrackingBFSSPState, u, v) 
@@ -53,7 +53,7 @@ end
     push!(s.closest_vertices, v)
     s.pathcounts[v] = s.pathcounts[u]
     s.predecessors[v] = [u;]
-    return true
+    return VSUCCESS
 end
 
 function revisitfn!(s::TrackingBFSSPState, u, v)
@@ -61,12 +61,12 @@ function revisitfn!(s::TrackingBFSSPState, u, v)
         s.pathcounts[v] += s.pathcounts[u] 
         push!(s.predecessors[v], u)
     end
-    return true
+    return VSUCCESS
 end
 
 @inline function postlevelfn!(s::TrackingBFSSPState{U}) where {U}
     s.n_level += one(U)
-    return true
+    return VSUCCESS
 end
 
 

--- a/src/Transitivity/Transitivity.jl
+++ b/src/Transitivity/Transitivity.jl
@@ -5,6 +5,7 @@ using SimpleTraits
 using LightGraphs.Connectivity: connected_components, condensation, StrongConnectivityAlgorithm, Tarjan
 using LightGraphs.Traversals: topological_sort, DepthFirst, TraversalState, traverse_graph!
 import LightGraphs.Traversals: initfn!, visitfn!
+using LightGraphs.Traversals: VSUCCESS, VTERMINATE
 
 """
 transitive_closure!(g, selflooped=false, alg=Tarjan())
@@ -180,12 +181,12 @@ function visitfn!(s::DiSpanTree, u, v)
         s.label[v] = s.head
         add_edge!(s.resultg, s.verts[u], s.verts[v])
     end
-    return true
+    return VSUCCESS
 end
 
 function initfn!(s::DiSpanTree, u)
     s.head = u
-    return true
+    return VSUCCESS
 end
 
 @traitfn function transitive_reduction(

--- a/src/Traversals/Traversals.jl
+++ b/src/Traversals/Traversals.jl
@@ -89,14 +89,14 @@ An enum representing the possible return values for visitor functions
 `VFAIL` corresponds to `break`
 `VTERMINATE` corresponds to `return false`
 """
-@enum VisitorReturnValue begin
+@enum VisitorReturnValue::UInt8 begin
     VSUCCESS
     VSKIP
     VFAIL
     VTERMINATE
 end
 
-is_successful(a::VisitorReturnValue) = a == VSUCCESS
+@inline is_successful(a::VisitorReturnValue) = a == VSUCCESS
 
 """
     preinitfn!(state, visited)

--- a/src/Traversals/Traversals.jl
+++ b/src/Traversals/Traversals.jl
@@ -334,12 +334,10 @@ end
 function preinitfn!(s::PathState, visited)
     visited[s.exclude_vertices] .= true
     s.vertices_in_exclude = visited[s.u] | visited[s.v]
-    !s.vertices_in_exclude && return VSUCCESS
-    return VTERMINATE
+    return !s.vertices_in_exclude ? VSUCCESS : VTERMINATE
 end
 function newvisitfn!(s::PathState, u, v)
-    s.v != v && return VSUCCESS
-    return VTERMINATE
+    return s.v != v ? VSUCCESS : VTERMINATE
 end
 
 """

--- a/src/Traversals/breadthfirst.jl
+++ b/src/Traversals/breadthfirst.jl
@@ -6,6 +6,30 @@ const NOOPSort = NOOPSortAlg()
 
 sort!(x, ::Integer, ::Integer, ::NOOPSortAlg, ::Base.Sort.Ordering) = x
 
+"""
+    BreadthFirst{F <: Function, T <: Base.Sort.Algorithm} <: TraversalAlgorithm
+
+Struct representing the BFS traversal algorithm.
+
+### Optional Arguments
+- `neighborfn::Function`: the function to use to compute the neighbors of a vertex (default [`outneighbors`](@ref)).
+- `sort_alg::Base.Sort.Algorithm`: the function to use to sort every level of BFS (default `QuickSort`).
+
+### Visitor Function Usage
+- `preinitfn!`: continue with normal execution if `VSUCCESS`, otherwise terminate
+- `initfn!`: continue with normal execution if `VSUCCESS`, otherwise terminate
+- `previsitfn!`: continue with normal execution if `VSUCCESS`, otherwise terminate
+- `visitfn!`: this function is called for every neighbor (irrespective of whether it is already
+              visited or not) of the vertex being explored
+              if `VTERMINATE`: terminate complete traversal
+              if `VSKIP`: skip neighbor and continue to the next one
+              if `VFAIL`: stop exploring neighbors and go to `postvisitfn!`
+              if `VSUCCESS`: continue with normal execution
+- `newvisitfn!`: same as `visitfn!` but for newly discovered neighbors
+- `revisitfn!`: same as `visitfn!` but for re-discovered neighbors
+- `postvisitfn!`: continue with normal execution if `VSUCCESS`, otherwise terminate
+- `postlevelfn!`: continue with normal execution if `VSUCCESS`, otherwise terminate
+"""
 struct BreadthFirst{F<:Function, T<:Base.Sort.Algorithm} <: TraversalAlgorithm
     neighborfn::F
     sort_alg::T

--- a/src/Traversals/breadthfirst.jl
+++ b/src/Traversals/breadthfirst.jl
@@ -21,10 +21,10 @@ Struct representing the BFS traversal algorithm.
 - `previsitfn!`: continue with normal execution if `VSUCCESS`, otherwise terminate
 - `visitfn!`: this function is called for every neighbor (irrespective of whether it is already
               visited or not) of the vertex being explored
-              if `VTERMINATE`: terminate complete traversal
-              if `VSKIP`: skip neighbor and continue to the next one
-              if `VFAIL`: stop exploring neighbors and go to `postvisitfn!`
-              if `VSUCCESS`: continue with normal execution
+              - if `VTERMINATE`: terminate complete traversal
+              - if `VSKIP`: skip neighbor and continue to the next one
+              - if `VFAIL`: stop exploring neighbors and go to `postvisitfn!`
+              - if `VSUCCESS`: continue with normal execution
 - `newvisitfn!`: same as `visitfn!` but for newly discovered neighbors
 - `revisitfn!`: same as `visitfn!` but for re-discovered neighbors
 - `postvisitfn!`: continue with normal execution if `VSUCCESS`, otherwise terminate
@@ -69,14 +69,14 @@ function traverse_graph!(
             is_successful(previsitfn!(state, v)) || return false
             @inbounds for i in alg.neighborfn(g, v)
                 x = visitfn!(state, v, i)
-                x ==  VTERMINATE && return false # terminate bfs
+                x == VTERMINATE && return false # terminate bfs
                 x == VSKIP && continue  # skip to next neighbor
                 x == VFAIL && break # stop exploring curr vertex's neighbors
                 if !visited[i]
                     # newvisitfn! return values have same effect as visitfn! but only for
                     # newly discovered vertices
                     x = newvisitfn!(state, v, i)
-                    x ==  VTERMINATE && return false
+                    x == VTERMINATE && return false
                     x == VSKIP && continue
                     x == VFAIL && break
                     push!(next_level, i)
@@ -85,7 +85,7 @@ function traverse_graph!(
                     # revisitfn! return values have same effect as visitfn! but only for
                     # rediscovered vertices
                     x = revisitfn!(state, v, i)
-                    x ==  VTERMINATE && return false
+                    x == VTERMINATE && return false
                     x == VSKIP && continue
                     x == VFAIL && break
                 end

--- a/src/Traversals/depthfirst.jl
+++ b/src/Traversals/depthfirst.jl
@@ -16,9 +16,10 @@ Struct representing the DFS traversal algorithm.
 - `previsitfn!`: continue with normal execution if `VSUCCESS`, otherwise terminate
 - `visitfn!`: this function is called for every neighbor (irrespective of whether it is already
               visited or not) of the vertex being explored
-              if `VTERMINATE`: terminate
-              if `VSKIP`: skip neighbor
-              if `VFAIL`: stop exploring neighbors 
+              if `VTERMINATE`: terminate complete traversal
+              if `VSKIP`: skip neighbor and continue to the next one
+              if `VFAIL`: stop exploring neighbors and go to `postvisitfn!`,
+                          this will also result in execution of `postlevelfn!`.
               if `VSUCCESS`: continue with normal execution
 - `newvisitfn!`: same as `visitfn!` but for newly discovered neighbors
 - `revisitfn!`: same as `visitfn!` but for re-discovered neighbors
@@ -101,12 +102,17 @@ function traverse_graph!(
                 end
                 ptr += 1
             end
+            # In DFS postvisitfn! is performed after the first unvisited neighbor is discovered
+            # and pushed to the stack (for exploration in next iteration) or if all neighbors
+            # are already visited
             is_successful(postvisitfn!(state, v)) || return false
             # if ptr > length(neighs) then we have finished all children of the node,
             # and the next time we pop from the stack we will be in the parent of the current
             # node. We would like to continue from where we stoped, otherwise we have found
             # a new unvisited child, so we will make ptr = 1
             if ptr > length(neighs)
+                # In DFS postlevelfn! is performed when all neighbors of current vertex have
+                # been visited
                 is_successful(postlevelfn!(state)) || return false
                 _, ptr =pop!(S)
             else

--- a/src/Traversals/depthfirst.jl
+++ b/src/Traversals/depthfirst.jl
@@ -16,11 +16,11 @@ Struct representing the DFS traversal algorithm.
 - `previsitfn!`: continue with normal execution if `VSUCCESS`, otherwise terminate
 - `visitfn!`: this function is called for every neighbor (irrespective of whether it is already
               visited or not) of the vertex being explored
-              if `VTERMINATE`: terminate complete traversal
-              if `VSKIP`: skip neighbor and continue to the next one
-              if `VFAIL`: stop exploring neighbors and go to `postvisitfn!`,
+              - if `VTERMINATE`: terminate complete traversal
+              - if `VSKIP`: skip neighbor and continue to the next one
+              - if `VFAIL`: stop exploring neighbors and go to `postvisitfn!`,
                           this will also result in execution of `postlevelfn!`.
-              if `VSUCCESS`: continue with normal execution
+              - if `VSUCCESS`: continue with normal execution
 - `newvisitfn!`: same as `visitfn!` but for newly discovered neighbors
 - `revisitfn!`: same as `visitfn!` but for re-discovered neighbors
 - `postvisitfn!`: continue with normal execution if `VSUCCESS`, otherwise terminate
@@ -61,7 +61,7 @@ function traverse_graph!(
             @inbounds while ptr <= length(neighs)
                 i = neighs[ptr]
                 x = visitfn!(state, v, i)
-                x ==  VTERMINATE && return false # terminate dfs
+                x == VTERMINATE && return false # terminate dfs
                 if x == VSKIP # skip this neighbor
                     ptr += 1
                     continue
@@ -74,7 +74,7 @@ function traverse_graph!(
                     # newvisitfn! return values have same effect as visitfn! but only for
                     # newly discovered vertices
                     x = newvisitfn!(state, v, i)
-                    x ==  VTERMINATE && return false
+                    x == VTERMINATE && return false
                     if x == VSKIP
                         ptr += 1
                         continue
@@ -90,7 +90,7 @@ function traverse_graph!(
                     # revisitfn! return values have same effect as visitfn! but only for
                     # rediscovered vertices
                     x = revisitfn!(state, v, i)
-                    x ==  VTERMINATE && return false
+                    x == VTERMINATE && return false
                     if x == VSKIP
                         ptr += 1
                         continue

--- a/src/Traversals/depthfirst.jl
+++ b/src/Traversals/depthfirst.jl
@@ -2,6 +2,29 @@ import Base.showerror
 struct CycleError <: Exception end
 Base.showerror(io::IO, e::CycleError) = print(io, "Cycles are not allowed in this function.")
 
+"""
+    DepthFirst{F <: Function} <: TraversalAlgorithm
+
+Struct representing the DFS traversal algorithm.
+
+### Optional Arguments
+- `neighborfn::Function`: the function to use to compute the neighbors of a vertex (default [`outneighbors`](@ref)).
+
+### Visitor Function Usage
+- `preinitfn!`: continue with normal execution if `VSUCCESS`, otherwise terminate
+- `initfn!`: continue with normal execution if `VSUCCESS`, otherwise terminate
+- `previsitfn!`: continue with normal execution if `VSUCCESS`, otherwise terminate
+- `visitfn!`: this function is called for every neighbor (irrespective of whether it is already
+              visited or not) of the vertex being explored
+              if `VTERMINATE`: terminate
+              if `VSKIP`: skip neighbor
+              if `VFAIL`: stop exploring neighbors 
+              if `VSUCCESS`: continue with normal execution
+- `newvisitfn!`: same as `visitfn!` but for newly discovered neighbors
+- `revisitfn!`: same as `visitfn!` but for re-discovered neighbors
+- `postvisitfn!`: continue with normal execution if `VSUCCESS`, otherwise terminate
+- `postlevelfn!`: continue with normal execution if `VSUCCESS`, otherwise terminate
+"""
 struct DepthFirst{F<:Function} <: TraversalAlgorithm
     neighborfn::F
 end

--- a/src/Traversals/threaded-breadthfirst.jl
+++ b/src/Traversals/threaded-breadthfirst.jl
@@ -15,10 +15,10 @@ at a time (default `20`). For graphs with uniform degree, a larger value of
 - `previsitfn!`: continue with normal execution if `VSUCCESS`, otherwise terminate
 - `visitfn!`: this function is called for every neighbor (irrespective of whether it is already
               visited or not) of the vertex being explored
-              if `VTERMINATE`: terminate complete traversal
-              if `VSKIP`: skip neighbor and continue to the next one
-              if `VFAIL`: stop exploring neighbors and go to `postvisitfn!`
-              if `VSUCCESS`: continue with normal execution
+              - if `VTERMINATE`: terminate complete traversal
+              - if `VSKIP`: skip neighbor and continue to the next one
+              - if `VFAIL`: stop exploring neighbors and go to `postvisitfn!`
+              - if `VSUCCESS`: continue with normal execution
 - `newvisitfn!`: same as `visitfn!` but this function is only called for newly discovered neighbors
 - `revisitfn!`: same as `visitfn!` but this function is only called for re-discovered neighbors
 - `postvisitfn!`: continue with normal execution if `VSUCCESS`, otherwise terminate
@@ -121,7 +121,7 @@ function traverse_graph!(
                         # (visited[v] && vert_level[v] == n_level-one(U)) || continue
                         for i in alg.neighborfn(g, v)
                             x = visitfn!(state, v, i, thread_id)
-                            if x ==  VTERMINATE # terminate bfs
+                            if x == VTERMINATE # terminate bfs
                                 atomic_and!(retval, false)
                                 break
                             end
@@ -132,7 +132,7 @@ function traverse_graph!(
                                 # newvisitfn! return values have same effect as visitfn! but only for
                                 # newly discovered vertices
                                 x = newvisitfn!(state, v, i, thread_id)
-                                if x ==  VTERMINATE
+                                if x == VTERMINATE
                                     atomic_and!(retval, false)
                                     break
                                 end
@@ -146,7 +146,7 @@ function traverse_graph!(
                                 # newvisitfn! return values have same effect as visitfn! but only for
                                 # rediscovered vertices
                                 x = revisitfn!(state, v, i, thread_id)
-                                if x ==  VTERMINATE
+                                if x == VTERMINATE
                                     atomic_and!(retval, false)
                                     break
                                 end

--- a/src/Traversals/threaded-breadthfirst.jl
+++ b/src/Traversals/threaded-breadthfirst.jl
@@ -9,6 +9,21 @@ at a time (default `20`). For graphs with uniform degree, a larger value of
 `queue_segment_size` may improve performance.
 - `neighborfn::Function`: the function to use to compute the neighbors of a vertex (default [`outneighbors`](@ref)).
 
+### Visitor Function Usage
+- `preinitfn!`: continue with normal execution if `VSUCCESS`, otherwise terminate
+- `initfn!`: continue with normal execution if `VSUCCESS`, otherwise terminate
+- `previsitfn!`: continue with normal execution if `VSUCCESS`, otherwise terminate
+- `visitfn!`: this function is called for every neighbor (irrespective of whether it is already
+              visited or not) of the vertex being explored
+              if `VTERMINATE`: terminate complete traversal
+              if `VSKIP`: skip neighbor and continue to the next one
+              if `VFAIL`: stop exploring neighbors and go to `postvisitfn!`
+              if `VSUCCESS`: continue with normal execution
+- `newvisitfn!`: same as `visitfn!` but this function is only called for newly discovered neighbors
+- `revisitfn!`: same as `visitfn!` but this function is only called for re-discovered neighbors
+- `postvisitfn!`: continue with normal execution if `VSUCCESS`, otherwise terminate
+- `postlevelfn!`: continue with normal execution if `VSUCCESS`, otherwise terminate
+
 ### References
 - [Avoiding Locks and Atomic Instructions in Shared-Memory Parallel BFS Using Optimistic 
 Parallelization](https://www.computer.org/csdl/proceedings/ipdpsw/2013/4979/00/4979b628-abs.html).

--- a/test/Measurements/runtests.jl
+++ b/test/Measurements/runtests.jl
@@ -89,8 +89,6 @@ const LMS = LightGraphs.Measurements
         g1 = SimpleGraph(2)
         @test_logs (:warn, "Infinite path length detected for vertex 1: graph may not be connected") match_mode=:any LMS.eccentricity(g1)
         @test_logs (:warn, "Infinite path length detected for vertex 2: graph may not be connected") match_mode=:any LMS.eccentricity(g1)
-        @test_logs (:warn, "Infinite path length detected for vertex 1: graph may not be connected") match_mode=:any LMS.eccentricity(g1, LMS.Threaded())
-        @test_logs (:warn, "Infinite path length detected for vertex 2: graph may not be connected") match_mode=:any LMS.eccentricity(g1, LMS.Threaded())
         g2 = SimpleGraph(SGGEN.Path(2))
         @test_logs LMS.eccentricity(g2)
         @test_logs LMS.eccentricity(g2, LMS.Threaded())

--- a/test/ShortestPaths/threaded-bfs.jl
+++ b/test/ShortestPaths/threaded-bfs.jl
@@ -5,15 +5,15 @@
 
     @testset "$g" for g in testdigraphs(g5)
         # ThreadedBFS parents may differ from BFS
-        @test @inferred(ShortestPaths.shortest_paths(g, 1, ShortestPaths.ThreadedBFS())).dists  == ShortestPaths.shortest_paths(g, 1, ShortestPaths.BFS()).dists
-        @test @inferred(ShortestPaths.shortest_paths(g, [1, 3], ShortestPaths.ThreadedBFS())).dists  == ShortestPaths.shortest_paths(g, [1, 3], ShortestPaths.BFS()).dists
+        @test @inferred(ShortestPaths.shortest_paths(g, 1, ShortestPaths.ThreadedBFS())).dists == ShortestPaths.shortest_paths(g, 1, ShortestPaths.BFS()).dists
+        @test @inferred(ShortestPaths.shortest_paths(g, [1, 3], ShortestPaths.ThreadedBFS())).dists == ShortestPaths.shortest_paths(g, [1, 3], ShortestPaths.BFS()).dists
     end
 
     g6 = SimpleGraph(SGGEN.House())
 
     @testset "$g" for g in testgraphs(g6)
         # ThreadedBFS parents may differ from BFS
-        @test @inferred(ShortestPaths.shortest_paths(g, 2, ShortestPaths.ThreadedBFS())).dists  == ShortestPaths.shortest_paths(g, 2, ShortestPaths.BFS()).dists
+        @test @inferred(ShortestPaths.shortest_paths(g, 2, ShortestPaths.ThreadedBFS())).dists == ShortestPaths.shortest_paths(g, 2, ShortestPaths.BFS()).dists
         @test @inferred(ShortestPaths.shortest_paths(g, [1, 2], ShortestPaths.ThreadedBFS())).dists == ShortestPaths.shortest_paths(g, [1, 2], ShortestPaths.BFS()).dists
     end
 end

--- a/test/ShortestPaths/threaded-bfs.jl
+++ b/test/ShortestPaths/threaded-bfs.jl
@@ -4,14 +4,16 @@
     add_edge!(g5, 1, 2); add_edge!(g5, 2, 3); add_edge!(g5, 1, 3); add_edge!(g5, 3, 4)
 
     @testset "$g" for g in testdigraphs(g5)
-        @test @inferred(ShortestPaths.shortest_paths(g, 1, ShortestPaths.ThreadedBFS()))  == ShortestPaths.shortest_paths(g, 1, ShortestPaths.BFS())
-        @test @inferred(ShortestPaths.shortest_paths(g, [1, 3], ShortestPaths.ThreadedBFS()))  == ShortestPaths.shortest_paths(g, [1, 3], ShortestPaths.BFS())
+        # ThreadedBFS parents may differ from BFS
+        @test @inferred(ShortestPaths.shortest_paths(g, 1, ShortestPaths.ThreadedBFS())).dists  == ShortestPaths.shortest_paths(g, 1, ShortestPaths.BFS()).dists
+        @test @inferred(ShortestPaths.shortest_paths(g, [1, 3], ShortestPaths.ThreadedBFS())).dists  == ShortestPaths.shortest_paths(g, [1, 3], ShortestPaths.BFS()).dists
     end
 
     g6 = SimpleGraph(SGGEN.House())
 
     @testset "$g" for g in testgraphs(g6)
-        @test @inferred(ShortestPaths.shortest_paths(g, 2, ShortestPaths.ThreadedBFS()))  == ShortestPaths.shortest_paths(g, 2, ShortestPaths.BFS())
-        @test @inferred(ShortestPaths.shortest_paths(g, [1, 2], ShortestPaths.ThreadedBFS())) == ShortestPaths.shortest_paths(g, [1, 2], ShortestPaths.BFS())
+        # ThreadedBFS parents may differ from BFS
+        @test @inferred(ShortestPaths.shortest_paths(g, 2, ShortestPaths.ThreadedBFS())).dists  == ShortestPaths.shortest_paths(g, 2, ShortestPaths.BFS()).dists
+        @test @inferred(ShortestPaths.shortest_paths(g, [1, 2], ShortestPaths.ThreadedBFS())).dists == ShortestPaths.shortest_paths(g, [1, 2], ShortestPaths.BFS()).dists
     end
 end

--- a/test/Traversals/breadthfirst.jl
+++ b/test/Traversals/breadthfirst.jl
@@ -1,4 +1,4 @@
-import LightGraphs.Traversals: preinitfn!, TraversalState
+import LightGraphs.Traversals: preinitfn!, TraversalState, VTERMINATE
 @testset "BreadthFirst" begin
 
     g5 = SimpleDiGraph(4)
@@ -39,7 +39,7 @@ import LightGraphs.Traversals: preinitfn!, TraversalState
     end
 
     @testset "distances" begin
-        LT.preinitfn!(::DummyState, u) = false
+        LT.preinitfn!(::DummyState, u) = VTERMINATE
 
         @testset "$g" for g in testgraphs(g6)
             @test @inferred(LT.distances(g, 2)) == @inferred(LT.distances(g, 2, LT.BreadthFirst(sort_alg=MergeSort))) == [1, 0, 2, 1, 2]

--- a/test/Traversals/threaded-breadthfirst.jl
+++ b/test/Traversals/threaded-breadthfirst.jl
@@ -1,4 +1,5 @@
 import LightGraphs.Traversals: preinitfn!, initfn!, previsitfn!, visitfn!, newvisitfn!, postvisitfn!, postlevelfn!
+using LightGraphs.Traversals: VSUCCESS, VTERMINATE
 
 @testset "LT.ThreadedBreadthFirst" begin
     g5 = SimpleDiGraph(4)
@@ -45,31 +46,31 @@ import LightGraphs.Traversals: preinitfn!, initfn!, previsitfn!, visitfn!, newvi
 
     g7 = SimpleGraph(SGGEN.BinaryTree(4))
     struct DummyState <: LT.TraversalState end
-    LT.preinitfn!(::DummyState, u) = false
+    LT.preinitfn!(::DummyState, u) = VTERMINATE
 
     @test !LT.traverse_graph!(g7, 1, LT.ThreadedBreadthFirst(), DummyState())
 
-    LT.preinitfn!(::DummyState, u) = true
-    LT.initfn!(::DummyState, u) = false
+    LT.preinitfn!(::DummyState, u) = VSUCCESS
+    LT.initfn!(::DummyState, u) = VTERMINATE
     @test !LT.traverse_graph!(g7, 1, LT.ThreadedBreadthFirst(), DummyState())
 
-    LT.initfn!(::DummyState, u) = true
-    LT.previsitfn!(::DummyState, u, t::Integer) = false
+    LT.initfn!(::DummyState, u) = VSUCCESS
+    LT.previsitfn!(::DummyState, u, t::Integer) = VTERMINATE
     @test !LT.traverse_graph!(g7, 1, LT.ThreadedBreadthFirst(), DummyState())
 
-    LT.previsitfn!(::DummyState, u, t::Integer) = true
-    LT.visitfn!(::DummyState, u, v, t::Integer) = false
+    LT.previsitfn!(::DummyState, u, t::Integer) = VSUCCESS
+    LT.visitfn!(::DummyState, u, v, t::Integer) = VTERMINATE
     @test !LT.traverse_graph!(g7, 1, LT.ThreadedBreadthFirst(), DummyState())
 
-    LT.visitfn!(::DummyState, u, v, t::Integer) = true
-    LT.newvisitfn!(::DummyState, u, v, t::Integer) = false
+    LT.visitfn!(::DummyState, u, v, t::Integer) = VSUCCESS
+    LT.newvisitfn!(::DummyState, u, v, t::Integer) = VTERMINATE
     @test !LT.traverse_graph!(g7, 1, LT.ThreadedBreadthFirst(), DummyState())
 
-    LT.newvisitfn!(::DummyState, u, v, t::Integer) = true
-    LT.postvisitfn!(::DummyState, u, t::Integer) = false
+    LT.newvisitfn!(::DummyState, u, v, t::Integer) = VSUCCESS
+    LT.postvisitfn!(::DummyState, u, t::Integer) = VTERMINATE
     @test !LT.traverse_graph!(g7, 1, LT.ThreadedBreadthFirst(), DummyState())
 
-    LT.postvisitfn!(::DummyState, u, t::Integer) = true
-    LT.postlevelfn!(::DummyState) = false
+    LT.postvisitfn!(::DummyState, u, t::Integer) = VSUCCESS
+    LT.postlevelfn!(::DummyState) = VTERMINATE
     @test !LT.traverse_graph!(g7, 1, LT.ThreadedBreadthFirst(), DummyState())
 end

--- a/test/deprecations13/distance13.jl
+++ b/test/deprecations13/distance13.jl
@@ -51,6 +51,6 @@
         @test_logs (:warn, "Infinite path length detected for vertex 1: graph may not be connected") match_mode=:any eccentricity(g1)
         @test_logs (:warn, "Infinite path length detected for vertex 2: graph may not be connected") match_mode=:any eccentricity(g1)
         g2 = path_graph(2)
-        @test_logs eccentricity(g2)
+        @test_logs LightGraphs.Measurements.eccentricity(g2)
     end
 end

--- a/test/deprecations13/distance13.jl
+++ b/test/deprecations13/distance13.jl
@@ -51,6 +51,6 @@
         @test_logs (:warn, "Infinite path length detected for vertex 1: graph may not be connected") match_mode=:any eccentricity(g1)
         @test_logs (:warn, "Infinite path length detected for vertex 2: graph may not be connected") match_mode=:any eccentricity(g1)
         g2 = path_graph(2)
-        @test_logs LightGraphs.Measurements.eccentricity(g2)
+        @test_logs eccentricity(g2)
     end
 end


### PR DESCRIPTION
The visitor return value names are not final and yet to discussed. I will update the documentation accordingly.
I created a table for comparing the benchmarks. There is a slight performance hit (5-10%). The number of memory allocations are unaffected.
```
julia> g = loadsnap(:soc_slashdot0902_u)
{82168, 582533} undirected simple Int64 graph

julia> dg = loadsnap(:ego_twitter_d)
{81306, 1768149} directed simple Int64 graph
```

**BENCHMARKS**
| Test                                                  | New time   | Old time   |
|-------------------------------------------------------|------------|------------|
| connected_components(g, DFS())                        | 28.892 ms  | 26.824 ms  |
| connected_components(dg, Kosaraju())                  | 55.429 ms  | 50.502 ms  |
| connected_components(dg, Tarjan())                    | 36.570 ms  | 34.143 ms  |
| distances(g, ss, DepthFirst())                        | 27.230 ms  | 25.082 ms  |
| distances(g, ss, BreadthFirst())                      | 10.846 ms  | 9.662 ms   |
| distances(g, ss, ThreadedBreadthFirst())              | 3.117 ms   | 2.975 ms   |
| parents(g, ss, DepthFirst())                          | 26.929 ms  | 24.852 ms  |
| parents(g, ss, BreadthFirst())                        | 10.449 ms  | 9.654 ms   |
| parents(g, ss, ThreadedBreadthFirst())                | 3.125 ms   | 2.989 ms   |
| distances(dg, ss, DepthFirst())                       | 25.672 ms  | 23.866 ms  |
| distances(dg, ss, BreadthFirst())                     | 15.784 ms  | 14.215 ms  |
| distances(dg, ss, ThreadedBreadthFirst())             | 4.767 ms   | 4.526 ms   |
| parents(dg, ss, DepthFirst())                         | 25.535 ms  | 23.934 ms  |
| parents(dg, ss, BreadthFirst())                       | 15.784 ms  | 14.458 ms  |
| parents(dg, ss, ThreadedBreadthFirst())               | 4.783 ms   | 4.538 ms   |
| shortest_paths(g, ss, TrackingBFS())                  | 30.665 ms  | 29.654 ms  |
| shortest_paths(dg, ss, TrackingBFS())                 | 33.841 ms  | 31.971 ms  |
| ____has_path on 100 pairs of (u, v)____               |            |            |
| test_has_path(g, DepthFirst(), srcs, dsts)            | 1.315 s    | 1.233 s    |
| test_has_path(g, BreadthFirst(), srcs, dsts)          | 262.609 ms | 246.744 ms |
| test_has_path(g, ThreadedBreadthFirst(), srcs, dsts)  | 192.383 ms | 185.362 ms |
| test_has_path(dg, DepthFirst(), srcs, dsts)           | 811.993 ms | 750.751 ms |
| test_has_path(dg, BreadthFirst(), srcs, dsts)         | 349.377 ms | 318.146 ms |
| test_has_path(dg, ThreadedBreadthFirst(), srcs, dsts) | 198.299 ms | 187.514 ms |

I've also corrected some errors which I encountered on testing LightGraphs locally. Since we don't have multi-threading enabled on CI, it was unable to detect them.

Here is the benchmark code for reference:
```julia
julia> using LightGraphs

julia> using LightGraphs.Connectivity: connected_components, DFS, Kosaraju, Tarjan

julia> using LightGraphs.Traversals: distances, parents, has_path, BreadthFirst, DepthFirst, ThreadedBreadthFirst

julia> using LightGraphs.ShortestPaths: shortest_paths, TrackingBFS

julia> using SNAPDatasets, BenchmarkTools

julia> using Random

julia> Random.seed!(1);

julia> BenchmarkTools.DEFAULT_PARAMETERS.samples = 100
100

julia> Threads.nthreads()
6

julia> g = loadsnap(:soc_slashdot0902_u)
{82168, 582533} undirected simple Int64 graph

julia> dg = loadsnap(:ego_twitter_d)
{81306, 1768149} directed simple Int64 graph

julia> # wcc
       @btime connected_components(g, DFS())
  28.892 ms (30 allocations: 3.89 MiB)

julia> # scc
       @btime connected_components(dg, Kosaraju())
  55.429 ms (24917 allocations: 7.64 MiB)

julia> @btime connected_components(dg, Tarjan())
  36.570 ms (24586 allocations: 8.25 MiB)

julia> # undirected distances and parents
       ss = [1, 5, 6];

julia> @btime distances(g, ss, DepthFirst())
  27.230 ms (20 allocations: 1.64 MiB)

julia> @btime distances(g, ss, BreadthFirst())
  10.846 ms (9 allocations: 1.89 MiB)

julia> @btime distances(g, ss, ThreadedBreadthFirst())
  3.117 ms (443 allocations: 2.00 MiB)

julia> @btime parents(g, ss, DepthFirst())
  26.929 ms (20 allocations: 1.64 MiB)

julia> @btime parents(g, ss, BreadthFirst())
  10.449 ms (9 allocations: 1.89 MiB)

julia> @btime parents(g, ss, ThreadedBreadthFirst())
  3.125 ms (443 allocations: 2.00 MiB)

julia> # directed distances and parents
       ss = [1, 7, 10];

julia> @btime distances(dg, ss, DepthFirst())
  25.672 ms (20 allocations: 1.63 MiB)

julia> @btime distances(dg, ss, BreadthFirst())
  15.784 ms (9 allocations: 1.87 MiB)

julia> @btime distances(dg, ss, ThreadedBreadthFirst())
  4.767 ms (401 allocations: 1.98 MiB)

julia> @btime parents(dg, ss, DepthFirst())
  25.535 ms (20 allocations: 1.63 MiB)

julia> @btime parents(dg, ss, BreadthFirst())
  15.883 ms (9 allocations: 1.87 MiB)

julia> @btime parents(dg, ss, ThreadedBreadthFirst())
  4.783 ms (399 allocations: 1.98 MiB)

julia> # shortest paths tracking bfs
       ss = [1, 50, 200];

julia> @btime shortest_paths(g, ss, TrackingBFS())
  30.665 ms (133869 allocations: 15.43 MiB)

julia> @btime shortest_paths(dg, ss, TrackingBFS())
  33.841 ms (147797 allocations: 16.69 MiB)

julia> # has path on 100 pairs of (u, v)
       function test_has_path(g, alg, srcs, dsts) where T
               for i in 1:100
                       has_path(g, srcs[i], dsts[i], alg)
               end
       end
test_has_path (generic function with 1 method)

julia> srcs = rand(1:nv(g), 100);

julia> dsts = rand(1:nv(g), 100);

julia> @btime test_has_path(g, DepthFirst(), srcs, dsts)
  1.315 s (2257 allocations: 86.50 MiB)

julia> @btime test_has_path(g, BreadthFirst(), srcs, dsts)
  262.609 ms (1200 allocations: 126.43 MiB)

julia> @btime test_has_path(g, ThreadedBreadthFirst(), srcs, dsts)
  192.383 ms (27656 allocations: 142.10 MiB)

julia> srcs = rand(1:nv(dg), 100);

julia> dsts = rand(1:nv(dg), 100);

julia> @btime test_has_path(dg, DepthFirst(), srcs, dsts)
  811.993 ms (2017 allocations: 64.35 MiB)

julia> @btime test_has_path(dg, BreadthFirst(), srcs, dsts)
  349.377 ms (1200 allocations: 125.11 MiB)

julia> @btime test_has_path(dg, ThreadedBreadthFirst(), srcs, dsts)
  198.299 ms (27254 allocations: 134.39 MiB)
```