### PR TITLE
Bug fix in biconnected components

### DIFF
--- a/src/biconnectivity13/biconnect.jl
+++ b/src/biconnectivity13/biconnect.jl
@@ -49,9 +49,11 @@ function visit!(g::AbstractGraph, state::Biconnections{E}, u::Integer, v::Intege
                 push!(state.biconnected_comps, st)
             end
 
-        elseif w != u && state.low[v] > state.depth[w]
-            push!(state.stack, E(min(v, w), max(v, w)))
-            state.low[v] = state.depth[w]
+        elseif w != u
+            state.low[v] = min(state.low[v], state.depth[w])
+            if state.depth[v] > state.depth[w]
+                push!(state.stack, E(min(v, w), max(v, w)))
+            end
         end
     end
 end

--- a/test/biconnectivity13/biconnect.jl
+++ b/test/biconnectivity13/biconnect.jl
@@ -49,4 +49,17 @@
         @test bcc == a
         @test typeof(bcc) === Vector{Vector{Edge{eltype(g)}}}
     end
+
+    gx = Graph(4)
+    add_edge!(gx, 1, 2)
+    add_edge!(gx, 2, 3)
+    add_edge!(gx, 3, 4)
+    add_edge!(gx, 1, 4)
+    add_edge!(gx, 2, 4)
+    a = [[Edge(2, 4), Edge(1, 4), Edge(3, 4), Edge(2, 3), Edge(1, 2)]]
+    for g in testgraphs(gx)
+        bcc = @inferred(biconnected_components(g))
+        @test bcc == a
+        @test typeof(bcc) === Vector{Vector{Edge{eltype(g)}}}
+    end
 end


### PR DESCRIPTION
I was trying to write the biconnectivity functions using the new visitor functions. `articulation` and `bridges` were working fine and there was only a small performance hit. But `biconnected_components` was about 3X slower with visitor functions. Then I observed that actually the old code produces the wrong output (and hence faster). I've corrected the algorithm here. You can clearly see that the old code is giving the wrong results. Here is an example -
```julia
julia> using LightGraphs

julia> g = Graph(4)
{4, 0} undirected simple Int64 graph

julia> add_edge!(g, 1, 2)
true

julia> add_edge!(g, 2, 3)
true

julia> add_edge!(g, 3, 4)
true

julia> add_edge!(g, 4, 1)
true

julia> add_edge!(g, 4, 2)
true

julia> biconnected_components(g)
1-element Array{Array{LightGraphs.SimpleGraphsCore.SimpleEdge{Int64},1},1}:
 [Edge 1 => 4, Edge 3 => 4, Edge 2 => 3, Edge 1 => 2]
```
While the correct result should be -
```
[Edge 2 => 4, Edge 1 => 4, Edge 3 => 4, Edge 2 => 3, Edge 1 => 2]
``` 

I'll make a PR for the new Biconnectivity module using visitor functions, but for the time being we should merge this. It will also make it easier to compare the benchmarks.