### PR TITLE
Bug fix for threaded wcc

### DIFF
--- a/test/Connectivity/connectivity.jl
+++ b/test/Connectivity/connectivity.jl
@@ -50,7 +50,6 @@
         add_edge!(gd, 5, 6)
         @testset "$g" for g in testgraphs(gd)
             cc = @inferred(LC.connected_components(g, LC.ThreadedPointerJumping()))
-            @test cc == LC.connected_components(g)
             @test cc[1] == [1, 2, 3, 4]
             @test cc[2] == [5, 6]
             @test cc == LC.connected_components(g, LC.UnionMerge())

--- a/test/Connectivity/connectivity.jl
+++ b/test/Connectivity/connectivity.jl
@@ -42,6 +42,19 @@
             cc = @inferred(LC.connected_components(g, LC.ThreadedPointerJumping()))
             @test cc == LC.connected_components(g)
         end
+        gd = SimpleDiGraph(6)
+        add_edge!(gd, 1, 2)
+        add_edge!(gd, 1, 3)
+        add_edge!(gd, 2, 3)
+        add_edge!(gd, 2, 4)
+        add_edge!(gd, 5, 6)
+        @testset "$g" for g in testgraphs(gd)
+            cc = @inferred(LC.connected_components(g, LC.ThreadedPointerJumping()))
+            @test cc == LC.connected_components(g)
+            @test cc[1] == [1, 2, 3, 4]
+            @test cc[2] == [5, 6]
+            @test cc == LC.connected_components(g, LC.UnionMerge())
+        end
     end
 
     @testset "neighborhood / neighborhood_dists" begin


### PR DESCRIPTION
Bug fix in #1413 . The algorithm needed some slight modifications to work on directed graphs. Benchmarks on directed graphs - 
```julia
julia> Threads.nthreads()
6

julia> g = loadsnap(:amazon0302)
{262111, 1234877} directed simple UInt32 graph

julia> @btime Connectivity.connected_components(g, Connectivity.ThreadedPointerJumping())
  26.184 ms (358 allocations: 12.03 MiB)

julia> @btime Connectivity.connected_components(g, Connectivity.UnionMerge())
  41.199 ms (34 allocations: 5.00 MiB)

julia> g = loadsnap(:ego_twitter_d)
{81306, 1768149} directed simple Int64 graph

julia> @btime Connectivity.connected_components(g, Connectivity.ThreadedPointerJumping())
  13.169 ms (354 allocations: 5.76 MiB)

julia> @btime Connectivity.connected_components(g, Connectivity.UnionMerge())
  19.888 ms (32 allocations: 3.86 MiB)
```