### PR TITLE
remove vector constraint on vertices

### DIFF
--- a/src/centrality/betweenness.jl
+++ b/src/centrality/betweenness.jl
@@ -44,7 +44,7 @@ julia> betweenness_centrality(path_graph(4))
 ```
 """
 function betweenness_centrality(g::AbstractGraph,
-    vs::AbstractVector=vertices(g),
+    vs=vertices(g),
     distmx::AbstractMatrix=weights(g);
     normalize=true,
     endpoints=false)


### PR DESCRIPTION
The AbstractVector assumption here is not necessary and forces the allocation of a vector, while something like:
```
vtx_subset = (v for v in vertices if v != skipped_vertex)
```
would be valid as second argument