### PR TITLE
Fix a typo will break docs rendering for `all_neighbors`

### DIFF
--- a/src/core.jl
+++ b/src/core.jl
@@ -255,7 +255,7 @@ julia> all_neighbors(g, 3)
 2-element Array{Int64,1}:
  1
  2
- ```
+```
 """
 function all_neighbors end
 @traitfn all_neighbors(g::::IsDirected, v::Integer) =


### PR DESCRIPTION
Before editing:
![image](https://user-images.githubusercontent.com/25192197/93174434-f708e180-f6fb-11ea-8e1e-5cb8af8f8ad9.png)
