### PR TITLE
Compatibility for DataStructures v0.18, and deprecation fix for find_root

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -28,6 +28,6 @@ test = ["Base64", "DelimitedFiles", "Test"]
 [compat]
 julia = "1"
 ArnoldiMethod = "0.0.4"
-DataStructures = "0.17.9"
+DataStructures = "0.17.9, 0.18"
 Inflate = "0.1.1"
 SimpleTraits = "0.9.1"

--- a/src/LightGraphs.jl
+++ b/src/LightGraphs.jl
@@ -7,7 +7,7 @@ using ArnoldiMethod
 using Statistics: mean
 
 using Inflate: InflateGzipStream
-using DataStructures: IntDisjointSets, PriorityQueue, dequeue!, dequeue_pair!, enqueue!, heappop!, heappush!, in_same_set, peek, union!, find_root
+using DataStructures: IntDisjointSets, PriorityQueue, dequeue!, dequeue_pair!, enqueue!, heappop!, heappush!, in_same_set, peek, union!, find_root!
 using LinearAlgebra: I, Symmetric, diagm, eigen, eigvals, norm, rmul!, tril, triu
 import LinearAlgebra: Diagonal, issymmetric, mul!
 using Random: AbstractRNG, GLOBAL_RNG, MersenneTwister, randperm, randsubseq!, seed!, shuffle, shuffle!

--- a/src/spanningtrees/boruvka.jl
+++ b/src/spanningtrees/boruvka.jl
@@ -29,8 +29,8 @@ function boruvka_mst end
         # find cheapest edge that connects two components
         found_edge = false
         for edge in edges(g)
-            set1 = find_root(djset, src(edge))
-            set2 = find_root(djset, dst(edge))
+            set1 = find_root!(djset, src(edge))
+            set2 = find_root!(djset, dst(edge))
             if set1 != set2
                 found_edge = true
                 e1 = cheapest[set1]


### PR DESCRIPTION
This PR is against branch v1.3.3, and passes tests locally.  Fixes https://github.com/JuliaGraphs/LightGraphs.jl/issues/1469.
- Fixes deprecation of `find_root`.
- Adds compatibility to DataStructures v0.18.