### PR TITLE
Add dag-topo in ShortestPaths

### DIFF
--- a/src/ShortestPaths/ShortestPaths.jl
+++ b/src/ShortestPaths/ShortestPaths.jl
@@ -1,7 +1,7 @@
 module ShortestPaths
 using LightGraphs
 using LightGraphs.Traversals
-import LightGraphs.Traversals: tree, parents, distances
+import LightGraphs.Traversals: tree, parents, distances, topological_sort
 using DataStructures: PriorityQueue, Queue, Deque, dequeue!, enqueue!, peek
 using SparseArrays: sparse
 using Distributed: @distributed
@@ -30,7 +30,7 @@ calculation.
 """
 abstract type ShortestPathResult <: AbstractGraphResult end
 
-==(a::T, b::T) where {T<:ShortestPathResult} = parents(a) == parents(b) && distances(a) == distances(b)
+==(a::T, b::T) where {T <: ShortestPathResult} = parents(a) == parents(b) && distances(a) == distances(b)
 
 """
     ShortestPathAlgorithm <: AbstractGraphAlgorithm
@@ -112,8 +112,8 @@ shortest_paths(g::AbstractGraph, s, alg::ShortestPathAlgorithm) =
     shortest_paths(g, s, weights(g), alg)
 
 # If we don't specify an algorithm AND there are no dists, use BFS.
-shortest_paths(g::AbstractGraph{T}, s::Integer) where {T<:Integer} = shortest_paths(g, s, BFS())
-shortest_paths(g::AbstractGraph{T}, ss::AbstractVector) where {T<:Integer} = shortest_paths(g, ss, BFS())
+shortest_paths(g::AbstractGraph{T}, s::Integer) where {T <: Integer} = shortest_paths(g, s, BFS())
+shortest_paths(g::AbstractGraph{T}, ss::AbstractVector) where {T <: Integer} = shortest_paths(g, ss, BFS())
 
 # Full-formed methods.
 """
@@ -235,6 +235,7 @@ include("threaded-bellman-ford.jl")
 include("threaded-bfs.jl")
 include("threaded-floyd-warshall.jl")
 include("yen.jl")
+include("dag-topo.jl")
 
 # TODO 2.0.0: uncomment this
 # export ShortestPathAlgorithm, NegativeCycleError

--- a/src/ShortestPaths/ShortestPaths.jl
+++ b/src/ShortestPaths/ShortestPaths.jl
@@ -1,7 +1,7 @@
 module ShortestPaths
 using LightGraphs
 using LightGraphs.Traversals
-import LightGraphs.Traversals: tree, parents, distances, topological_sort
+import LightGraphs.Traversals: tree, parents, distances
 using DataStructures: PriorityQueue, Queue, Deque, dequeue!, enqueue!, peek
 using SparseArrays: sparse
 using Distributed: @distributed

--- a/src/ShortestPaths/dag-topo.jl
+++ b/src/ShortestPaths/dag-topo.jl
@@ -1,0 +1,52 @@
+struct DagTopoResult{T,U <: Integer}  <: ShortestPathResult
+    dists::Vector{T}
+    parents::Vector{U}
+end
+
+"""
+    struct DagTopo <: SSSPAlgorithm
+
+The structure used to configure and specify that [`shortest_paths`](@ref)
+should use [Topo Sort + DP](https://en.wikipedia.org/wiki/Topological_sorting#Application_to_shortest_path_finding)
+to compute shortest paths. 
+
+### Implementation Notes
+`DagTopo` supports the following shortest-path functionality:
+- (required) directed acyclic graphs 
+- negative and non-negative edge weights
+- (optional) multiple sources
+- all destinations
+
+### Performance
+Time and space complexity is of the order O(V+E).
+"""
+struct DagTopo <: SSSPAlgorithm end
+
+function shortest_paths(g::AbstractGraph, srcs::Vector{U}, distmx::AbstractMatrix{T}, alg::DagTopo) where {T,U <: Integer}
+    nvg = nv(g)
+    dists = fill(typemax(T), nvg)
+    parents = zeros(U, nvg)
+
+    for src in srcs
+        dists[src] = zero(T)
+    end
+
+    topo_sorted = topological_sort(g)
+
+    for u in topo_sorted
+        d = dists[u]
+        d == typemax(T) && continue
+
+        for v in outneighbors(g, u)
+            alt = d + distmx[u, v]
+            alt >= dists[v] && continue
+
+            dists[v] = alt
+            parents[v] = u
+        end
+    end
+
+    return DagTopoResult{T,U}(dists, parents)
+end
+
+shortest_paths(g::AbstractGraph, s::Integer, distmx::AbstractMatrix, alg::DagTopo) = shortest_paths(g, [s], distmx, alg)


### PR DESCRIPTION
#1485 
Uses topo sort + DP to find shortest paths in a DAG.
I'll work on writing test cases benchmarks soon.
