### PR TITLE
Compat for ArnoldiMethod 0.1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -27,7 +27,7 @@ test = ["Base64", "DelimitedFiles", "Test"]
 
 [compat]
 julia = "1"
-ArnoldiMethod = "0.0"
+ArnoldiMethod = "0.0, 0.1"
 DataStructures = "0.17, 0.18"
 Inflate = "0.1"
 SimpleTraits = "0.9"


### PR DESCRIPTION
`]add StaticArrays`, `]add LightGraphs` results in StaticArrays v1.0.1 and LightGraphs v1.3.4 installed, but ArnoldiMethod v0.0.2 which has seen three releases after.  This PR adds compat for ArnoldiMethod v0.1.0 was released on Dec 17 2020.