### PR TITLE
Implement hash for AbstractSimpleEdge

### DIFF
--- a/src/SimpleGraphs/simpleedge.jl
+++ b/src/SimpleGraphs/simpleedge.jl
@@ -1,4 +1,4 @@
-import Base: Pair, Tuple, show, ==
+import Base: Pair, Tuple, show, ==, hash
 import LightGraphs: AbstractEdge, src, dst, reverse
 
 abstract type AbstractSimpleEdge{T<:Integer} <: AbstractEdge{T} end
@@ -31,3 +31,4 @@ SimpleEdge{T}(e::AbstractSimpleEdge) where T <: Integer = SimpleEdge{T}(T(e.src)
 # Convenience functions
 reverse(e::T) where T<:AbstractSimpleEdge = T(dst(e), src(e))
 ==(e1::AbstractSimpleEdge, e2::AbstractSimpleEdge) = (src(e1) == src(e2) && dst(e1) == dst(e2))
+hash(e::AbstractSimpleEdge, h::UInt) = hash(src(e), hash(dst(e), h))

--- a/test/simplegraphs/simpleedge.jl
+++ b/test/simplegraphs/simpleedge.jl
@@ -25,6 +25,9 @@
         @test SimpleEdge(t1) == SimpleEdge{UInt8}(t1) == SimpleEdge{Int16}(t1)
         @test SimpleEdge{Int64}(ep1) == e
 
+        @test hash(SimpleEdge(t1)) == hash(SimpleEdge{UInt8}(t1)) == hash(SimpleEdge{UInt16}(t1))
+        @test hash(SimpleEdge(1, 2)) != hash(SimpleEdge(2, 1))
+
         @test Pair(e) == p
         @test Tuple(e) == t1
         @test reverse(ep1) == re


### PR DESCRIPTION
Previously the `==` method was overriden for `AbstractSimpleEdge` but not `hash`. In order for dictionaries for edges to work correctly, we also have to implement `hash` so that `e1 == e2` implies `hash(e1) == hash(e2)`.

This has some serious consequences for `MetaGraphs.jl`, where  `weights(g)` alawys returns values of `1.0` whenever the eltype of a `MetaGraph` is not `Int`. See the example below:

This PR should fix that, but I was wondering if we also should have some fix in `MetaGraphs` to ensure that no one produces incorrect results whenever they use a not up-to-date version of `LightGraphs`. Maybe we could just enforce a new enough version of `LightGraphs` in `Project.toml`.

```julia

julia> g = MetaGraph(squash(smallgraph(:house)))
{5, 6} undirected UInt8 metagraph with Float64 weights defined by :weight (default weight 1.0)

julia> set_prop!(g, 1, 2, :weight, 2.0)
true

julia> get_prop(g, 1, 2, :weight)
ERROR: KeyError: key :weight not found
Stacktrace:
 [1] getindex at ./dict.jl:467 [inlined]
 [2] get_prop at /home/simon/.julia/dev/MetaGraphs/src/MetaGraphs.jl:256 [inlined]
 [3] get_prop(::MetaGraph{UInt8,Float64}, ::Int64, ::Int64, ::Symbol) at /home/simon/.julia/dev/MetaGraphs/src/MetaGraphs.jl:258
 [4] top-level scope at REPL[4]:1

julia> weights(g)[1, 2]
1.0
```