### PR TITLE
fix #1489

### DIFF
--- a/src/linalg/spectral.jl
+++ b/src/linalg/spectral.jl
@@ -160,7 +160,7 @@ function incidence_matrix(g::AbstractGraph, T::DataType=Int; oriented=false)
     (isdir || oriented) ? -fill(one(T), n_e) : fill(one(T), n_e),
         fill(one(T), n_e),
     )
-    return sparse(I, J, V)
+    return sparse(I, J, V, nv(g), ne(g))
 end
 
 """

--- a/src/linalg/spectral.jl
+++ b/src/linalg/spectral.jl
@@ -157,7 +157,7 @@ function incidence_matrix(g::AbstractGraph, T::DataType=Int; oriented=false)
     I = vcat(src.(edges(g)), dst.(edges(g)))
     J = vcat(1:n_e, 1:n_e)
     V = vcat(
-    (isdir || oriented) ? -fill(one(T), n) : fill(one(T), n),
+    (isdir || oriented) ? -fill(one(T), n_e) : fill(one(T), n_e),
         fill(one(T), n_e),
     )
     return sparse(I, J, V)

--- a/src/linalg/spectral.jl
+++ b/src/linalg/spectral.jl
@@ -153,34 +153,14 @@ between `v` and `i`.
 """
 function incidence_matrix(g::AbstractGraph, T::DataType=Int; oriented=false)
     isdir = is_directed(g)
-    n_v = nv(g)
     n_e = ne(g)
-    nz = 2 * n_e
-
-    # every col has the same 2 entries
-    colpt = collect(1:2:(nz + 1))
-    nzval = repeat([(isdir || oriented) ? -one(T) : one(T), one(T)], n_e)
-
-    # iterate over edges for row indices
-    rowval = zeros(Int, nz)
-    i = 1
-    for u in vertices(g)
-        for v in outneighbors(g, u)
-            if isdir || u < v # add every edge only once
-                if u > v
-                    v, u = u, v
-                    # need to make sure that columns of the CSC matrix are sorted
-                    nzval[2 * i - 1], nzval[2 * i] = nzval[2 * i], nzval[2 * i - 1]
-                end
-                rowval[2 * i - 1] = u
-                rowval[2 * i] = v
-                i += 1
-            end
-        end
-    end
-
-    spmx = SparseMatrixCSC(n_v, n_e, colpt, rowval, nzval)
-    return spmx
+    I = vcat(src.(edges(g)), dst.(edges(g)))
+    J = vcat(1:n_e, 1:n_e)
+    V = vcat(
+        fill((isdir || oriented) ? -one(T) : one(T), n_e),
+        fill(one(T), n_e)
+    )
+    return sparse(I, J, V)
 end
 
 """

--- a/src/linalg/spectral.jl
+++ b/src/linalg/spectral.jl
@@ -158,7 +158,7 @@ function incidence_matrix(g::AbstractGraph, T::DataType=Int; oriented=false)
     J = vcat(1:n_e, 1:n_e)
     V = vcat(
         fill((isdir || oriented) ? -one(T) : one(T), n_e),
-        fill(one(T), n_e)
+        fill(one(T), n_e),
     )
     return sparse(I, J, V)
 end

--- a/src/linalg/spectral.jl
+++ b/src/linalg/spectral.jl
@@ -157,7 +157,7 @@ function incidence_matrix(g::AbstractGraph, T::DataType=Int; oriented=false)
     I = vcat(src.(edges(g)), dst.(edges(g)))
     J = vcat(1:n_e, 1:n_e)
     V = vcat(
-        fill((isdir || oriented) ? -one(T) : one(T), n_e),
+    (isdir || oriented) ? -fill(one(T), n) : fill(one(T), n),
         fill(one(T), n_e),
     )
     return sparse(I, J, V)

--- a/test/linalg/spectral.jl
+++ b/test/linalg/spectral.jl
@@ -129,6 +129,16 @@ Matrix(nbt::Nonbacktracking) = Matrix(sparse(nbt))
         @test incidence_matrix(g; oriented=true)[2, 1] == 1
         @test incidence_matrix(g; oriented=true)[3, 1] == 0
     end
+
+    # Check size of incidence matrix with isolated vertices
+    g6 = complete_graph(4)
+    for k = 1:3
+        add_vertex!(g6)
+    end
+    for g in testgraphs(g6)
+        @test size(incidence_matrix(g6)) == (7, 6)
+    end
+
     # TESTS FOR Nonbacktracking operator.
 
     n = 10; k = 5


### PR DESCRIPTION
Hi!
I modified the code in `spectral.jl` to make it correct. it became shorter and clearer in the process, using the `sparse(I, J, V)` constructor for the adjacency matrix instead of a heavier `SparseMatrixCSC` routine.
However I didn't know how to run the tests using the new version of `LightGraphs.jl`, hopefully this didn't break anything.