### PR TITLE
Some adjustments to `watts_strogatz`

### DIFF
--- a/src/SimpleGraphs/generators/randgraphs.jl
+++ b/src/SimpleGraphs/generators/randgraphs.jl
@@ -1,5 +1,5 @@
 using Random:
-    AbstractRNG, MersenneTwister, randperm, seed!, shuffle!
+    AbstractRNG, MersenneTwister, randperm, randperm!, seed!, shuffle!
 using Statistics: mean
 
 using LightGraphs:
@@ -281,13 +281,16 @@ function watts_strogatz(n::Integer, k::Integer, β::Real; is_directed=false, see
 
     # Phase 2:
 
+    ns = collect(1:n)
+
     for i = 1:div(k, 2), s = 1:n
 
         (rand(rng) < β && degree(g, s) < n - 1) || continue
 
         t = target(s, i)
 
-        for d in randperm(rng, n)
+        randperm!(rng, ns)
+        for d in ns
             d == s && continue
             d == t && break
             add_edge!(g, s, d) && rem_edge!(g, s, t) && break

--- a/src/SimpleGraphs/generators/randgraphs.jl
+++ b/src/SimpleGraphs/generators/randgraphs.jl
@@ -1,5 +1,5 @@
 using Random:
-    AbstractRNG, MersenneTwister, randperm, randperm!, seed!, shuffle!
+    AbstractRNG, MersenneTwister, randperm, seed!, shuffle!
 using Statistics: mean
 
 using LightGraphs:
@@ -281,16 +281,14 @@ function watts_strogatz(n::Integer, k::Integer, β::Real; is_directed=false, see
 
     # Phase 2:
 
-    ns = collect(1:n)
-
     for i = 1:div(k, 2), s = 1:n
 
         (rand(rng) < β && degree(g, s) < n - 1) || continue
 
         t = target(s, i)
 
-        randperm!(rng, ns)
-        for d in ns
+        while true
+            d = rand(1:n)
             d == s && continue
             d == t && break
             add_edge!(g, s, d) && rem_edge!(g, s, t) && break

--- a/src/SimpleGraphs/generators/randgraphs.jl
+++ b/src/SimpleGraphs/generators/randgraphs.jl
@@ -275,7 +275,7 @@ function watts_strogatz(n::Integer, k::Integer, β::Real; is_directed=false, see
     # The ith next vertex, in clockwise order.
     # (Reduce to zero-based indexing, so the modulo works, by subtracting 1
     # before and adding 1 after.)
-    target(s, i) = ((s + i - 1) % n) + 1
+    @inline target(s, i) = ((s + i - 1) % n) + 1
 
     # Phase 1: For each step size i, add an edge from each vertex s to the ith
     # next vertex, in clockwise order.


### PR DESCRIPTION
Hi!

While using `watts_strogatz`, I noticed that it got stuck in an infinite loop for certain inputs. E.g.:

```julia
julia> watts_strogatz(11, 10, .2)
# hangs
```

I looked at the code to fix the bug, and noticed a few other minor issues that I thought I'd address. It might have been better to [open an issue first](https://github.com/JuliaGraphs/LightGraphs.jl/blob/b210395e8cbd109dc04c286f8af0c267cad47a85/CONTRIBUTING.md), before coding, but since I need a corrected version myself anyway, I though there was little potential for wasted effort, even if you decide not to go with my adjustments :-) I'll sketch out the rationale for the PR below.

**The infinite loop:** The original version uses trial and error to find a node to rewire to. If the source node is already connected to all other nodes, this leads to an infinite loop. This issue is handled by the condition `degree(g, s) < n - 1` for rewiring in my code, though even if this is removed, the reworked loop will be correct: Instead of trial and error, my version goes through the nodes (in random order) until a free one is found, rather than proceeding by trial and error. (I could have used reservoir sampling or something here, but `randperm` is very straightforward and obviously correct.) This ensures a single pass through the candidate nodes – but if the `degree(g, s) < n - 1` check were removed (if one wanted to do this), it could potentially lead to *no* valid neighbor being found. However, this is solved by permitting reattachment to the original neighbor (see below).

**Reattachment:** The original Watts–Strogatz paper is a bit vague on some details of their procedure, but e.g. Watts's book *Small Worlds* goes into a bit more detail. Specifically, he specifies deleting the edge in question before uniformly selecting a neighbor, excluding self-connections and multiple edges. In other words, it is valid to re-attach the edge to its original target, even if it's being rewired. This was not permitted in the original `watts_strogatz` function, affecting the probability distribution over the graphs.

**Always rewiring:** In the original, there was the following `if` statement:

```julia
if rand(rng) > β && !has_edge(g, s, target)
```

This triggered adding an edge (because it was not rewired). However, the `else` then was also triggered regardless of whether `rand(rng) > β`, as long as there was an edge there (e.g., rewired from somewhere else). In this case, it would automatically be rewired. This is no longer an issue in the new implementation. (Maybe this was part of the mechanism for getting the correct probability distribution, despite there not being edges there to block rewirings in the first place; if so, I'm just not understanding it properly :-))

**Two passes:** The original `watts_strogatz` function is optimized by not adding any edges initially, and considering each edge in turn, either adding it where it “should have been,” or where it would get rewired to. Now, it may be that the result is equivalent, but at least it's not obvious to me – and I think an obviously correct solution might be better, at least without an explanation of why the original was correct. The issue, it seems to me, is that when one considers rewiring in this version, many edges are missing, and will therefore not block potential rewiring sites. In my rewrite, I explicitly use the two phases consistently described by Watts and Strogatz in their various sources, first creating the lattice and then going through it, potentially rewiring. (I only delete the edge if it actually gets rewired to some other node than its original target, at least; and for a low `β` an performance hit from first adding and then rewiring should be pretty low.)

**Complete graph:** If `k == n - 1` and `k` is even, I just return a complete graph.

**Probability:** In Watts's description, he explicitly states that one should generate a random deviate `r`, and then use the conditions `r < β` and `r ≥ β` (i.e., not `r ≤ β` and `r > β`, as in the original `watts_strogats`). This is also used in the [NetworkX implementation](https://networkx.org/documentation/stable/_modules/networkx/generators/random_graphs.html#watts_strogatz_graph), by the way. Of courtse, our random value won't be from `[0,1]`, but `[0,1)`, but that does not make this less relevant. Specifically, it is consistent with never rewiring for `β = 0` and always rewiring for `β = 1`.

**Docstring:** I've also made some adjustments to the docstring (e.g., not stating that all nodes have degree `k`, but that they have an *expected* degree of `k` or `k - 1`, and adding a description of the procedure used).