### PR TITLE
Migrate Benchmarks

### DIFF
--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -15,9 +15,13 @@ GRAPHS = Dict{String,Graph}(
 
 
 suite = BenchmarkGroup()
+
+# include all benchmarks
 include("core.jl")
 include("centrality.jl")
-
+include("connectivity.jl")
+include("insertions.jl")
+include("traversals.jl")
 
 tune!(suite);
 results = run(suite, verbose = true, seconds = 10)

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -16,6 +16,7 @@ GRAPHS = Dict{String,Graph}(
 
 suite = BenchmarkGroup()
 include("core.jl")
+include("centrality.jl")
 
 
 tune!(suite);

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -24,5 +24,8 @@ include("edges.jl")
 include("insertions.jl")
 include("traversals.jl")
 
+# include parallel benchmarks
+include("parallel/parallel_benchmarks.jl")
+
 tune!(suite);
 results = run(suite, verbose = true, seconds = 10)

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -20,6 +20,7 @@ suite = BenchmarkGroup()
 include("core.jl")
 include("centrality.jl")
 include("connectivity.jl")
+include("edges.jl")
 include("insertions.jl")
 include("traversals.jl")
 

--- a/benchmark/centrality.jl
+++ b/benchmark/centrality.jl
@@ -1,26 +1,25 @@
+suite["centrality"] = BenchmarkGroup(["degree", "closeness", "betweenness", "katz", "pagerank"])
 
-@benchgroup "centrality" begin
-  @benchgroup "graphs" begin
-    for (name, g) in GRAPHS
-      @bench "$(name): degree" LightGraphs.degree_centrality($g)
-      @bench "$(name): closeness" LightGraphs.closeness_centrality($g)
-      if nv(g) < 1000
-        @bench "$(name): betweenness" LightGraphs.betweenness_centrality($g)
-        @bench "$(name): katz" LightGraphs.katz_centrality($g)
-      end
-    end
-  end #graphs
-  @benchgroup "digraphs" begin
-    for (name, g) in DIGRAPHS
-      @bench "$(name): degree" LightGraphs.degree_centrality($g)
-      @bench "$(name): closeness" LightGraphs.closeness_centrality($g)
-      if nv(g) < 1000
-        @bench "$(name): betweenness" LightGraphs.betweenness_centrality($g)
-        @bench "$(name): katz" LightGraphs.katz_centrality($g)
-      end
-      if nv(g) < 500
-        @bench "$(name): pagerank"  LightGraphs.pagerank($g)
-      end
-    end
-  end # digraphs
-end # centrality
+# betweenness
+suite["centrality"]["degree"] = BenchmarkGroup(["graphs", "digraphs"])
+suite["centrality"]["degree"]["graphs"] = @benchmarkable [LightGraphs.degree_centrality(g) for (n,g) in $GRAPHS]
+suite["centrality"]["degree"]["digraphs"] = @benchmarkable [LightGraphs.degree_centrality(g) for (n,g) in $DIGRAPHS]
+
+# closeness
+suite["centrality"]["closeness"] = BenchmarkGroup(["graphs", "digraphs"])
+suite["centrality"]["closeness"]["graphs"] = @benchmarkable [LightGraphs.closeness_centrality(g) for (n,g) in $GRAPHS]
+suite["centrality"]["closeness"]["digraphs"] = @benchmarkable [LightGraphs.closeness_centrality(g) for (n,g) in $DIGRAPHS]
+
+# betweenness
+suite["centrality"]["betweenness"] = BenchmarkGroup(["graphs", "digraphs"])
+suite["centrality"]["betweenness"]["graphs"] = @benchmarkable [LightGraphs.betweenness_centrality(g) for (n,g) in $GRAPHS if nv(g) < 1000]
+suite["centrality"]["betweenness"]["digraphs"] = @benchmarkable [LightGraphs.betweenness_centrality(g) for (n,g) in $DIGRAPHS if nv(g) < 1000]
+
+# katz
+suite["centrality"]["katz"] = BenchmarkGroup(["graphs", "digraphs"])
+suite["centrality"]["katz"]["graphs"] = @benchmarkable [LightGraphs.katz_centrality(g) for (n,g) in $GRAPHS if nv(g) < 1000]
+suite["centrality"]["katz"]["digraphs"] = @benchmarkable [LightGraphs.katz_centrality(g) for (n,g) in $DIGRAPHS if nv(g) < 1000]
+
+#pagerank
+suite["centrality"]["katz"] = BenchmarkGroup(["digraphs"])
+suite["centrality"]["katz"]["digraphs"] = @benchmarkable [LightGraphs.pagerank(g) for (n,g) in $DIGRAPHS if nv(g) < 500]

--- a/benchmark/connectivity.jl
+++ b/benchmark/connectivity.jl
@@ -1,12 +1,3 @@
-@benchgroup "connectivity" begin
-  @benchgroup "digraphs" begin
-    for (name, g) in DIGRAPHS
-      @bench "$(name): strongly_connected_components" LightGraphs.strongly_connected_components($g)
-    end
-  end # digraphs
-  @benchgroup "graphs" begin
-    for (name, g) in GRAPHS
-        @bench "$(name): connected_components" LightGraphs.connected_components($g)
-    end
-  end # graphs
-end # connectivity
+suite["centrality"] = BenchmarkGroup(["graphs", "digraphs"])
+suite["centrality"]["graphs"] = @benchmarkable [LightGraphs.connected_components(g) for (n,g) in $GRAPHS]
+suite["centrality"]["digraphs"] = @benchmarkable [LightGraphs.strongly_connected_components(g) for (n,g) in $DIGRAPHS]

--- a/benchmark/connectivity.jl
+++ b/benchmark/connectivity.jl
@@ -1,3 +1,3 @@
-suite["centrality"] = BenchmarkGroup(["graphs", "digraphs"])
-suite["centrality"]["graphs"] = @benchmarkable [LightGraphs.connected_components(g) for (n,g) in $GRAPHS]
-suite["centrality"]["digraphs"] = @benchmarkable [LightGraphs.strongly_connected_components(g) for (n,g) in $DIGRAPHS]
+suite["connectivity"] = BenchmarkGroup(["graphs", "digraphs"])
+suite["connectivity"]["graphs"] = @benchmarkable [LightGraphs.connected_components(g) for (n,g) in $GRAPHS]
+suite["connectivity"]["digraphs"] = @benchmarkable [LightGraphs.strongly_connected_components(g) for (n,g) in $DIGRAPHS]

--- a/benchmark/core.jl
+++ b/benchmark/core.jl
@@ -1,25 +1,5 @@
 suite["core"] = BenchmarkGroup(["nv", "edges", "has_edge"])
 
-
-# nv
-suite["core"]["nv"] = BenchmarkGroup(["graphs", "digraphs"])
-suite["core"]["nv"]["graphs"] = @benchmarkable [nv(g) for (n,g) in $GRAPHS]
-suite["core"]["nv"]["digraphs"] = @benchmarkable [nv(g) for (n,g) in $DIGRAPHS]
-
-# iterate edges
-function iter_edges(g::AbstractGraph)
-    i = 0
-    for e in edges(g)
-        i += 1
-    end
-    return i
-end
-
-suite["core"]["edges"] = BenchmarkGroup(["graphs", "digraphs"])
-suite["core"]["edges"]["graphs"] = @benchmarkable [iter_edges(g) for (n,g) in $GRAPHS]
-suite["core"]["edges"]["digraphs"] = @benchmarkable [iter_edges(g) for (n,g) in $DIGRAPHS]
-
-# has edge
 function all_has_edge(g::AbstractGraph)
     nvg = nv(g)
     srcs = rand([1:nvg;], cld(nvg, 4))
@@ -33,6 +13,25 @@ function all_has_edge(g::AbstractGraph)
     return i
 end
 
+function iter_edges(g::AbstractGraph)
+    i = 0
+    for e in edges(g)
+        i += 1
+    end
+    return i
+end
+
+# nv
+suite["core"]["nv"] = BenchmarkGroup(["graphs", "digraphs"])
+suite["core"]["nv"]["graphs"] = @benchmarkable [nv(g) for (n,g) in $GRAPHS]
+suite["core"]["nv"]["digraphs"] = @benchmarkable [nv(g) for (n,g) in $DIGRAPHS]
+
+# iter edges
+suite["core"]["edges"] = BenchmarkGroup(["graphs", "digraphs"])
+suite["core"]["edges"]["graphs"] = @benchmarkable [iter_edges(g) for (n,g) in $GRAPHS]
+suite["core"]["edges"]["digraphs"] = @benchmarkable [iter_edges(g) for (n,g) in $DIGRAPHS]
+
+# has edge
 suite["core"]["has_edge"] = BenchmarkGroup(["graphs", "digraphs"])
-suite["core"]["has_edge"]["graphs"] = @benchmark [all_has_edge(g) for (n,g) in $GRAPHS]
-suite["core"]["has_edge"]["digraphs"] = @benchmark [all_has_edge(g) for (n,g) in $DIGRAPHS]
+suite["core"]["has_edge"]["graphs"] = @benchmarkable [all_has_edge(g) for (n,g) in $GRAPHS]
+suite["core"]["has_edge"]["digraphs"] = @benchmarkable [all_has_edge(g) for (n,g) in $DIGRAPHS]

--- a/benchmark/edges.jl
+++ b/benchmark/edges.jl
@@ -1,11 +1,13 @@
 import Base: convert
 
+suite["edges"] = BenchmarkGroup(["fille", "fillp", "tsume", "tsump"])
+
 const P = Pair{Int,Int}
 
 convert(::Type{Tuple}, e::Pair) = (e.first, e.second)
 
 function fille(n)
-    t = Array{LightGraphs.Edge,1}(n)
+    t = Array{LightGraphs.Edge,1}(undef, n)
     for i in 1:n
         t[i] = LightGraphs.Edge(i, i + 1)
     end
@@ -13,7 +15,7 @@ function fille(n)
 end
 
 function fillp(n)
-    t = Array{P,1}(n)
+    t = Array{P,1}(undef, n)
     for i in 1:n
         t[i] = P(i, i + 1)
     end
@@ -30,11 +32,10 @@ function tsum(t)
     return x
 end
 
+
 n = 10000
-@benchgroup "edges" begin
-  @bench "$(n): fille" fille($n)
-  @bench "$(n): fillp" fillp($n)
-  a, b = fille(n), fillp(n)
-  @bench "$(n): tsume" tsum($a)
-  @bench "$(n): tsump" tsum($b)
-end # edges
+suite["centrality"]["fille"] = @benchmarkable fille($n)
+suite["centrality"]["fillp"] = @benchmarkable fillp($n)
+a, b = fille(n), fillp(n)
+suite["centrality"]["tsume"] = @benchmarkable tsum($a)
+suite["centrality"]["tsump"] = @benchmarkable tsum($b)

--- a/benchmark/edges.jl
+++ b/benchmark/edges.jl
@@ -34,8 +34,8 @@ end
 
 
 n = 10000
-suite["centrality"]["fille"] = @benchmarkable fille($n)
-suite["centrality"]["fillp"] = @benchmarkable fillp($n)
+suite["edges"]["fille"] = @benchmarkable fille($n)
+suite["edges"]["fillp"] = @benchmarkable fillp($n)
 a, b = fille(n), fillp(n)
-suite["centrality"]["tsume"] = @benchmarkable tsum($a)
-suite["centrality"]["tsump"] = @benchmarkable tsum($b)
+suite["edges"]["tsume"] = @benchmarkable tsum($a)
+suite["edges"]["tsump"] = @benchmarkable tsum($b)

--- a/benchmark/insertions.jl
+++ b/benchmark/insertions.jl
@@ -1,4 +1,4 @@
-@benchgroup "insertions" begin
-  n = 10000
-  @bench "ER Generation" g = SimpleGraph($n, 16 * $n)
-end
+suite["insertions"] = BenchmarkGroup(["ER Generation"])
+
+n = 10000
+suite["insertions"]["ER Generation"] = @benchmarkable SimpleGraph($n, 16 * $n)

--- a/benchmark/parallel/egonets.jl
+++ b/benchmark/parallel/egonets.jl
@@ -1,63 +1,47 @@
-using LightGraphs
-using BenchmarkTools
-@show Threads.nthreads()
+suite["parallel"]["egonets"] = BenchmarkGroup(["vertex_function", "twohop", "singlethread_vertex_function", "singlethread_twohop"])
 
-@benchgroup "parallel" begin
-    @benchgroup "egonet" begin
-        function vertex_function(g::Graph, i::Int)
-            a = 0
-            for u in neighbors(g, i)
-                a += degree(g, u)
-            end
-            return a
-        end
-
-        function twohop(g::Graph, i::Int)
-            a = 0
-            for u in neighbors(g, i)
-                for v in neighbors(g, u)
-                    a += degree(g, v)
-                end
-            end
-            return a
-        end
-
-
-        function mapvertices(f, g::Graph)
-            n = nv(g)
-            a = zeros(Int, n)
-            Threads.@threads for i in 1:n
-                a[i] = f(g, i)
-            end
-            return a
-        end
-
-        function mapvertices_single(f, g)
-            n = nv(g)
-            a = zeros(Int, n)
-            for i in 1:n
-                a[i] = f(g, i)
-            end
-            return a
-        end
-
-        function comparison(f, g)
-            println("Mulithreaded on $(Threads.nthreads())")
-            b1 =  @benchmark mapvertices($f, $g)
-            println(b1)
-
-            println("singlethreaded")
-            b2 = @benchmark mapvertices_single($f, $g)
-            println(b2)
-            println("done")
-        end
-
-        nv_ = 10000
-        g = SimpleGraph(nv_, 64 * nv_)
-        f = vertex_function
-        println(g)
-
-        comparison(vertex_function, g)
-        comparison(twohop, g)
+function vertex_function(g::Graph, i::Int)
+    a = 0
+    for u in neighbors(g, i)
+        a += degree(g, u)
     end
+    return a
 end
+
+function twohop(g::Graph, i::Int)
+    a = 0
+    for u in neighbors(g, i)
+        for v in neighbors(g, u)
+            a += degree(g, v)
+        end
+    end
+    return a
+end
+
+
+function mapvertices(f, g::Graph)
+    n = nv(g)
+    a = zeros(Int, n)
+    Threads.@threads for i in 1:n
+        a[i] = f(g, i)
+    end
+    return a
+end
+
+function mapvertices_single(f, g)
+    n = nv(g)
+    a = zeros(Int, n)
+    for i in 1:n
+        a[i] = f(g, i)
+    end
+    return a
+end
+
+nv_ = 10000
+g = SimpleGraph(nv_, 64 * nv_)
+f = vertex_function
+
+suite["parallel"]["egonets"]["singlethread_vertex_function"] = @benchmarkable mapvertices_single(vertex_function, $g)
+suite["parallel"]["egonets"]["singlethread_twohop"] = @benchmarkable mapvertices_single(twohop, $g)
+suite["parallel"]["egonets"]["vertex_function"] = @benchmarkable mapvertices(vertex_function, $g)
+suite["parallel"]["egonets"]["twohop"] = @benchmarkable mapvertices(twohop, $g)

--- a/benchmark/parallel/parallel_benchmarks.jl
+++ b/benchmark/parallel/parallel_benchmarks.jl
@@ -1,0 +1,6 @@
+@show Threads.nthreads()
+
+suite["parallel"] = BenchmarkGroup()
+
+# include all benchmarks
+include("egonets.jl")

--- a/benchmark/traversals.jl
+++ b/benchmark/traversals.jl
@@ -1,14 +1,11 @@
-@benchgroup "traversals" begin
-  @benchgroup "graphs" begin
-    for (name, g) in GRAPHS
-        @bench "$(name): bfs_tree" LightGraphs.bfs_tree($g, 1)
-        @bench "$(name): dfs_tree" LightGraphs.dfs_tree($g, 1)
-    end
-  end # graphs
-  @benchgroup "digraphs" begin
-    for (name, g) in DIGRAPHS
-        @bench "$(name): bfs_tree" LightGraphs.bfs_tree($g, 1)
-        @bench "$(name): dfs_tree" LightGraphs.dfs_tree($g, 1)
-    end
-  end # digraphs
-end # traversals
+suite["traversals"] = BenchmarkGroup(["bfs", "dfs"])
+
+# breadth first
+suite["traversals"]["bfs"] = BenchmarkGroup(["graphs", "digraphs"])
+suite["traversals"]["bfs"]["graphs"] = @benchmarkable [LightGraphs.bfs_tree(g, 1) for (n,g) in $GRAPHS]
+suite["traversals"]["bfs"]["digraphs"] = @benchmarkable [LightGraphs.bfs_tree(g, 1) for (n,g) in $DIGRAPHS]
+
+# depth first
+suite["traversals"]["dfs"] = BenchmarkGroup(["graphs", "digraphs"])
+suite["traversals"]["dfs"]["graphs"] = @benchmarkable [LightGraphs.dfs_tree(g, 1) for (n,g) in $GRAPHS]
+suite["traversals"]["dfs"]["digraphs"] = @benchmarkable [LightGraphs.dfs_tree(g, 1) for (n,g) in $DIGRAPHS]


### PR DESCRIPTION
Migrate benchmarks (almost) as they are. I changed the parallel egonet benchmark to match the others in form.

The results on my slightly underpowered machine:

```
ryan@smol-birm:~/Documents/lightGraphs.jl$ julia benchmark/benchmarks.jl 
Threads.nthreads() = 1
(1/7) benchmarking "centrality"...
  (1/4) benchmarking "katz"...
    (1/1) benchmarking "digraphs"...
    done (took 0.747453009 seconds)
  done (took 1.511866832 seconds)
  (2/4) benchmarking "closeness"...
    (1/2) benchmarking "graphs"...
    done (took 10.586301256 seconds)
    (2/2) benchmarking "digraphs"...
    done (took 10.473894175 seconds)
  done (took 21.684834209 seconds)
  (3/4) benchmarking "degree"...
    (1/2) benchmarking "graphs"...
    done (took 0.793924245 seconds)
    (2/2) benchmarking "digraphs"...
    done (took 0.869926203 seconds)
  done (took 2.079441909 seconds)
  (4/4) benchmarking "betweenness"...
    (1/2) benchmarking "graphs"...
    done (took 10.526361854 seconds)
    (2/2) benchmarking "digraphs"...
    done (took 10.487052105 seconds)
  done (took 21.433570912 seconds)
done (took 47.469966809 seconds)
(2/7) benchmarking "parallel"...
  (1/1) benchmarking "egonets"...
    (1/4) benchmarking "singlethread_twohop"...
    done (took 10.637293333 seconds)
    (2/4) benchmarking "twohop"...
    done (took 11.119775323 seconds)
    (3/4) benchmarking "vertex_function"...
    done (took 10.471103836 seconds)
    (4/4) benchmarking "singlethread_vertex_function"...
    done (took 10.426632506 seconds)
  done (took 43.072715999 seconds)
done (took 43.483286784 seconds)
(3/7) benchmarking "core"...
  (1/3) benchmarking "nv"...
    (1/2) benchmarking "graphs"...
    done (took 1.595693265 seconds)
    (2/2) benchmarking "digraphs"...
    done (took 1.783288031 seconds)
  done (took 3.724088337 seconds)
  (2/3) benchmarking "edges"...
    (1/2) benchmarking "graphs"...
    done (took 0.580241265 seconds)
    (2/2) benchmarking "digraphs"...
    done (took 0.725503726 seconds)
  done (took 1.688129037 seconds)
  (3/3) benchmarking "has_edge"...
    (1/2) benchmarking "graphs"...
    done (took 0.877881273 seconds)
    (2/2) benchmarking "digraphs"...
    done (took 0.846322027 seconds)
  done (took 2.168768052 seconds)
done (took 7.927419443 seconds)
(4/7) benchmarking "connectivity"...
  (1/2) benchmarking "graphs"...
  done (took 1.232661542 seconds)
  (2/2) benchmarking "digraphs"...
  done (took 1.788056745 seconds)
done (took 3.525376797 seconds)
(5/7) benchmarking "insertions"...
  (1/1) benchmarking "ER Generation"...
  done (took 10.521656818 seconds)
done (took 10.889699043 seconds)
(6/7) benchmarking "traversals"...
  (1/2) benchmarking "bfs"...
    (1/2) benchmarking "graphs"...
    done (took 1.980961843 seconds)
    (2/2) benchmarking "digraphs"...
    done (took 2.115471639 seconds)
  done (took 4.454986527 seconds)
  (2/2) benchmarking "dfs"...
    (1/2) benchmarking "graphs"...
    done (took 1.933328059 seconds)
    (2/2) benchmarking "digraphs"...
    done (took 1.816685835 seconds)
  done (took 4.108990358 seconds)
done (took 8.942675144 seconds)
(7/7) benchmarking "edges"...
  (1/4) benchmarking "fillp"...
  done (took 0.695897891 seconds)
  (2/4) benchmarking "fille"...
  done (took 1.678886128 seconds)
  (3/4) benchmarking "tsume"...
  done (took 10.39830357 seconds)
  (4/4) benchmarking "tsump"...
  done (took 10.414347046 seconds)
done (took 23.53861924 seconds)
```