### PR TITLE
added rich club metric

### DIFF
--- a/docs/src/community.md
+++ b/docs/src/community.md
@@ -19,6 +19,7 @@ Pages   = [
     "community/label_propagation.jl",
     "community/modularity.jl",
     "community/assortativity.jl"
+    "community/rich_club.jl"
 ]
 Private = false
 ```

--- a/src/LightGraphs.jl
+++ b/src/LightGraphs.jl
@@ -114,7 +114,7 @@ barabasi_albert!, static_fitness_model, static_scale_free, kronecker, dorogovtse
 #community
 modularity, core_periphery_deg,
 local_clustering,local_clustering_coefficient, global_clustering_coefficient, triangles,
-label_propagation, maximal_cliques, clique_percolation, assortativity,
+label_propagation, maximal_cliques, clique_percolation, assortativity,rich_club,
 
 #generators
 complete_graph, star_graph, path_graph, wheel_graph, cycle_graph,
@@ -256,6 +256,7 @@ include("community/clustering.jl")
 include("community/cliques.jl")
 include("community/clique_percolation.jl")
 include("community/assortativity.jl")
+include("community/rich_club.jl")
 include("spanningtrees/boruvka.jl")
 include("spanningtrees/kruskal.jl")
 include("spanningtrees/prim.jl")

--- a/src/community/rich_club.jl
+++ b/src/community/rich_club.jl
@@ -1,0 +1,23 @@
+"""
+    rich_club(g,k)
+
+Return the non-normalised [rich-club coefficient](https://en.wikipedia.org/wiki/Rich-club_coefficient) of graph `g`,
+with degree cut-off `k`.
+
+```jldoctest
+julia> using LightGraphs
+julia> g = star_graph(5)
+julia> rich_club(g,1)
+0.4
+```
+"""
+function rich_club(g::AbstractGraph{T},k::Int) where T
+    E = zero(T)
+    for e in edges(g)
+        if (degree(g,src(e)) >= k) && (degree(g,dst(e)) >= k )
+            E +=1
+        end
+    end
+    N = count(degree(g) .>= k)
+    return 2*E / (N*(N-1))
+end


### PR DESCRIPTION
Hi there, I suggest to add the rich-club metric (cf [Wikipedia](https://en.wikipedia.org/wiki/Rich-club_coefficient) ) to beautiful LightGraphs.jl, under the community metrics.

`rich_club(g,k)`

Return the non-normalised [rich-club coefficient](https://en.wikipedia.org/wiki/Rich-club_coefficient) of graph `g`,
with degree cut-off `k`.
```jldoctest
julia> using LightGraphs
julia> g = star_graph(5)
julia> rich_club(g,1)
0.4
```