### PR TITLE
Correct type annotations for enumerate_paths, fixes #1552

### DIFF
--- a/src/shortestpaths/bellman-ford.jl
+++ b/src/shortestpaths/bellman-ford.jl
@@ -110,7 +110,7 @@ will return a vector (indexed by destination vertex) of paths from source `v`
 to all other vertices. In addition, `enumerate_paths(state, v, d)` will return
 a vector representing the path from vertex `v` to vertex `d`.
 """
-function enumerate_paths(state::AbstractPathState, vs::Vector{<:Integer})
+function enumerate_paths(state::AbstractPathState, vs::AbstractVector{<:Integer})
     parents = state.parents
     T = eltype(parents)
 
@@ -131,6 +131,6 @@ function enumerate_paths(state::AbstractPathState, vs::Vector{<:Integer})
     return all_paths
 end
 
-enumerate_paths(state::AbstractPathState, v) = enumerate_paths(state, [v])[1]
+enumerate_paths(state::AbstractPathState, v::Integer) = enumerate_paths(state, [v])[1]
 enumerate_paths(state::AbstractPathState) = enumerate_paths(state, [1:length(state.parents);])
 

--- a/test/shortestpaths/dijkstra.jl
+++ b/test/shortestpaths/dijkstra.jl
@@ -17,6 +17,9 @@
         @test @inferred(enumerate_paths(z)) == enumerate_paths(y)
         @test @inferred(enumerate_paths(z))[4] ==
           enumerate_paths(z, 4) ==
+          # test that we can pass a range into enumerate_paths - previously this caused
+          # infinite recursion - see #1552
+          enumerate_paths(z, 3:4)[2] ==
           enumerate_paths(y, 4) == [2, 3, 4]
     end
 


### PR DESCRIPTION
This fixes #1552 and adds a unit test for using enumerate_paths with a UnitRange.