### PR TITLE
fix Issue #1577 in src/SimpleGraphs/generators/randgraphs.jl

### DIFF
--- a/src/SimpleGraphs/generators/randgraphs.jl
+++ b/src/SimpleGraphs/generators/randgraphs.jl
@@ -358,7 +358,7 @@ function _try_creation(n::T, k::Vector{T}, rng::AbstractRNG) where T <: Integer
             return Set{SimpleEdge{T}}()
         end
 
-        stubs = Vector{Int}()
+        stubs = Vector{T}()
         for (e, ct) in potential_edges
             append!(stubs, fill(e, ct))
         end


### PR DESCRIPTION
fix for Issue #1577 in `src/SimpleGraphs/generators/randgraphs.jl:_try_creation(n::T, k::Vector{T}, rng::AbstractRNG)` when `{T}` is not `{Int64}`