### PR TITLE
Remove single argument Pair constructor which invalidates

### DIFF
--- a/src/SimpleGraphs/simpleedge.jl
+++ b/src/SimpleGraphs/simpleedge.jl
@@ -23,7 +23,7 @@ dst(e::AbstractSimpleEdge) = e.dst
 show(io::IO, e::AbstractSimpleEdge) = print(io, "Edge $(e.src) => $(e.dst)")
 
 # Conversions
-Pair(e::AbstractSimpleEdge) = Pair(src(e), dst(e))
+#Pair(e::AbstractSimpleEdge) = Pair(src(e), dst(e))
 Tuple(e::AbstractSimpleEdge) = (src(e), dst(e))
 
 SimpleEdge{T}(e::AbstractSimpleEdge) where T <: Integer = SimpleEdge{T}(T(e.src), T(e.dst))

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -83,7 +83,7 @@ julia> dst(first(edges(g)))
 """
 dst(e::AbstractEdge) = _NI("dst")
 
-Pair(e::AbstractEdge) = _NI("Pair")
+#Pair(e::AbstractEdge) = _NI("Pair")
 Tuple(e::AbstractEdge) = _NI("Tuple")
 
 """


### PR DESCRIPTION
All of the Base Pair constructors are 2 arguments, so the single argument one seems to cause invalidation which then infect the precompilation of all downstream packages. 

Before:

```julia
using SnoopCompile
using DiffEqBase, RecursiveFactorization
invalidations = @snoopr using OrdinaryDiffEq
length(invalidations) # 61
trees = invalidation_trees(invalidations)

1-element Vector{SnoopCompile.MethodInvalidations}:
 inserting Pair(e::LightGraphs.SimpleGraphs.AbstractSimpleEdge) in LightGraphs.SimpleGraphs at C:\Users\accou\.julia\packages\LightGraphs\IgJif\src\SimpleGraphs\simpleedge.jl:26 invalidated:
   mt_backedges: 1: signature Tuple{Type{Pair}, Vararg{Any}} triggered MethodInstance for (::Base.var"#6#7"{Pair})(::Any) (23 children)
   1 mt_cache
```

After:

```julia
length(invalidations) # 14
trees = invalidation_trees(invalidations) # zero
```

This only caused a 0.5 second compile time drop to OrdinaryDiffEq.jl, but it is nice and this should be fairly pervasive since `Pair` is used... well... everywhere. Also, I checked and this `Pair` constructor isn't even documented in the public API and does not seem to be used in the private API (the error messages even avoid using it), so it seems like just removing it is the best idea.