### PR TITLE
Use array of concrete eltype for efficiency in astar

### DIFF
--- a/src/shortestpaths/astar.jl
+++ b/src/shortestpaths/astar.jl
@@ -86,7 +86,7 @@ function a_star(g::AbstractGraph{U},  # the g
     f_score = fill(Inf, nv(g))
     f_score[s] = heuristic(s)
 
-    came_from = -ones(Integer, nv(g))
+    came_from = fill(-one(s), nv(g))
     came_from[s] = s
 
     a_star_impl!(g, t, open_set, closed_set, g_score, f_score, came_from, distmx, heuristic)


### PR DESCRIPTION
An array of eltype `Integer` is used in the astar algorithm. But, the elements are always only of a single concrete subtype of `Integer`. This PR changes the array to the narrower type. Timing the second test of astar in the test suite (applying astar to the complete graph) shows a 2x improvement in speed.

EDIT: it would be better if `ones(Integer, n)` threw an error, rather than arbitrarily choosing to fill with `Int`s. But, that ship has sailed.