### PR TITLE
fix merge_vertices

### DIFF
--- a/test/operators.jl
+++ b/test/operators.jl
@@ -103,6 +103,13 @@
             @test neighbors(h2, 5) == [2]
             @test ne(h2) == 3
             @test nv(h2) == 5
+
+            h3 = star_graph(5)
+            h3merged = merge_vertices(h3, [1,2])
+            @test neighbors(h3merged, 1) == [2,3,4]
+            @test neighbors(h3merged, 2) == [1]
+            @test neighbors(h3merged, 3) == [1]
+            @test neighbors(h3merged, 4) == [1]
         end
     end
 


### PR DESCRIPTION
Fix for [1586](https://github.com/JuliaGraphs/LightGraphs.jl/issues/1586).

`merge_vertices` was mutating `vs`, this is fixed. 

I also restricted the definition of the method from `AbstractGraph` to `AbstractSimpleGraph`, because it assumes the vertices are a OneTo range. Tell me if you think I should not change this method definition, but I think a more general method would be quite meaningless.

I harmonized it a bit with the in-place method and did some little optimizations. It is possible to do a little bit better by updating `new_vertex_ids` only for vertices above `merged_vertex`, should I do it, or is it ok like this? I hope I didn't break anything.

This is my first PR and I have a few questions :
- I see that some tests, notably for Operators.jl, are in a testset `"$g" for g in testlargegraphs(g3)` run on different types, but don't rely on `g`, so these are run multiple times. Should we move these to another static testset ? I added a new test to cover the issue, and put it with these tests, but I can modify that.
- Some functions (like `complement`) are defined for the concrete types Graph and DiGraph. Should these be implemented for AbstractSimpleGraph (with eventually the Trait `IsDirected`, as it is done in `reverse`)?
- From when is it worth to specialize methods for `AbstractSimpleGraphs`? Also, it seems that a lot of methods defined for `AbstractGraph` use the assumption that vertices form a continuous range (for example `a_star`, if I'm not mistaking, as it uses vertices as indices of a `Vector`).