### PR TITLE
Fix bug when making an `adjacency_matrix` from a `SimpleGraph` with self-loops in Julia 1.7

### DIFF
--- a/src/linalg/spectral.jl
+++ b/src/linalg/spectral.jl
@@ -55,6 +55,9 @@ function _adjacency_matrix(g::AbstractGraph, T::DataType, neighborfn::Function, 
     for j in 1:n_v  # this is by column, not by row.
         if has_edge(g, j, j)
             push!(selfloops, j)
+            if !(T <: Bool) && !is_directed(g)
+                nz -= 1
+            end
         end
         dsts = sort(neighborfn(g, j)) # TODO for most graphs it might not be necessary to sort
         colpt[j + 1] = colpt[j] + length(dsts)


### PR DESCRIPTION
Fix bug when making an `adjacency_matrix` from a `SimpleGraph` with self-loops in Julia 1.7

As described in #1594, Julia 1.7 adds a stricter check on the `SparseMatrixCSC` constructor for consistency about the number of nonzero elements input. The number of nonzero elements are currently being overcounted in the case of `SimpleGraph` with self-loops, this should fix that overcounting.

Fixes #1594.