### PR TITLE
Switch to immutable structs

### DIFF
--- a/benchmark/core.jl
+++ b/benchmark/core.jl
@@ -34,5 +34,5 @@ function all_has_edge(g::AbstractGraph)
 end
 
 suite["core"]["has_edge"] = BenchmarkGroup(["graphs", "digraphs"])
-suite["core"]["has_edge"]["graphs"] = @benchmark [all_has_edge(g) for (n,g) in $GRAPHS]
-suite["core"]["has_edge"]["digraphs"] = @benchmark [all_has_edge(g) for (n,g) in $DIGRAPHS]
+suite["core"]["has_edge"]["graphs"] = @benchmarkable [all_has_edge(g) for (n,g) in $GRAPHS]
+suite["core"]["has_edge"]["digraphs"] = @benchmarkable [all_has_edge(g) for (n,g) in $DIGRAPHS]

--- a/src/SimpleGraphs/SimpleGraphs.jl
+++ b/src/SimpleGraphs/SimpleGraphs.jl
@@ -74,7 +74,6 @@ end
 
 edges(g::AbstractSimpleGraph) = SimpleEdgeIter(g)
 
-
 fadj(g::AbstractSimpleGraph) = g.fadjlist
 fadj(g::AbstractSimpleGraph, v::Integer) = g.fadjlist[v]
 
@@ -200,9 +199,9 @@ function rem_vertex!(g::AbstractSimpleGraph, v::Integer)
     if self_loop_n
         add_edge!(g, edgetype(g)(v, v))
     end
-    pop!(g.fadjlist)
+    pop!(fadj(g))
     if is_directed(g)
-        pop!(g.badjlist)
+        pop!(badj(g))
     end
     return true
 end

--- a/src/SimpleGraphs/SimpleGraphs.jl
+++ b/src/SimpleGraphs/SimpleGraphs.jl
@@ -74,9 +74,8 @@ end
 
 edges(g::AbstractSimpleGraph) = SimpleEdgeIter(g)
 
-fadj(g::AbstractSimpleGraph) = g.fadjlist
-fadj(g::AbstractSimpleGraph, v::Integer) = g.fadjlist[v]
-
+fadj(g::AbstractSimpleGraph, v::Integer) = fadj(g)[v]
+badj(g::AbstractSimpleGraph, v::Integer) = badj(g)[v]
 
 badj(x...) = _NI("badj")
 

--- a/src/SimpleGraphs/generators/randgraphs.jl
+++ b/src/SimpleGraphs/generators/randgraphs.jl
@@ -456,7 +456,7 @@ function barabasi_albert!(g::AbstractGraph, n::Integer, k::Integer; seed::Int=-1
     rng = getRNG(seed)
 
     # add missing vertices
-    sizehint!(g.fadjlist, n)
+    sizehint!(fadj(g), n)
     add_vertices!(g, n - n0)
 
     # if initial graph doesn't contain any edges
@@ -1222,7 +1222,7 @@ julia> random_orientation_dag(star_graph(Int8(10)), 123)
 ```
 """
 function random_orientation_dag(g::SimpleGraph{T}, seed::Int=-1) where {T <: Integer}
-    nvg = length(g.fadjlist)
+    nvg = length(fadj(g))
     rng = getRNG(seed)
     order = randperm(rng, nvg)
     g2 = SimpleDiGraph(nv(g))

--- a/src/SimpleGraphs/generators/randgraphs.jl
+++ b/src/SimpleGraphs/generators/randgraphs.jl
@@ -26,12 +26,12 @@ function SimpleGraph{T}(nv::Integer, ne::Integer; seed::Int=-1) where T <: Integ
     tnv = T(nv)
     maxe = div(Int(nv) * (nv - 1), 2)
     @assert(ne <= maxe, "Maximum number of edges for this graph is $maxe")
-    ne > div((2 * maxe), 3)  && return complement(SimpleGraph(tnv, maxe - ne, seed=seed))
+    ne > div((2 * maxe), 3) && return complement(SimpleGraph(tnv, maxe - ne, seed=seed))
 
     rng = getRNG(seed)
     g = SimpleGraph(tnv)
 
-    while g.ne < ne
+    while LightGraphs.ne(g) < ne
         source = rand(rng, one(T):tnv)
         dest = rand(rng, one(T):tnv)
         source != dest && add_edge!(g, source, dest)
@@ -67,7 +67,7 @@ function SimpleDiGraph{T}(nv::Integer, ne::Integer; seed::Int=-1) where T <: Int
 
     rng = getRNG(seed)
     g = SimpleDiGraph(tnv)
-    while g.ne < ne
+    while LightGraphs.ne(g) < ne
         source = rand(rng, one(T):tnv)
         dest = rand(rng, one(T):tnv)
         source != dest && add_edge!(g, source, dest)

--- a/src/SimpleGraphs/simpledigraph.jl
+++ b/src/SimpleGraphs/simpledigraph.jl
@@ -33,7 +33,7 @@ end
 
 eltype(x::SimpleDiGraph{T}) where T = T
 
-ne(g::SimpleDiGraph) = getfield(g, :ne)[]
+@inline ne(g::SimpleDiGraph) = getfield(getfield(g, :ne), :x)
 
 # DiGraph{UInt8}(6), DiGraph{Int16}(7), DiGraph{Int8}()
 """

--- a/src/SimpleGraphs/simpledigraph.jl
+++ b/src/SimpleGraphs/simpledigraph.jl
@@ -365,9 +365,8 @@ end
 edgetype(::SimpleDiGraph{T}) where T <: Integer = SimpleGraphEdge{T}
 
 
-badj(g::SimpleDiGraph) = g.badjlist
-badj(g::SimpleDiGraph, v::Integer) = badj(g)[v]
-
+@inline badj(g::SimpleDiGraph) = getfield(g, :badjlist)
+@inline fadj(g::SimpleDiGraph) = getfield(g, :fadjlist)
 
 copy(g::SimpleDiGraph{T}) where T <: Integer =
 SimpleDiGraph{T}(ne(g), deepcopy_adjlist(g.fadjlist), deepcopy_adjlist(g.badjlist))
@@ -384,8 +383,8 @@ is_directed(::Type{<:SimpleDiGraph}) = true
 function has_edge(g::SimpleDiGraph{T}, s, d) where T
     verts = vertices(g)
     (s in verts && d in verts) || return false  # edge out of bounds
-    @inbounds list = g.fadjlist[s]
-    @inbounds list_backedge = g.badjlist[d]
+    @inbounds list = fadj(g)[s]
+    @inbounds list_backedge = badj(g)[d]
     if length(list) > length(list_backedge)
         d = s
         list = list_backedge

--- a/src/SimpleGraphs/simpledigraph.jl
+++ b/src/SimpleGraphs/simpledigraph.jl
@@ -500,7 +500,7 @@ function rem_vertices!(g::SimpleDiGraph{T},
     # count the number of edges that will be removed
     num_removed_edges = 0
     @inbounds for u in remove
-        for v in fadjlst[u]
+        for v in fadjlist[u]
             num_removed_edges += 1
         end
         for v in badjlist[u]

--- a/src/SimpleGraphs/simplegraph.jl
+++ b/src/SimpleGraphs/simplegraph.jl
@@ -25,7 +25,7 @@ end
 
 eltype(x::SimpleGraph{T}) where T = T
 
-ne(g::SimpleGraph) = getfield(g, :ne)[]
+@inline ne(g::SimpleGraph) = getfield(getfield(g, :ne), :x)
 
 # Graph{UInt8}(6), Graph{Int16}(7), Graph{UInt8}()
 """

--- a/src/SimpleGraphs/simplegraph.jl
+++ b/src/SimpleGraphs/simplegraph.jl
@@ -26,6 +26,7 @@ end
 eltype(x::SimpleGraph{T}) where T = T
 
 @inline ne(g::SimpleGraph) = getfield(getfield(g, :ne), :x)
+@inline fadj(g::SimpleGraph) = getfield(g, :fadjlist)
 
 # Graph{UInt8}(6), Graph{Int16}(7), Graph{UInt8}()
 """

--- a/src/operators.jl
+++ b/src/operators.jl
@@ -78,7 +78,7 @@ function reverse end
 @traitfn function reverse(g::G::IsDirected) where G<:AbstractSimpleGraph
     gnv = nv(g)
     gne = ne(g)
-    return SimpleDiGraph(gne, deepcopy_adjlist(fadj(g)), deepcopy_adjlist(badj(g)))
+    return SimpleDiGraph(gne, deepcopy_adjlist(SimpleGraphs.badj(g)), deepcopy_adjlist(SimpleGraphs.fadj(g)))
 end
 
 # TODO ensure this works as intended
@@ -90,11 +90,11 @@ See [`reverse`](@ref) for a non-modifying version.
 """
 function reverse! end
 @traitfn function reverse!(g::G::IsDirected) where G<:AbstractSimpleGraph
-    fadjlist = fadj(g)
-    badjlist = badj(g)
+    fadjlist = SimpleGraphs.fadj(g)
+    badjlist = SimpleGraphs.badj(g)
     @inbounds for i in vertices(g)
-        f_i = fadjlist[i]
-        b_i = badjlist[i]
+        f_i = copy(fadjlist[i])
+        b_i = copy(badjlist[i])
         fadjlist[i] = b_i
         badjlist[i] = f_i
     end
@@ -296,11 +296,11 @@ function union(g::T, h::T) where T <: AbstractSimpleGraph
     hnv = nv(h)
 
     r = T(max(gnv, hnv))
-    r.ne = ne(g)
+    r.ne[] = ne(g)
     for i in vertices(g)
-        fadj(r)[i] = deepcopy(fadj(g)[i])
+        SimpleGraphs.fadj(r)[i] = deepcopy(SimpleGraphs.fadj(g)[i])
         if is_directed(g)
-            badj(r)[i] = deepcopy(badj(g)[i])
+            SimpleGraphs.badj(r)[i] = deepcopy(SimpleGraphs.badj(g)[i])
         end
     end
     for e in edges(h)
@@ -835,13 +835,13 @@ function merge_vertices!(g::Graph{T}, vs::Vector{U} where U <: Integer) where T
                     push!(nbrs_to_rewire, new_vertex_ids[j])
                 end
             end
-            fadj(g)[new_vertex_ids[i]] = sort(collect(nbrs_to_rewire))
+            SimpleGraphs.fadj(g)[new_vertex_ids[i]] = sort(collect(nbrs_to_rewire))
 
 
         # Collect connections to new merged vertex
         else
             nbrs_to_merge = Set{T}()
-            for element in filter(x -> !(insorted(x, vs)) && (x != merged_vertex), fadj(g)[i])
+            for element in filter(x -> !(insorted(x, vs)) && (x != merged_vertex), SimpleGraphs.fadj(g)[i])
                 push!(nbrs_to_merge, new_vertex_ids[element])
             end
 
@@ -850,12 +850,12 @@ function merge_vertices!(g::Graph{T}, vs::Vector{U} where U <: Integer) where T
                     push!(nbrs_to_merge, new_vertex_ids[e])
                 end
             end
-            fadj(g)[i] = sort(collect(nbrs_to_merge))
+            SimpleGraphs.fadj(g)[i] = sort(collect(nbrs_to_merge))
         end
     end
 
     # TODO ensure this works
-    fadjlist = fadj(g)
+    fadjlist = SimpleGraphs.fadj(g)
     resize!(fadjlist, length(fadjlist) - length(vs))
 
     # Correct edge counts

--- a/src/operators.jl
+++ b/src/operators.jl
@@ -76,12 +76,9 @@ Edge 5 => 4
 """
 function reverse end
 @traitfn function reverse(g::G::IsDirected) where G<:AbstractSimpleGraph
-    gnv = nv(g)
-    gne = ne(g)
-    return SimpleDiGraph(gne, deepcopy_adjlist(SimpleGraphs.badj(g)), deepcopy_adjlist(SimpleGraphs.fadj(g)))
+    return SimpleDiGraph(ne(g), deepcopy_adjlist(SimpleGraphs.badj(g)), deepcopy_adjlist(SimpleGraphs.fadj(g)))
 end
 
-# TODO ensure this works as intended
 """
     reverse!(g)
 
@@ -93,10 +90,7 @@ function reverse! end
     fadjlist = SimpleGraphs.fadj(g)
     badjlist = SimpleGraphs.badj(g)
     @inbounds for i in vertices(g)
-        f_i = copy(fadjlist[i])
-        b_i = copy(badjlist[i])
-        fadjlist[i] = b_i
-        badjlist[i] = f_i
+        fadjlist[i], badjlist[i] = badjlist[i], fadjlist[i]
     end
     return g
 end
@@ -854,7 +848,6 @@ function merge_vertices!(g::Graph{T}, vs::Vector{U} where U <: Integer) where T
         end
     end
 
-    # TODO ensure this works
     fadjlist = SimpleGraphs.fadj(g)
     resize!(fadjlist, length(fadjlist) - length(vs))
 

--- a/test/simplegraphs/runtests.jl
+++ b/test/simplegraphs/runtests.jl
@@ -31,7 +31,7 @@ function isvalid_simplegraph(g::SimpleGraph{T}) where {T <: Integer}
             edge_count += 1
         end
     end
-    g.ne == edge_count || return false
+    ne(g) == edge_count || return false
     #  checks for backwards edge
     for u in one(T):n
         listu = g.fadjlist[u]
@@ -62,12 +62,12 @@ function isvalid_simplegraph(g::SimpleDiGraph{T}) where {T <: Integer}
     for u in one(T):n
         edge_count += length(g.fadjlist[u])
     end
-    g.ne == edge_count || return false
+    ne(g) == edge_count || return false
     edge_count = 0
     for u in one(T):n
         edge_count += length(g.badjlist[u])
     end
-    g.ne == edge_count || return false
+    ne(g) == edge_count || return false
     #  checks for backwards edge
     for u in one(T):n
         listu = g.fadjlist[u]


### PR DESCRIPTION
This improves access efficiency to fields of `SimpleGraph` and `SimpleDiGraph`.
It also makes more code consistent with contributing guidelines "Minimizing use of internal struct fields".